### PR TITLE
feat(admin): Kolab management, user delete, grant/revoke subscription

### DIFF
--- a/app/Enums/SubscriptionSource.php
+++ b/app/Enums/SubscriptionSource.php
@@ -8,4 +8,5 @@ enum SubscriptionSource: string
 {
     case Stripe = 'stripe';
     case AppleIap = 'apple_iap';
+    case Maintainer = 'maintainer';
 }

--- a/app/Http/Controllers/Admin/KolabController.php
+++ b/app/Http/Controllers/Admin/KolabController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\KolabStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UpdateKolabRequest;
+use App\Models\Kolab;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class KolabController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $kolabs = Kolab::query()
+            ->with(['creatorProfile.businessProfile', 'creatorProfile.communityProfile'])
+            ->when($request->filled('status'), fn ($query) => $query->where('status', $request->string('status')))
+            ->when($request->filled('q'), function ($query) use ($request): void {
+                $term = '%'.$request->string('q').'%';
+                $query->where(function ($inner) use ($term): void {
+                    $inner->where('title', 'like', $term)
+                        ->orWhere('preferred_city', 'like', $term);
+                });
+            })
+            ->latest()
+            ->paginate(20)
+            ->withQueryString();
+
+        return view('admin.kolabs.index', [
+            'kolabs' => $kolabs,
+            'statuses' => KolabStatus::cases(),
+            'filters' => [
+                'status' => (string) $request->string('status'),
+                'q' => (string) $request->string('q'),
+            ],
+        ]);
+    }
+
+    public function edit(Kolab $kolab): View
+    {
+        $kolab->loadMissing(['creatorProfile.businessProfile', 'creatorProfile.communityProfile']);
+
+        return view('admin.kolabs.edit', [
+            'kolab' => $kolab,
+            'statuses' => KolabStatus::cases(),
+        ]);
+    }
+
+    public function update(UpdateKolabRequest $request, Kolab $kolab): RedirectResponse
+    {
+        $data = $request->validated();
+        $status = KolabStatus::from($data['status']);
+
+        if ($status === KolabStatus::Published && $kolab->published_at === null) {
+            $data['published_at'] = now();
+        }
+
+        $kolab->update($data);
+
+        return redirect()
+            ->route('admin.kolabs.edit', $kolab)
+            ->with('status', __('Kolab updated.'));
+    }
+
+    public function destroy(Kolab $kolab): RedirectResponse
+    {
+        $kolab->delete();
+
+        return redirect()
+            ->route('admin.kolabs.index')
+            ->with('status', __('Kolab deleted.'));
+    }
+}

--- a/app/Http/Controllers/Admin/ManagedUserController.php
+++ b/app/Http/Controllers/Admin/ManagedUserController.php
@@ -22,7 +22,7 @@ class ManagedUserController extends Controller
     public function index(): View
     {
         $profiles = Profile::query()
-            ->with(['businessProfile', 'communityProfile', 'attendeeProfile'])
+            ->with(['businessProfile', 'communityProfile', 'attendeeProfile', 'subscription'])
             ->latest()
             ->paginate(20);
 
@@ -48,7 +48,7 @@ class ManagedUserController extends Controller
 
     public function edit(Profile $profile): View
     {
-        $profile->loadMissing(['businessProfile', 'communityProfile', 'attendeeProfile']);
+        $profile->loadMissing(['businessProfile', 'communityProfile', 'attendeeProfile', 'subscription']);
 
         return view('admin.users.edit', [
             'profile' => $profile,
@@ -61,5 +61,33 @@ class ManagedUserController extends Controller
 
         return redirect()->route('admin.users.edit', $profile)
             ->with('status', __('User updated successfully.'));
+    }
+
+    public function destroy(Profile $profile): RedirectResponse
+    {
+        $this->managedProfileService->delete($profile);
+
+        return redirect()->route('admin.users.index')
+            ->with('status', __('User deleted.'));
+    }
+
+    public function grantSubscription(Profile $profile): RedirectResponse
+    {
+        abort_unless($profile->isBusiness(), 422, 'Only business users can receive a subscription.');
+
+        $this->managedProfileService->grantSubscription($profile);
+
+        return redirect()->back()
+            ->with('status', __('Subscription granted for 12 months.'));
+    }
+
+    public function revokeSubscription(Profile $profile): RedirectResponse
+    {
+        abort_unless($profile->isBusiness(), 422, 'Only business users have a subscription.');
+
+        $this->managedProfileService->revokeSubscription($profile);
+
+        return redirect()->back()
+            ->with('status', __('Subscription revoked.'));
     }
 }

--- a/app/Http/Requests/Admin/UpdateKolabRequest.php
+++ b/app/Http/Requests/Admin/UpdateKolabRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\KolabStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateKolabRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['required', 'string', 'max:5000'],
+            'preferred_city' => ['required', 'string', 'max:100'],
+            'area' => ['nullable', 'string', 'max:100'],
+            'status' => ['required', Rule::in(KolabStatus::values())],
+            'offer_headline' => ['nullable', 'string', 'max:255'],
+            'base_offer' => ['nullable', 'string', 'max:2000'],
+        ];
+    }
+}

--- a/app/Services/Admin/ManagedProfileService.php
+++ b/app/Services/Admin/ManagedProfileService.php
@@ -131,6 +131,52 @@ class ManagedProfileService
         ]);
     }
 
+    public function delete(Profile $profile): void
+    {
+        $profile->delete();
+    }
+
+    /**
+     * Grant a maintainer-issued subscription that unblocks publish.
+     * Defaults to 12 months from today.
+     */
+    public function grantSubscription(Profile $profile, int $months = 12): BusinessSubscription
+    {
+        return DB::transaction(function () use ($profile, $months): BusinessSubscription {
+            $subscription = BusinessSubscription::query()->firstOrNew(
+                ['profile_id' => $profile->id],
+            );
+
+            $subscription->source = SubscriptionSource::Maintainer;
+            $subscription->status = SubscriptionStatus::Active;
+            $subscription->current_period_start = now();
+            $subscription->current_period_end = now()->addMonths($months);
+            $subscription->cancel_at_period_end = false;
+            $subscription->save();
+
+            return $subscription;
+        });
+    }
+
+    public function revokeSubscription(Profile $profile): ?BusinessSubscription
+    {
+        return DB::transaction(function () use ($profile): ?BusinessSubscription {
+            $subscription = BusinessSubscription::query()
+                ->where('profile_id', $profile->id)
+                ->first();
+
+            if ($subscription === null) {
+                return null;
+            }
+
+            $subscription->status = SubscriptionStatus::Inactive;
+            $subscription->cancel_at_period_end = true;
+            $subscription->save();
+
+            return $subscription;
+        });
+    }
+
     /**
      * @param  array<string, mixed>  $data
      */

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -319,6 +319,13 @@ return [
             'icon' => 'fas fa-fw fa-user-plus',
             'active' => ['admin/users/create'],
         ],
+        ['header' => 'CONTENT'],
+        [
+            'text' => 'Kolabs',
+            'route' => 'admin.kolabs.index',
+            'icon' => 'fas fa-fw fa-handshake',
+            'active' => ['admin/kolabs', 'admin/kolabs/*'],
+        ],
     ],
 
     /*

--- a/resources/views/admin/kolabs/edit.blade.php
+++ b/resources/views/admin/kolabs/edit.blade.php
@@ -1,0 +1,100 @@
+@extends('admin.layout', ['title' => 'Edit Kolab'])
+
+@section('page_title', 'Edit Kolab')
+@section('page_subtitle', $kolab->title)
+
+@section('page_actions')
+    <a href="{{ route('admin.kolabs.index') }}" class="btn btn-outline-secondary mr-2">
+        <i class="fas fa-arrow-left mr-1"></i>
+        Back
+    </a>
+    <form method="POST" action="{{ route('admin.kolabs.destroy', $kolab) }}" class="d-inline" onsubmit="return confirm('Delete this Kolab? This cannot be undone.');">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-danger">
+            <i class="fas fa-trash mr-1"></i>
+            Delete
+        </button>
+    </form>
+@endsection
+
+@section('admin_content')
+    @php
+        $creator = $kolab->creatorProfile;
+        $creatorLabel = $creator?->businessProfile?->name
+            ?? $creator?->communityProfile?->name
+            ?? $creator?->email
+            ?? '—';
+    @endphp
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-3">Creator</dt>
+                <dd class="col-sm-9">{{ $creatorLabel }} <small class="text-muted">({{ $creator?->user_type->value ?? '—' }})</small></dd>
+                <dt class="col-sm-3">Intent</dt>
+                <dd class="col-sm-9">{{ str_replace('_', ' ', $kolab->intent_type->value) }}</dd>
+                <dt class="col-sm-3">Published at</dt>
+                <dd class="col-sm-9">{{ $kolab->published_at?->toDayDateTimeString() ?? '—' }}</dd>
+            </dl>
+        </div>
+    </div>
+
+    <form method="POST" action="{{ route('admin.kolabs.update', $kolab) }}">
+        @csrf
+        @method('PUT')
+
+        <div class="card">
+            <div class="card-body">
+                <div class="form-group">
+                    <label for="title">Title</label>
+                    <input type="text" name="title" id="title" value="{{ old('title', $kolab->title) }}" class="form-control" required maxlength="255">
+                </div>
+
+                <div class="form-group">
+                    <label for="description">Description</label>
+                    <textarea name="description" id="description" rows="5" class="form-control" required maxlength="5000">{{ old('description', $kolab->description) }}</textarea>
+                </div>
+
+                <div class="form-row">
+                    <div class="form-group col-md-6">
+                        <label for="preferred_city">Preferred city</label>
+                        <input type="text" name="preferred_city" id="preferred_city" value="{{ old('preferred_city', $kolab->preferred_city) }}" class="form-control" required maxlength="100">
+                    </div>
+                    <div class="form-group col-md-6">
+                        <label for="area">Area <small class="text-muted">(optional)</small></label>
+                        <input type="text" name="area" id="area" value="{{ old('area', $kolab->area) }}" class="form-control" maxlength="100">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label for="offer_headline">Offer headline <small class="text-muted">(optional)</small></label>
+                    <input type="text" name="offer_headline" id="offer_headline" value="{{ old('offer_headline', $kolab->offer_headline) }}" class="form-control" maxlength="255">
+                </div>
+
+                <div class="form-group">
+                    <label for="base_offer">Base offer <small class="text-muted">(optional)</small></label>
+                    <textarea name="base_offer" id="base_offer" rows="3" class="form-control" maxlength="2000">{{ old('base_offer', $kolab->base_offer) }}</textarea>
+                </div>
+
+                <div class="form-group">
+                    <label for="status">Status</label>
+                    <select name="status" id="status" class="form-control" required>
+                        @foreach ($statuses as $status)
+                            <option value="{{ $status->value }}" {{ old('status', $kolab->status->value) === $status->value ? 'selected' : '' }}>
+                                {{ ucfirst($status->value) }}
+                            </option>
+                        @endforeach
+                    </select>
+                    <small class="form-text text-muted">Moving a draft to "published" stamps the publication date automatically.</small>
+                </div>
+            </div>
+            <div class="card-footer text-right">
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-save mr-1"></i>
+                    Save changes
+                </button>
+            </div>
+        </div>
+    </form>
+@endsection

--- a/resources/views/admin/kolabs/index.blade.php
+++ b/resources/views/admin/kolabs/index.blade.php
@@ -1,0 +1,99 @@
+@extends('admin.layout', ['title' => 'Kolabs'])
+
+@section('page_title', 'Kolabs')
+@section('page_subtitle', 'Review, edit, and delete collaboration offers.')
+
+@section('admin_content')
+    <div class="card mb-3">
+        <div class="card-body">
+            <form method="GET" action="{{ route('admin.kolabs.index') }}" class="form-row align-items-end">
+                <div class="form-group col-md-5">
+                    <label for="q" class="small text-muted mb-1">Search</label>
+                    <input type="text" name="q" id="q" value="{{ $filters['q'] }}" class="form-control" placeholder="Title or city…">
+                </div>
+                <div class="form-group col-md-4">
+                    <label for="status" class="small text-muted mb-1">Status</label>
+                    <select name="status" id="status" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($statuses as $status)
+                            <option value="{{ $status->value }}" {{ $filters['status'] === $status->value ? 'selected' : '' }}>
+                                {{ ucfirst($status->value) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <button type="submit" class="btn btn-primary btn-block">Filter</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Title</th>
+                            <th>Creator</th>
+                            <th>City</th>
+                            <th>Intent</th>
+                            <th>Status</th>
+                            <th>Created</th>
+                            <th class="text-right pr-4">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($kolabs as $kolab)
+                            @php
+                                $creator = $kolab->creatorProfile;
+                                $creatorLabel = $creator?->businessProfile?->name
+                                    ?? $creator?->communityProfile?->name
+                                    ?? $creator?->email
+                                    ?? '—';
+                                $statusClass = match ($kolab->status->value) {
+                                    'published' => 'badge-success',
+                                    'closed' => 'badge-secondary',
+                                    default => 'badge-warning',
+                                };
+                            @endphp
+                            <tr>
+                                <td>
+                                    <div class="font-weight-bold">{{ $kolab->title }}</div>
+                                    <small class="text-muted">{{ $kolab->id }}</small>
+                                </td>
+                                <td>{{ $creatorLabel }}</td>
+                                <td>{{ $kolab->preferred_city }}</td>
+                                <td>
+                                    <span class="badge badge-light text-uppercase">{{ str_replace('_', ' ', $kolab->intent_type->value) }}</span>
+                                </td>
+                                <td>
+                                    <span class="badge {{ $statusClass }} text-uppercase">{{ $kolab->status->value }}</span>
+                                </td>
+                                <td>{{ $kolab->created_at?->toDateString() ?? '—' }}</td>
+                                <td class="text-right pr-4">
+                                    <a href="{{ route('admin.kolabs.edit', $kolab) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+                                    <form method="POST" action="{{ route('admin.kolabs.destroy', $kolab) }}" class="d-inline" onsubmit="return confirm('Delete this Kolab? This cannot be undone.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="text-center text-muted py-4">No Kolabs found.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @if ($kolabs->hasPages())
+            <div class="card-footer clearfix">
+                {{ $kolabs->links('pagination::bootstrap-4') }}
+            </div>
+        @endif
+    </div>
+@endsection

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -4,13 +4,63 @@
 @section('page_subtitle', 'Update the selected application profile without changing API-side workflows.')
 
 @section('page_actions')
-    <a href="{{ route('admin.users.index') }}" class="btn btn-outline-secondary">
+    <a href="{{ route('admin.users.index') }}" class="btn btn-outline-secondary mr-2">
         <i class="fas fa-arrow-left mr-1"></i>
         Back to Users
     </a>
+
+    @if ($profile->user_type->value === 'business')
+        @php $subActive = $profile->subscription?->status?->value === 'active'; @endphp
+        @if ($subActive)
+            <form method="POST" action="{{ route('admin.users.subscription.revoke', $profile) }}" class="d-inline mr-2" onsubmit="return confirm('Revoke subscription access for this user?');">
+                @csrf
+                <button type="submit" class="btn btn-warning">
+                    <i class="fas fa-ban mr-1"></i>
+                    Revoke subscription
+                </button>
+            </form>
+        @else
+            <form method="POST" action="{{ route('admin.users.subscription.grant', $profile) }}" class="d-inline mr-2">
+                @csrf
+                <button type="submit" class="btn btn-success">
+                    <i class="fas fa-check mr-1"></i>
+                    Grant subscription (12mo)
+                </button>
+            </form>
+        @endif
+    @endif
+
+    <form method="POST" action="{{ route('admin.users.destroy', $profile) }}" class="d-inline" onsubmit="return confirm('Delete this user? They will be soft-deleted.');">
+        @csrf
+        @method('DELETE')
+        <button type="submit" class="btn btn-danger">
+            <i class="fas fa-trash mr-1"></i>
+            Delete user
+        </button>
+    </form>
 @endsection
 
 @section('admin_content')
+    @if ($profile->user_type->value === 'business' && $profile->subscription)
+        @php
+            $sub = $profile->subscription;
+            $statusClass = match ($sub->status->value) {
+                'active' => 'success',
+                'past_due' => 'danger',
+                'cancelled' => 'secondary',
+                default => 'warning',
+            };
+        @endphp
+        <div class="alert alert-{{ $statusClass }}">
+            <strong>Subscription:</strong>
+            {{ $sub->status->label() }}
+            <span class="text-muted">(source: {{ $sub->source->value }})</span>
+            @if ($sub->current_period_end)
+                · ends {{ $sub->current_period_end->toDayDateTimeString() }}
+            @endif
+        </div>
+    @endif
+
     <div class="card card-primary card-outline">
         <form method="post" action="{{ route('admin.users.update', $profile) }}">
             @csrf

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -48,9 +48,28 @@
                                     </span>
                                 </td>
                                 <td class="text-right pr-4">
-                                    <a href="{{ route('admin.users.edit', $profile) }}" class="btn btn-sm btn-outline-primary">
-                                        Edit
-                                    </a>
+                                    <a href="{{ route('admin.users.edit', $profile) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+
+                                    @if ($profile->user_type->value === 'business')
+                                        @php $subActive = $profile->subscription?->status?->value === 'active'; @endphp
+                                        @if ($subActive)
+                                            <form method="POST" action="{{ route('admin.users.subscription.revoke', $profile) }}" class="d-inline" onsubmit="return confirm('Revoke subscription access for this user?');">
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-warning" title="Revoke subscription">Revoke sub</button>
+                                            </form>
+                                        @else
+                                            <form method="POST" action="{{ route('admin.users.subscription.grant', $profile) }}" class="d-inline">
+                                                @csrf
+                                                <button type="submit" class="btn btn-sm btn-outline-success" title="Grant 12 months of access">Grant sub</button>
+                                            </form>
+                                        @endif
+                                    @endif
+
+                                    <form method="POST" action="{{ route('admin.users.destroy', $profile) }}" class="d-inline" onsubmit="return confirm('Delete this user? They will be soft-deleted.');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                    </form>
                                 </td>
                             </tr>
                         @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,8 @@
 <?php
 
-use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\AuthController as AdminAuthController;
+use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\KolabController as AdminKolabController;
 use App\Http\Controllers\Admin\ManagedUserController;
 use Illuminate\Support\Facades\Route;
 
@@ -23,6 +24,14 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::post('/users', [ManagedUserController::class, 'store'])->name('users.store');
     Route::get('/users/{profile}/edit', [ManagedUserController::class, 'edit'])->name('users.edit');
     Route::put('/users/{profile}', [ManagedUserController::class, 'update'])->name('users.update');
+    Route::delete('/users/{profile}', [ManagedUserController::class, 'destroy'])->name('users.destroy');
+    Route::post('/users/{profile}/subscription/grant', [ManagedUserController::class, 'grantSubscription'])->name('users.subscription.grant');
+    Route::post('/users/{profile}/subscription/revoke', [ManagedUserController::class, 'revokeSubscription'])->name('users.subscription.revoke');
+
+    Route::get('/kolabs', [AdminKolabController::class, 'index'])->name('kolabs.index');
+    Route::get('/kolabs/{kolab}/edit', [AdminKolabController::class, 'edit'])->name('kolabs.edit');
+    Route::put('/kolabs/{kolab}', [AdminKolabController::class, 'update'])->name('kolabs.update');
+    Route::delete('/kolabs/{kolab}', [AdminKolabController::class, 'destroy'])->name('kolabs.destroy');
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/tests/Feature/Admin/KolabManagementTest.php
+++ b/tests/Feature/Admin/KolabManagementTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\KolabStatus;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class KolabManagementTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_maintainer_sees_kolab_list(): void
+    {
+        $kolab = Kolab::factory()->create(['title' => 'Beach club takeover']);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index'))
+            ->assertOk()
+            ->assertSee('Beach club takeover');
+    }
+
+    public function test_index_filters_by_status(): void
+    {
+        Kolab::factory()->create(['status' => KolabStatus::Draft, 'title' => 'Draft Kolab Alpha']);
+        Kolab::factory()->published()->create(['title' => 'Published Kolab Beta']);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index', ['status' => 'published']));
+
+        $response->assertSee('Published Kolab Beta');
+        $response->assertDontSee('Draft Kolab Alpha');
+    }
+
+    public function test_maintainer_can_edit_a_kolab(): void
+    {
+        $kolab = Kolab::factory()->create([
+            'title' => 'Old title',
+            'status' => KolabStatus::Draft,
+        ]);
+
+        $payload = [
+            'title' => 'New title',
+            'description' => $kolab->description,
+            'preferred_city' => 'Barcelona',
+            'area' => 'El Born',
+            'status' => 'published',
+            'offer_headline' => null,
+            'base_offer' => null,
+        ];
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.kolabs.update', $kolab), $payload)
+            ->assertRedirect(route('admin.kolabs.edit', $kolab));
+
+        $kolab->refresh();
+        $this->assertSame('New title', $kolab->title);
+        $this->assertSame(KolabStatus::Published, $kolab->status);
+        $this->assertNotNull($kolab->published_at);
+    }
+
+    public function test_update_validates_required_fields(): void
+    {
+        $kolab = Kolab::factory()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.kolabs.update', $kolab), [])
+            ->assertSessionHasErrors(['title', 'description', 'preferred_city', 'status']);
+    }
+
+    public function test_maintainer_can_delete_a_kolab(): void
+    {
+        $kolab = Kolab::factory()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->delete(route('admin.kolabs.destroy', $kolab))
+            ->assertRedirect(route('admin.kolabs.index'));
+
+        $this->assertDatabaseMissing('kolabs', ['id' => $kolab->id]);
+    }
+
+    public function test_non_maintainer_cannot_touch_kolabs(): void
+    {
+        $user = User::factory()->create(['is_maintainer' => false]);
+        $kolab = Kolab::factory()->create();
+
+        $this->actingAs($user, 'admin')
+            ->get(route('admin.kolabs.index'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Admin/UserManagementTest.php
+++ b/tests/Feature/Admin/UserManagementTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\SubscriptionSource;
+use App\Enums\SubscriptionStatus;
+use App\Models\BusinessSubscription;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class UserManagementTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_maintainer_can_soft_delete_a_user(): void
+    {
+        $profile = Profile::factory()->business()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->delete(route('admin.users.destroy', $profile))
+            ->assertRedirect(route('admin.users.index'));
+
+        $this->assertSoftDeleted('profiles', ['id' => $profile->id]);
+    }
+
+    public function test_maintainer_can_grant_subscription_to_a_business_user(): void
+    {
+        $profile = Profile::factory()->business()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.users.subscription.grant', $profile))
+            ->assertRedirect();
+
+        $subscription = BusinessSubscription::where('profile_id', $profile->id)->firstOrFail();
+
+        $this->assertSame(SubscriptionStatus::Active, $subscription->status);
+        $this->assertSame(SubscriptionSource::Maintainer, $subscription->source);
+        $this->assertNotNull($subscription->current_period_end);
+        $this->assertTrue($subscription->current_period_end->isAfter(now()->addMonths(11)));
+    }
+
+    public function test_granting_subscription_updates_existing_subscription_row(): void
+    {
+        $profile = Profile::factory()->business()->create();
+
+        // The factory creates an inactive Stripe sub; granting should flip it.
+        BusinessSubscription::firstOrCreate(
+            ['profile_id' => $profile->id],
+            ['source' => SubscriptionSource::Stripe, 'status' => SubscriptionStatus::Inactive],
+        );
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.users.subscription.grant', $profile))
+            ->assertRedirect();
+
+        $this->assertDatabaseCount('business_subscriptions', 1);
+        $this->assertDatabaseHas('business_subscriptions', [
+            'profile_id' => $profile->id,
+            'status' => 'active',
+            'source' => 'maintainer',
+        ]);
+    }
+
+    public function test_maintainer_can_revoke_subscription(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessSubscription::firstOrCreate(
+            ['profile_id' => $profile->id],
+            ['source' => SubscriptionSource::Maintainer, 'status' => SubscriptionStatus::Active],
+        );
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.users.subscription.revoke', $profile))
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('business_subscriptions', [
+            'profile_id' => $profile->id,
+            'status' => 'inactive',
+        ]);
+    }
+
+    public function test_granting_subscription_to_non_business_user_is_rejected(): void
+    {
+        $profile = Profile::factory()->community()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.users.subscription.grant', $profile))
+            ->assertStatus(422);
+
+        $this->assertDatabaseMissing('business_subscriptions', ['profile_id' => $profile->id]);
+    }
+
+    public function test_users_index_renders_action_buttons(): void
+    {
+        Profile::factory()->business()->create();
+        Profile::factory()->community()->create();
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.users.index'));
+
+        $response->assertOk();
+        $response->assertSee('Grant sub', false);
+        $response->assertSee('Delete', false);
+    }
+
+    public function test_admin_routes_reject_non_maintainer(): void
+    {
+        $user = User::factory()->create(['is_maintainer' => false]);
+        $profile = Profile::factory()->business()->create();
+
+        $this->actingAs($user, 'admin')
+            ->delete(route('admin.users.destroy', $profile))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- New **Kolabs** sidebar tab in the admin panel: list with status filter + title/city search, edit form (title, description, city, area, offer headline, base offer, status — auto-stamps `published_at` on draft→published), hard delete with confirm.
- **Delete user** action on both the user list and the edit page. Uses the existing `SoftDeletes` on `profiles`, so the row stays recoverable.
- **Grant / revoke subscription** for business users — buttons appear on the user list (compact) and edit page (with a current-status banner). Grants flip the user's `BusinessSubscription` to **active** for **12 months** with a new `SubscriptionSource::Maintainer` case so admin-issued access is auditable. Revokes set the sub **inactive** with `cancel_at_period_end=true`. Non-business profiles return **422**.

## Test plan
- [x] `php artisan test --filter="Admin|Subscription|Onboarding"` — 57 passed
- [x] Full suite via `php -d memory_limit=-1 vendor/bin/phpunit` — **662 passed, 3413 assertions**
- [x] `vendor/bin/pint --dirty` — clean
- [ ] Manual: log in to /admin as a maintainer, edit a Kolab status, delete a Kolab, soft-delete a user, grant + revoke a business subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)