### PR TITLE
feat: gamification redesign, collab-day reminders, and review system

### DIFF
--- a/app/Console/Commands/SendCollabReminders.php
+++ b/app/Console/Commands/SendCollabReminders.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Collaboration;
+use App\Services\NotificationService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class SendCollabReminders extends Command
+{
+    protected $signature = 'app:send-collab-reminders
+        {--dry-run : Log what would be sent without actually sending}';
+
+    protected $description = 'Send collab-day and follow-up reminders for scheduled collaborations';
+
+    public function handle(NotificationService $notificationService): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $today = Carbon::today();
+        $yesterday = Carbon::yesterday();
+
+        // ─── Morning reminder: scheduled_date = today, not yet completed/cancelled ───
+        $todayCollabs = Collaboration::query()
+            ->whereDate('scheduled_date', $today)
+            ->whereNotIn('status', ['completed', 'cancelled'])
+            ->with(['creatorProfile', 'applicantProfile'])
+            ->get();
+
+        $this->info("Day-of reminders: {$todayCollabs->count()} collab(s) scheduled for today.");
+
+        foreach ($todayCollabs as $collab) {
+            if ($dryRun) {
+                $this->line("  [dry-run] Would send day-of reminder for collab {$collab->id}");
+                continue;
+            }
+            $notificationService->notifyCollabDayReminder($collab);
+        }
+
+        // ─── Follow-up reminder: scheduled_date = yesterday, not completed/cancelled ───
+        $followUpCollabs = Collaboration::query()
+            ->whereDate('scheduled_date', $yesterday)
+            ->whereNotIn('status', ['completed', 'cancelled'])
+            ->with(['creatorProfile', 'applicantProfile'])
+            ->get();
+
+        $this->info("Follow-up reminders: {$followUpCollabs->count()} collab(s) from yesterday still pending.");
+
+        foreach ($followUpCollabs as $collab) {
+            if ($dryRun) {
+                $this->line("  [dry-run] Would send follow-up reminder for collab {$collab->id}");
+                continue;
+            }
+            $notificationService->notifyCollabFollowUpReminder($collab);
+        }
+
+        $this->info('Done.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/GamificationBadgeSlug.php
+++ b/app/Enums/GamificationBadgeSlug.php
@@ -24,10 +24,10 @@ enum GamificationBadgeSlug: string
     {
         return match ($this) {
             self::FirstKolab => 'First Kolab',
-            self::ContentCreator => 'Content Creator',
-            self::CommunityEarner => 'Community Earner',
+            self::ContentCreator => 'Storyteller',
+            self::CommunityEarner => 'Momentum Club',
             self::ReferralPioneer => 'Referral Pioneer',
-            self::PowerPartner => 'Power Partner',
+            self::PowerPartner => 'Trusted Voice',
         };
     }
 
@@ -35,10 +35,10 @@ enum GamificationBadgeSlug: string
     {
         return match ($this) {
             self::FirstKolab => 'Completed your first collaboration',
-            self::ContentCreator => 'Posted 3 reviews or pieces of content',
-            self::CommunityEarner => 'Earned your first 100 points',
-            self::ReferralPioneer => 'Referred a business that converted',
-            self::PowerPartner => 'Completed 5 collaborations',
+            self::ContentCreator => 'Share your story — post 3 collaboration reviews',
+            self::CommunityEarner => 'Keep the momentum — reach 100 XP',
+            self::ReferralPioneer => 'Grow the community — refer your first partner',
+            self::PowerPartner => 'A trusted voice — complete 5 Kolabs',
         };
     }
 }

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -16,6 +16,8 @@ enum NotificationType: string
     case PointsEarned = 'points_earned';
     case GamificationBadgeEarned = 'gamification_badge_earned';
     case WithdrawalProcessed = 'withdrawal_processed';
+    case CollabDayReminder = 'collab_day_reminder';
+    case CollabFollowUpReminder = 'collab_followup_reminder';
 
     /**
      * @return array<string>

--- a/app/Enums/PointEventType.php
+++ b/app/Enums/PointEventType.php
@@ -7,6 +7,7 @@ namespace App\Enums;
 enum PointEventType: string
 {
     case CollaborationComplete = 'collaboration_complete';
+    case FirstKolabBonus = 'first_kolab_bonus';
     case ReviewPosted = 'review_posted';
     case UgcPosted = 'ugc_posted';
     case ReferralConversion = 'referral_conversion';
@@ -26,9 +27,10 @@ enum PointEventType: string
     public function defaultPoints(): int
     {
         return match ($this) {
-            self::CollaborationComplete => 1,
-            self::ReviewPosted => 1,
-            self::UgcPosted => 1,
+            self::CollaborationComplete => 10,
+            self::FirstKolabBonus => 50,
+            self::ReviewPosted => 10,
+            self::UgcPosted => 10,
             self::ReferralConversion => 50,
             self::Withdrawal => 0,
         };

--- a/app/Http/Controllers/Api/V1/CollaborationController.php
+++ b/app/Http/Controllers/Api/V1/CollaborationController.php
@@ -4,22 +4,27 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Enums\PointEventType;
 use App\Exceptions\CollaborationException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CancelCollaborationRequest;
 use App\Http\Requests\Api\V1\CompleteCollaborationRequest;
+use App\Http\Requests\Api\V1\StoreCollaborationReviewRequest;
 use App\Http\Resources\Api\V1\CollaborationCollection;
 use App\Http\Resources\Api\V1\CollaborationResource;
 use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use App\Models\Profile;
 use App\Services\CollaborationService;
+use App\Services\GamificationWalletService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class CollaborationController extends Controller
 {
     public function __construct(
-        private readonly CollaborationService $collaborationService
+        private readonly CollaborationService $collaborationService,
+        private readonly GamificationWalletService $gamificationService,
     ) {}
 
     /**
@@ -175,5 +180,91 @@ class CollaborationController extends Controller
             'message' => __('collaboration.cancelled'),
             'data' => new CollaborationResource($collaboration),
         ]);
+    }
+
+    /**
+     * Submit a lightweight review for a completed collaboration.
+     *
+     * POST /api/v1/collaborations/{collaboration}/review
+     *
+     * Rules:
+     * - Collaboration must be completed
+     * - Reviewer must be a participant
+     * - One review per reviewer per collaboration (idempotent: returns 200 on duplicate)
+     * - reviewed_profile_id is derived from business/community profile columns,
+     *   NOT from who submitted — ensuring correct cross-party attribution
+     * - XP awarded only on first creation (not on duplicate)
+     */
+    public function review(
+        StoreCollaborationReviewRequest $request,
+        Collaboration $collaboration,
+    ): JsonResponse {
+        /** @var Profile $reviewer */
+        $reviewer = $request->user();
+
+        $this->authorize('view', $collaboration);
+
+        if (! $collaboration->isCompleted()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Reviews can only be left for completed collaborations.',
+                'error_code' => 'collaboration_not_completed',
+            ], 422);
+        }
+
+        // Determine which profile is being reviewed (the OTHER party).
+        // business_profile_id / community_profile_id are dedicated FK columns
+        // that are always set regardless of creator/applicant assignment order.
+        $reviewedProfileId = $reviewer->id === $collaboration->business_profile_id
+            ? $collaboration->community_profile_id
+            : $collaboration->business_profile_id;
+
+        if ($reviewedProfileId === null) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Could not determine the profile to be reviewed.',
+                'error_code' => 'missing_participant',
+            ], 422);
+        }
+
+        // Idempotency: if a review already exists, return it without awarding XP again.
+        $existing = CollaborationReview::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $reviewer->id)
+            ->first();
+
+        if ($existing !== null) {
+            return response()->json([
+                'success' => true,
+                'message' => 'Review already submitted.',
+                'data' => $existing,
+            ]);
+        }
+
+        $validated = $request->validated();
+
+        $review = CollaborationReview::create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $reviewer->id,
+            'reviewed_profile_id' => $reviewedProfileId,
+            'rating' => $validated['rating'],
+            'body' => $validated['body'] ?? null,
+            'would_collaborate_again' => $validated['would_collaborate_again'] ?? null,
+        ]);
+
+        // Award XP once for leaving a review — uses existing ReviewPosted event type.
+        $this->gamificationService->awardPoints(
+            $reviewer->id,
+            PointEventType::ReviewPosted->defaultPoints(),
+            PointEventType::ReviewPosted,
+            $collaboration->id,
+            'Left a review for a completed Kolab',
+        );
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Review submitted successfully.',
+            'data' => $review,
+        ], 201);
     }
 }

--- a/app/Http/Requests/Api/V1/StoreCollaborationReviewRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCollaborationReviewRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCollaborationReviewRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true; // Authorization handled in the controller via policy
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'body' => ['nullable', 'string', 'max:500'],
+            'would_collaborate_again' => ['nullable', 'boolean'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'rating.required' => 'A star rating is required.',
+            'rating.min' => 'Rating must be at least 1 star.',
+            'rating.max' => 'Rating cannot exceed 5 stars.',
+            'body.max' => 'Review text cannot exceed 500 characters.',
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/CollaborationResource.php
+++ b/app/Http/Resources/Api/V1/CollaborationResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -96,6 +97,13 @@ class CollaborationResource extends JsonResource
             }),
             'completed_at' => $this->completed_at?->toIso8601String(),
             'my_role' => $this->when($currentProfile !== null, fn () => $myRole),
+            'has_reviewed' => $this->when(
+                $currentProfile !== null && $this->isCompleted(),
+                fn () => CollaborationReview::query()
+                    ->where('collaboration_id', $this->id)
+                    ->where('reviewer_profile_id', $currentProfile->id)
+                    ->exists()
+            ),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];

--- a/app/Http/Resources/Api/V1/PublicProfileResource.php
+++ b/app/Http/Resources/Api/V1/PublicProfileResource.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Enums\CollaborationStatus;
 use App\Enums\UserType;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use App\Models\Profile;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -41,6 +44,34 @@ class PublicProfileResource extends JsonResource
                 : null,
             'website' => $extendedProfile?->website,
             'profile_photo' => $extendedProfile?->profile_photo,
+            'completed_kolabs_count' => Collaboration::query()
+                ->where('status', CollaborationStatus::Completed)
+                ->where(fn ($q) => $q
+                    ->where('creator_profile_id', $this->id)
+                    ->orWhere('applicant_profile_id', $this->id)
+                )
+                ->count(),
+            'review_stats' => $this->buildReviewStats(),
+        ];
+    }
+
+    /**
+     * @return array{average_rating: float|null, review_count: int}
+     */
+    private function buildReviewStats(): array
+    {
+        $stats = CollaborationReview::query()
+            ->where('reviewed_profile_id', $this->id)
+            ->selectRaw('COUNT(*) as review_count, AVG(rating) as average_rating')
+            ->first();
+
+        $count = (int) ($stats?->review_count ?? 0);
+
+        return [
+            'review_count' => $count,
+            'average_rating' => $count > 0
+                ? round((float) $stats->average_rating, 1)
+                : null,
         ];
     }
 }

--- a/app/Models/CollaborationReview.php
+++ b/app/Models/CollaborationReview.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $collaboration_id
+ * @property string $reviewer_profile_id
+ * @property string $reviewed_profile_id
+ * @property int $rating
+ * @property string|null $body
+ * @property bool|null $would_collaborate_again
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Collaboration $collaboration
+ * @property-read Profile $reviewer
+ * @property-read Profile $reviewed
+ */
+class CollaborationReview extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'collaboration_id',
+        'reviewer_profile_id',
+        'reviewed_profile_id',
+        'rating',
+        'body',
+        'would_collaborate_again',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'rating' => 'integer',
+            'would_collaborate_again' => 'boolean',
+        ];
+    }
+
+    /** @return BelongsTo<Collaboration, $this> */
+    public function collaboration(): BelongsTo
+    {
+        return $this->belongsTo(Collaboration::class);
+    }
+
+    /** @return BelongsTo<Profile, $this> */
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class, 'reviewer_profile_id');
+    }
+
+    /** @return BelongsTo<Profile, $this> */
+    public function reviewed(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class, 'reviewed_profile_id');
+    }
+}

--- a/app/Services/GamificationWalletService.php
+++ b/app/Services/GamificationWalletService.php
@@ -46,6 +46,21 @@ class GamificationWalletService
 
             $wallet->increment('points', $points);
 
+            // Award first-kolab bonus on the profile's very first completion
+            if ($eventType === PointEventType::CollaborationComplete) {
+                $completedCount = $this->countLedgerEvents($profileId, [PointEventType::CollaborationComplete]);
+                if ($completedCount === 1) {
+                    PointLedger::create([
+                        'profile_id' => $profileId,
+                        'points' => PointEventType::FirstKolabBonus->defaultPoints(),
+                        'event_type' => PointEventType::FirstKolabBonus,
+                        'reference_id' => $referenceId,
+                        'description' => 'First Kolab bonus!',
+                    ]);
+                    $wallet->increment('points', PointEventType::FirstKolabBonus->defaultPoints());
+                }
+            }
+
             $this->evaluateBadges($profileId);
 
             return $ledgerEntry;

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -9,6 +9,7 @@ use App\Jobs\SendPushNotification;
 use App\Models\Application;
 use App\Models\ChallengeCompletion;
 use App\Models\ChatMessage;
+use App\Models\Collaboration;
 use App\Models\Notification;
 use App\Models\Profile;
 use App\Models\RewardClaim;
@@ -229,6 +230,72 @@ class NotificationService
             targetId: $completion->id,
             targetType: 'challenge_completion',
         );
+    }
+
+    /**
+     * Send "Today's your Kolab 🎉" reminder to both parties.
+     * Idempotent: skips a party if a reminder of this type was already sent
+     * for this collaboration (checked via existing notifications rows).
+     */
+    public function notifyCollabDayReminder(Collaboration $collaboration): void
+    {
+        $collaboration->loadMissing(['creatorProfile', 'applicantProfile', 'collabOpportunity']);
+
+        $title = "Today's your Kolab! 🎉";
+        $body = "Your collaboration is happening today. Have a great Kolab!";
+
+        foreach ([$collaboration->creatorProfile, $collaboration->applicantProfile] as $profile) {
+            if ($this->reminderAlreadySent($profile->id, NotificationType::CollabDayReminder, $collaboration->id)) {
+                continue;
+            }
+            $this->createNotification(
+                recipient: $profile,
+                type: NotificationType::CollabDayReminder,
+                title: $title,
+                body: $body,
+                targetId: $collaboration->id,
+                targetType: 'collaboration',
+            );
+        }
+    }
+
+    /**
+     * Send "Did your Kolab happen? Mark it complete." follow-up to both parties.
+     * Idempotent: skips a party if a follow-up of this type was already sent.
+     */
+    public function notifyCollabFollowUpReminder(Collaboration $collaboration): void
+    {
+        $collaboration->loadMissing(['creatorProfile', 'applicantProfile']);
+
+        $title = 'Did your Kolab happen?';
+        $body = 'Mark it complete to earn your XP and keep your history up to date.';
+
+        foreach ([$collaboration->creatorProfile, $collaboration->applicantProfile] as $profile) {
+            if ($this->reminderAlreadySent($profile->id, NotificationType::CollabFollowUpReminder, $collaboration->id)) {
+                continue;
+            }
+            $this->createNotification(
+                recipient: $profile,
+                type: NotificationType::CollabFollowUpReminder,
+                title: $title,
+                body: $body,
+                targetId: $collaboration->id,
+                targetType: 'collaboration',
+            );
+        }
+    }
+
+    /**
+     * Check whether a reminder of the given type has already been sent
+     * to this profile for this collaboration.
+     */
+    private function reminderAlreadySent(string $profileId, NotificationType $type, string $targetId): bool
+    {
+        return Notification::query()
+            ->where('profile_id', $profileId)
+            ->where('type', $type)
+            ->where('target_id', $targetId)
+            ->exists();
     }
 
     /**

--- a/database/migrations/2026_05_25_000001_create_collaboration_reviews_table.php
+++ b/database/migrations/2026_05_25_000001_create_collaboration_reviews_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('collaboration_reviews', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('collaboration_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('reviewer_profile_id')->constrained('profiles')->cascadeOnDelete();
+            $table->foreignUuid('reviewed_profile_id')->constrained('profiles')->cascadeOnDelete();
+            $table->unsignedTinyInteger('rating'); // 1–5
+            $table->text('body')->nullable();
+            $table->boolean('would_collaborate_again')->nullable();
+            $table->timestamps();
+
+            // One review per reviewer per collaboration
+            $table->unique(['collaboration_id', 'reviewer_profile_id']);
+
+            $table->index('reviewed_profile_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('collaboration_reviews');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -604,6 +604,10 @@ Route::prefix('v1')->group(function (): void {
         Route::post('collaborations/{collaboration}/cancel', [CollaborationController::class, 'cancel'])
             ->name('api.v1.collaborations.cancel');
 
+        // Leave a review for a completed collaboration (one per reviewer, idempotent)
+        Route::post('collaborations/{collaboration}/review', [CollaborationController::class, 'review'])
+            ->name('api.v1.collaborations.review');
+
         // Sync selected challenges for a collaboration
         Route::put('collaborations/{collaboration}/challenges', [CollaborationChallengeController::class, 'sync'])
             ->name('api.v1.collaborations.challenges.sync');

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,14 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Send collab-day reminders at 08:00 every morning.
+// The command handles both day-of ("Today's your Kolab!") and
+// follow-up ("Did it happen?") in one pass; dedup is done via
+// the notifications table so re-runs are safe.
+Schedule::command('app:send-collab-reminders')->dailyAt('08:00');


### PR DESCRIPTION
Gamification:
- XP values 1→10 for CollaborationComplete, ReviewPosted, UgcPosted
- Add FirstKolabBonus (50 XP) awarded on first completed collab
- Rename badges: Storyteller, Momentum Club, Trusted Voice
- PublicProfileResource exposes completed_kolabs_count and review_stats

Collab-day reminders:
- New artisan command app:send-collab-reminders (--dry-run supported)
- Scheduled daily at 08:00 via Laravel scheduler
- Dedup via existing notifications table (zero new migrations)
- Notifies both parties for day-of and follow-up reminders

Review system:
- New collaboration_reviews table (rating, body, would_collaborate_again)
- POST /collaborations/{id}/review — idempotent, awards +10 XP on first submit
- reviewed_profile_id derived from business/community profile columns
- has_reviewed field added to CollaborationResource
- review_stats (average_rating, review_count) added to PublicProfileResource