### PR TITLE
feat(admin): surface Kolab lifecycle + force-cancel collaboration

### DIFF
--- a/app/Http/Controllers/Admin/KolabController.php
+++ b/app/Http/Controllers/Admin/KolabController.php
@@ -4,38 +4,71 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\ApplicationStatus;
 use App\Enums\KolabStatus;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\CancelKolabCollaborationRequest;
 use App\Http\Requests\Admin\UpdateKolabRequest;
+use App\Models\Application;
+use App\Models\Collaboration;
 use App\Models\Kolab;
+use App\Services\Admin\KolabLifecycleService;
+use App\Services\CollaborationService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class KolabController extends Controller
 {
+    public function __construct(
+        private readonly KolabLifecycleService $lifecycle,
+        private readonly CollaborationService $collaborations,
+    ) {}
+
     public function index(Request $request): View
     {
-        $kolabs = Kolab::query()
+        $query = Kolab::query()
+            ->select('kolabs.*')
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Pending->value),
+                'pending_applications_count'
+            )
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Accepted->value),
+                'accepted_applications_count'
+            )
             ->with(['creatorProfile.businessProfile', 'creatorProfile.communityProfile'])
-            ->when($request->filled('status'), fn ($query) => $query->where('status', $request->string('status')))
-            ->when($request->filled('q'), function ($query) use ($request): void {
+            ->when($request->filled('status'), fn ($q) => $q->where('kolabs.status', $request->string('status')))
+            ->when($request->filled('q'), function ($q) use ($request): void {
                 $term = '%'.$request->string('q').'%';
-                $query->where(function ($inner) use ($term): void {
+                $q->where(function ($inner) use ($term): void {
                     $inner->where('title', 'like', $term)
                         ->orWhere('preferred_city', 'like', $term);
                 });
             })
-            ->latest()
-            ->paginate(20)
-            ->withQueryString();
+            ->when($request->filled('lifecycle'), function ($q) use ($request): void {
+                $this->lifecycle->applyFilter($q, (string) $request->string('lifecycle'));
+            })
+            ->latest();
+
+        $kolabs = $query->paginate(20)->withQueryString();
+        $lifecycles = $this->lifecycle->summarizeMany($kolabs->getCollection());
 
         return view('admin.kolabs.index', [
             'kolabs' => $kolabs,
+            'lifecycles' => $lifecycles,
             'statuses' => KolabStatus::cases(),
+            'lifecycleOptions' => KolabLifecycleService::all(),
             'filters' => [
                 'status' => (string) $request->string('status'),
                 'q' => (string) $request->string('q'),
+                'lifecycle' => (string) $request->string('lifecycle'),
             ],
         ]);
     }
@@ -47,6 +80,7 @@ class KolabController extends Controller
         return view('admin.kolabs.edit', [
             'kolab' => $kolab,
             'statuses' => KolabStatus::cases(),
+            'summary' => $this->lifecycle->summarize($kolab),
         ]);
     }
 
@@ -73,5 +107,20 @@ class KolabController extends Controller
         return redirect()
             ->route('admin.kolabs.index')
             ->with('status', __('Kolab deleted.'));
+    }
+
+    public function cancelCollaboration(CancelKolabCollaborationRequest $request, Kolab $kolab): RedirectResponse
+    {
+        $collaboration = Collaboration::query()
+            ->where('collab_opportunity_id', $kolab->id)
+            ->first();
+
+        abort_if($collaboration === null, 404, 'No collaboration to cancel for this Kolab.');
+
+        $this->collaborations->cancel($collaboration, $request->validated('reason'));
+
+        return redirect()
+            ->route('admin.kolabs.edit', $kolab)
+            ->with('status', __('Collaboration cancelled.'));
     }
 }

--- a/app/Http/Requests/Admin/CancelKolabCollaborationRequest.php
+++ b/app/Http/Requests/Admin/CancelKolabCollaborationRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CancelKolabCollaborationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'min:3', 'max:500'],
+        ];
+    }
+}

--- a/app/Services/Admin/KolabLifecycleService.php
+++ b/app/Services/Admin/KolabLifecycleService.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
+use App\Enums\KolabStatus;
+use App\Models\Application;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Kolab;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
+
+class KolabLifecycleService
+{
+    public const DRAFT = 'draft';
+
+    public const OPEN = 'open';
+
+    public const RECEIVING = 'receiving_applicants';
+
+    public const MATCHED = 'matched';
+
+    public const SCHEDULED = 'scheduled';
+
+    public const ACTIVE = 'active';
+
+    public const COMPLETED = 'completed';
+
+    public const CANCELLED = 'cancelled';
+
+    public const CLOSED = 'closed';
+
+    /**
+     * All lifecycle keys in display order.
+     *
+     * @return array<int, string>
+     */
+    public static function all(): array
+    {
+        return [
+            self::DRAFT, self::OPEN, self::RECEIVING, self::MATCHED,
+            self::SCHEDULED, self::ACTIVE, self::COMPLETED, self::CANCELLED, self::CLOSED,
+        ];
+    }
+
+    public static function label(string $lifecycle): string
+    {
+        return match ($lifecycle) {
+            self::DRAFT => 'Draft',
+            self::OPEN => 'Open',
+            self::RECEIVING => 'Receiving applicants',
+            self::MATCHED => 'Matched',
+            self::SCHEDULED => 'Scheduled',
+            self::ACTIVE => 'Active',
+            self::COMPLETED => 'Completed',
+            self::CANCELLED => 'Cancelled',
+            self::CLOSED => 'Closed',
+            default => ucfirst(str_replace('_', ' ', $lifecycle)),
+        };
+    }
+
+    public static function badgeClass(string $lifecycle): string
+    {
+        return match ($lifecycle) {
+            self::DRAFT, self::CLOSED => 'badge-secondary',
+            self::OPEN => 'badge-info',
+            self::RECEIVING => 'badge-warning',
+            self::MATCHED => 'badge-primary',
+            self::SCHEDULED => 'badge-light',
+            self::ACTIVE => 'badge-success',
+            self::COMPLETED => 'badge-dark',
+            self::CANCELLED => 'badge-danger',
+            default => 'badge-light',
+        };
+    }
+
+    /**
+     * Derive the lifecycle for one Kolab.
+     *
+     * @param  array{pending: int, accepted: int}  $counts
+     */
+    public function derive(Kolab $kolab, ?Collaboration $collaboration, array $counts): string
+    {
+        if ($kolab->status === KolabStatus::Draft) {
+            return self::DRAFT;
+        }
+
+        if ($collaboration instanceof Collaboration) {
+            return match ($collaboration->status) {
+                CollaborationStatus::Scheduled => self::SCHEDULED,
+                CollaborationStatus::Active => self::ACTIVE,
+                CollaborationStatus::Completed => self::COMPLETED,
+                CollaborationStatus::Cancelled => self::CANCELLED,
+            };
+        }
+
+        if (($counts['accepted'] ?? 0) > 0) {
+            return self::MATCHED;
+        }
+
+        if ($kolab->status === KolabStatus::Closed) {
+            return self::CLOSED;
+        }
+
+        if (($counts['pending'] ?? 0) > 0) {
+            return self::RECEIVING;
+        }
+
+        return self::OPEN;
+    }
+
+    /**
+     * Hydrate per-kolab lifecycle context for a list page.
+     *
+     * @param  \Illuminate\Pagination\LengthAwarePaginator<Kolab>|Collection<int, Kolab>  $kolabs
+     * @return SupportCollection<string, array{lifecycle: string, pending: int, accepted: int, collaboration: Collaboration|null}>
+     */
+    public function summarizeMany($kolabs): SupportCollection
+    {
+        $ids = collect($kolabs)->pluck('id');
+
+        $collaborations = Collaboration::query()
+            ->with(['businessProfile', 'communityProfile'])
+            ->whereIn('collab_opportunity_id', $ids)
+            ->get()
+            ->keyBy('collab_opportunity_id');
+
+        return collect($kolabs)->mapWithKeys(function (Kolab $kolab) use ($collaborations): array {
+            $collaboration = $collaborations->get($kolab->id);
+            $counts = [
+                'pending' => (int) ($kolab->pending_applications_count ?? 0),
+                'accepted' => (int) ($kolab->accepted_applications_count ?? 0),
+            ];
+
+            return [$kolab->id => [
+                'lifecycle' => $this->derive($kolab, $collaboration, $counts),
+                'pending' => $counts['pending'],
+                'accepted' => $counts['accepted'],
+                'collaboration' => $collaboration,
+            ]];
+        });
+    }
+
+    /**
+     * Full lifecycle payload for a single Kolab (edit page).
+     *
+     * @return array{
+     *     lifecycle: string,
+     *     counts: array<string, int>,
+     *     recent_applications: Collection<int, Application>,
+     *     collaboration: Collaboration|null,
+     *     reviews: Collection<int, CollaborationReview>,
+     *     average_rating: float|null,
+     * }
+     */
+    public function summarize(Kolab $kolab): array
+    {
+        $counts = [
+            'pending' => 0, 'accepted' => 0, 'declined' => 0, 'withdrawn' => 0,
+        ];
+
+        Application::query()
+            ->toBase()
+            ->where('collab_opportunity_id', $kolab->id)
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->get()
+            ->each(function ($row) use (&$counts): void {
+                $counts[(string) $row->status] = (int) $row->total;
+            });
+
+        $recent = Application::query()
+            ->with('applicantProfile.businessProfile', 'applicantProfile.communityProfile')
+            ->where('collab_opportunity_id', $kolab->id)
+            ->latest()
+            ->limit(8)
+            ->get();
+
+        $collaboration = Collaboration::query()
+            ->with(['businessProfile', 'communityProfile', 'event'])
+            ->where('collab_opportunity_id', $kolab->id)
+            ->first();
+
+        $reviews = $collaboration
+            ? CollaborationReview::query()
+                ->with('reviewerProfile')
+                ->where('collaboration_id', $collaboration->id)
+                ->get()
+            : new Collection;
+
+        $ratings = $reviews->pluck('rating')->filter()->values();
+        $averageRating = $ratings->isNotEmpty() ? (float) round($ratings->avg(), 1) : null;
+
+        return [
+            'lifecycle' => $this->derive($kolab, $collaboration, $counts),
+            'counts' => $counts,
+            'recent_applications' => $recent,
+            'collaboration' => $collaboration,
+            'reviews' => $reviews,
+            'average_rating' => $averageRating,
+        ];
+    }
+
+    /**
+     * Apply a lifecycle filter to a Kolab query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<Kolab>  $query
+     */
+    public function applyFilter($query, string $lifecycle): void
+    {
+        $hasCollabWith = fn (CollaborationStatus $status) => function ($sub) use ($status): void {
+            $sub->from('collaborations')
+                ->whereColumn('collaborations.collab_opportunity_id', 'kolabs.id')
+                ->where('collaborations.status', $status->value);
+        };
+
+        $hasAnyCollab = function ($sub): void {
+            $sub->from('collaborations')
+                ->whereColumn('collaborations.collab_opportunity_id', 'kolabs.id');
+        };
+
+        $hasApplicationWith = fn (ApplicationStatus $status) => function ($sub) use ($status): void {
+            $sub->from('applications')
+                ->whereColumn('applications.collab_opportunity_id', 'kolabs.id')
+                ->where('applications.status', $status->value);
+        };
+
+        match ($lifecycle) {
+            self::DRAFT => $query->where('kolabs.status', KolabStatus::Draft->value),
+            self::CLOSED => $query->where('kolabs.status', KolabStatus::Closed->value)
+                ->whereNotExists($hasAnyCollab),
+            self::OPEN => $query->where('kolabs.status', KolabStatus::Published->value)
+                ->whereNotExists($hasAnyCollab)
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Pending))
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::RECEIVING => $query->where('kolabs.status', KolabStatus::Published->value)
+                ->whereNotExists($hasAnyCollab)
+                ->whereExists($hasApplicationWith(ApplicationStatus::Pending))
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::MATCHED => $query->whereNotExists($hasAnyCollab)
+                ->whereExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::SCHEDULED => $query->whereExists($hasCollabWith(CollaborationStatus::Scheduled)),
+            self::ACTIVE => $query->whereExists($hasCollabWith(CollaborationStatus::Active)),
+            self::COMPLETED => $query->whereExists($hasCollabWith(CollaborationStatus::Completed)),
+            self::CANCELLED => $query->whereExists($hasCollabWith(CollaborationStatus::Cancelled)),
+            default => null,
+        };
+    }
+}

--- a/resources/views/admin/kolabs/_lifecycle.blade.php
+++ b/resources/views/admin/kolabs/_lifecycle.blade.php
@@ -1,0 +1,188 @@
+@php
+    use App\Services\Admin\KolabLifecycleService;
+
+    $lifecycle = $summary['lifecycle'];
+    $counts = $summary['counts'];
+    $collaboration = $summary['collaboration'];
+    $reviews = $summary['reviews'];
+    $averageRating = $summary['average_rating'];
+    $recentApplications = $summary['recent_applications'];
+@endphp
+
+<div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="card-title mb-0">Lifecycle</h3>
+        <span class="badge {{ KolabLifecycleService::badgeClass($lifecycle) }} text-uppercase">
+            {{ KolabLifecycleService::label($lifecycle) }}
+        </span>
+    </div>
+
+    <div class="card-body">
+        {{-- Applications --}}
+        <h5 class="mb-2">Applications</h5>
+        <div class="row text-center mb-3">
+            <div class="col">
+                <div class="text-muted small">Pending</div>
+                <div class="h4 mb-0">{{ $counts['pending'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Accepted</div>
+                <div class="h4 mb-0 text-success">{{ $counts['accepted'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Declined</div>
+                <div class="h4 mb-0">{{ $counts['declined'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Withdrawn</div>
+                <div class="h4 mb-0">{{ $counts['withdrawn'] }}</div>
+            </div>
+        </div>
+
+        @if ($recentApplications->isEmpty())
+            <p class="text-muted small mb-0">Nobody has applied yet.</p>
+        @else
+            <div class="table-responsive mb-3">
+                <table class="table table-sm table-borderless mb-0">
+                    <thead>
+                        <tr class="text-muted">
+                            <th class="font-weight-normal small">Applicant</th>
+                            <th class="font-weight-normal small">Status</th>
+                            <th class="font-weight-normal small">When</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($recentApplications as $app)
+                            @php
+                                $applicant = $app->applicantProfile;
+                                $applicantLabel = $applicant?->businessProfile?->name
+                                    ?? $applicant?->communityProfile?->name
+                                    ?? $applicant?->email
+                                    ?? '—';
+                                $appBadge = match ($app->status->value) {
+                                    'accepted' => 'badge-success',
+                                    'declined' => 'badge-secondary',
+                                    'withdrawn' => 'badge-light',
+                                    default => 'badge-warning',
+                                };
+                            @endphp
+                            <tr>
+                                <td>{{ $applicantLabel }}</td>
+                                <td><span class="badge {{ $appBadge }} text-uppercase">{{ $app->status->value }}</span></td>
+                                <td class="text-muted small">{{ $app->created_at?->diffForHumans() ?? '—' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+
+        {{-- Collaboration --}}
+        <h5 class="mb-2 mt-4">Collaboration</h5>
+        @if ($collaboration === null)
+            <p class="text-muted small mb-0">No collaboration yet — no accepted match has produced an active deal.</p>
+        @else
+            @php
+                $business = $collaboration->businessProfile;
+                $community = $collaboration->communityProfile;
+                $collabBadge = match ($collaboration->status->value) {
+                    'active' => 'badge-success',
+                    'scheduled' => 'badge-info',
+                    'completed' => 'badge-dark',
+                    'cancelled' => 'badge-danger',
+                    default => 'badge-light',
+                };
+                $canCancel = in_array($collaboration->status->value, ['scheduled', 'active'], true);
+            @endphp
+            <dl class="row mb-2">
+                <dt class="col-sm-3">Status</dt>
+                <dd class="col-sm-9"><span class="badge {{ $collabBadge }} text-uppercase">{{ $collaboration->status->value }}</span></dd>
+                <dt class="col-sm-3">Scheduled date</dt>
+                <dd class="col-sm-9">{{ $collaboration->scheduled_date?->toFormattedDateString() ?? '—' }}</dd>
+                <dt class="col-sm-3">Completed at</dt>
+                <dd class="col-sm-9">{{ $collaboration->completed_at?->toDayDateTimeString() ?? '—' }}</dd>
+                <dt class="col-sm-3">Business side</dt>
+                <dd class="col-sm-9">
+                    @if ($business)
+                        {{ $business->name ?? '—' }}
+                        <span class="text-muted small">{{ $business->profile?->email ? '· '.$business->profile->email : '' }}</span>
+                    @else
+                        —
+                    @endif
+                </dd>
+                <dt class="col-sm-3">Community side</dt>
+                <dd class="col-sm-9">
+                    @if ($community)
+                        {{ $community->name ?? '—' }}
+                        <span class="text-muted small">{{ $community->profile?->email ? '· '.$community->profile->email : '' }}</span>
+                    @else
+                        —
+                    @endif
+                </dd>
+                @if ($collaboration->contact_methods)
+                    <dt class="col-sm-3">Contact methods</dt>
+                    <dd class="col-sm-9 small text-muted">{{ implode(', ', array_keys(array_filter($collaboration->contact_methods))) }}</dd>
+                @endif
+                @if ($collaboration->event_id)
+                    <dt class="col-sm-3">Event linked</dt>
+                    <dd class="col-sm-9 small text-muted">{{ $collaboration->event_id }}</dd>
+                @endif
+                @if ($collaboration->qr_code_url)
+                    <dt class="col-sm-3">QR</dt>
+                    <dd class="col-sm-9 small"><a href="{{ $collaboration->qr_code_url }}" target="_blank" rel="noopener">{{ $collaboration->qr_code_url }}</a></dd>
+                @endif
+            </dl>
+
+            @if ($canCancel)
+                <form method="POST" action="{{ route('admin.kolabs.collaboration.cancel', $kolab) }}" class="mt-3"
+                      onsubmit="return confirm('Force-cancel this collaboration? Both parties will be affected.');">
+                    @csrf
+                    <div class="form-row align-items-end">
+                        <div class="form-group col-md-9 mb-0">
+                            <label for="cancel-reason" class="small text-muted mb-1">Cancellation reason (required)</label>
+                            <input type="text" name="reason" id="cancel-reason" class="form-control" minlength="3" maxlength="500" required placeholder="Why is this being cancelled?">
+                            @error('reason')
+                                <small class="text-danger">{{ $message }}</small>
+                            @enderror
+                        </div>
+                        <div class="form-group col-md-3 mb-0">
+                            <button type="submit" class="btn btn-outline-danger btn-block">
+                                <i class="fas fa-ban mr-1"></i>
+                                Force-cancel
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            @endif
+        @endif
+
+        {{-- Reviews --}}
+        @if ($collaboration !== null)
+            <h5 class="mb-2 mt-4">Reviews</h5>
+            @if ($reviews->isEmpty())
+                <p class="text-muted small mb-0">No reviews submitted yet.</p>
+            @else
+                <p class="mb-2 small">
+                    {{ $reviews->count() }} review{{ $reviews->count() === 1 ? '' : 's' }}
+                    @if ($averageRating !== null)
+                        · average <strong>★ {{ number_format($averageRating, 1) }}</strong>
+                    @endif
+                </p>
+                <ul class="list-unstyled mb-0">
+                    @foreach ($reviews as $review)
+                        @php
+                            $reviewText = $review->body ?: $review->note;
+                            $roleLabel = $review->reviewer_role === 'business' ? 'Business → Community' : 'Community → Business';
+                        @endphp
+                        <li class="mb-2 pl-3 border-left">
+                            <div class="small text-muted">{{ $roleLabel }} · ★ {{ $review->rating ?? '—' }}</div>
+                            @if ($reviewText)
+                                <div class="small">{{ $reviewText }}</div>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        @endif
+    </div>
+</div>

--- a/resources/views/admin/kolabs/edit.blade.php
+++ b/resources/views/admin/kolabs/edit.blade.php
@@ -40,6 +40,8 @@
         </div>
     </div>
 
+    @include('admin.kolabs._lifecycle', ['summary' => $summary, 'kolab' => $kolab])
+
     <form method="POST" action="{{ route('admin.kolabs.update', $kolab) }}">
         @csrf
         @method('PUT')

--- a/resources/views/admin/kolabs/index.blade.php
+++ b/resources/views/admin/kolabs/index.blade.php
@@ -7,12 +7,12 @@
     <div class="card mb-3">
         <div class="card-body">
             <form method="GET" action="{{ route('admin.kolabs.index') }}" class="form-row align-items-end">
-                <div class="form-group col-md-5">
+                <div class="form-group col-md-4">
                     <label for="q" class="small text-muted mb-1">Search</label>
                     <input type="text" name="q" id="q" value="{{ $filters['q'] }}" class="form-control" placeholder="Title or city…">
                 </div>
-                <div class="form-group col-md-4">
-                    <label for="status" class="small text-muted mb-1">Status</label>
+                <div class="form-group col-md-3">
+                    <label for="status" class="small text-muted mb-1">Creator status</label>
                     <select name="status" id="status" class="form-control">
                         <option value="">All</option>
                         @foreach ($statuses as $status)
@@ -23,6 +23,17 @@
                     </select>
                 </div>
                 <div class="form-group col-md-3">
+                    <label for="lifecycle" class="small text-muted mb-1">Lifecycle</label>
+                    <select name="lifecycle" id="lifecycle" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($lifecycleOptions as $lifecycle)
+                            <option value="{{ $lifecycle }}" {{ $filters['lifecycle'] === $lifecycle ? 'selected' : '' }}>
+                                {{ \App\Services\Admin\KolabLifecycleService::label($lifecycle) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-2">
                     <button type="submit" class="btn btn-primary btn-block">Filter</button>
                 </div>
             </form>
@@ -40,6 +51,8 @@
                             <th>City</th>
                             <th>Intent</th>
                             <th>Status</th>
+                            <th>Lifecycle</th>
+                            <th class="text-center">Apps <small class="text-muted">(pending · accepted)</small></th>
                             <th>Created</th>
                             <th class="text-right pr-4">Actions</th>
                         </tr>
@@ -57,6 +70,9 @@
                                     'closed' => 'badge-secondary',
                                     default => 'badge-warning',
                                 };
+                                $summary = $lifecycles[$kolab->id] ?? ['lifecycle' => 'open', 'pending' => 0, 'accepted' => 0];
+                                $lifecycleClass = \App\Services\Admin\KolabLifecycleService::badgeClass($summary['lifecycle']);
+                                $lifecycleLabel = \App\Services\Admin\KolabLifecycleService::label($summary['lifecycle']);
                             @endphp
                             <tr>
                                 <td>
@@ -71,6 +87,12 @@
                                 <td>
                                     <span class="badge {{ $statusClass }} text-uppercase">{{ $kolab->status->value }}</span>
                                 </td>
+                                <td>
+                                    <span class="badge {{ $lifecycleClass }} text-uppercase">{{ $lifecycleLabel }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <span class="text-muted">{{ $summary['pending'] }} · {{ $summary['accepted'] }}</span>
+                                </td>
                                 <td>{{ $kolab->created_at?->toDateString() ?? '—' }}</td>
                                 <td class="text-right pr-4">
                                     <a href="{{ route('admin.kolabs.edit', $kolab) }}" class="btn btn-sm btn-outline-primary">Edit</a>
@@ -83,7 +105,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="7" class="text-center text-muted py-4">No Kolabs found.</td>
+                                <td colspan="9" class="text-center text-muted py-4">No Kolabs found.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::get('/kolabs/{kolab}/edit', [AdminKolabController::class, 'edit'])->name('kolabs.edit');
     Route::put('/kolabs/{kolab}', [AdminKolabController::class, 'update'])->name('kolabs.update');
     Route::delete('/kolabs/{kolab}', [AdminKolabController::class, 'destroy'])->name('kolabs.destroy');
+    Route::post('/kolabs/{kolab}/collaboration/cancel', [AdminKolabController::class, 'cancelCollaboration'])->name('kolabs.collaboration.cancel');
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/tests/Feature/Admin/KolabManagementTest.php
+++ b/tests/Feature/Admin/KolabManagementTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Admin;
 
+use App\Enums\CollaborationStatus;
 use App\Enums\KolabStatus;
+use App\Models\Application;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
 use App\Models\Kolab;
 use App\Models\Profile;
 use App\Models\User;
@@ -20,9 +24,25 @@ class KolabManagementTest extends TestCase
         return User::factory()->create(['is_maintainer' => true]);
     }
 
+    /**
+     * Build a Kolab + its paired CollabOpportunity (shared id) so applications
+     * and collaborations can reference the same UUID without FK violations.
+     */
+    private function kolabWithOpportunity(array $kolabOverrides = []): Kolab
+    {
+        $kolab = Kolab::factory()->published()->create($kolabOverrides);
+
+        CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        return $kolab;
+    }
+
     public function test_maintainer_sees_kolab_list(): void
     {
-        $kolab = Kolab::factory()->create(['title' => 'Beach club takeover']);
+        Kolab::factory()->create(['title' => 'Beach club takeover']);
 
         $this->actingAs($this->maintainer(), 'admin')
             ->get(route('admin.kolabs.index'))
@@ -30,7 +50,7 @@ class KolabManagementTest extends TestCase
             ->assertSee('Beach club takeover');
     }
 
-    public function test_index_filters_by_status(): void
+    public function test_index_filters_by_creator_status(): void
     {
         Kolab::factory()->create(['status' => KolabStatus::Draft, 'title' => 'Draft Kolab Alpha']);
         Kolab::factory()->published()->create(['title' => 'Published Kolab Beta']);
@@ -40,6 +60,139 @@ class KolabManagementTest extends TestCase
 
         $response->assertSee('Published Kolab Beta');
         $response->assertDontSee('Draft Kolab Alpha');
+    }
+
+    public function test_index_shows_lifecycle_badge_and_application_counts(): void
+    {
+        $kolab = $this->kolabWithOpportunity(['title' => 'Receiving Kolab']);
+
+        Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index'));
+
+        $response->assertOk();
+        $response->assertSee('Receiving applicants', false);
+        $response->assertSee('2 · 0', false);
+    }
+
+    public function test_lifecycle_filter_active_returns_only_kolabs_with_active_collaboration(): void
+    {
+        $active = $this->kolabWithOpportunity(['title' => 'Has Active Collab']);
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $active->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $active->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $active->creator_profile_id,
+        ]);
+
+        Kolab::factory()->published()->create(['title' => 'No Collab Kolab']);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index', ['lifecycle' => 'active']));
+
+        $response->assertSee('Has Active Collab');
+        $response->assertDontSee('No Collab Kolab');
+    }
+
+    public function test_edit_page_shows_collaboration_details_and_reviews(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        $application = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        $collaboration = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+            'scheduled_date' => now()->addDays(7),
+        ]);
+
+        $collaboration->reviews()->create([
+            'reviewer_profile_id' => $kolab->creator_profile_id,
+            'reviewed_profile_id' => $application->applicant_profile_id,
+            'reviewer_role' => 'business',
+            'rating' => 5,
+            'body' => 'Smooth, brought 30 people.',
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.edit', $kolab));
+
+        $response->assertOk();
+        $response->assertSee('Lifecycle');
+        $response->assertSee('Collaboration');
+        $response->assertSee('Smooth, brought 30 people.', false);
+        $response->assertSee('Force-cancel', false);
+    }
+
+    public function test_edit_page_with_no_collaboration_shows_empty_state(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.edit', $kolab))
+            ->assertOk()
+            ->assertSee('No collaboration yet', false);
+    }
+
+    public function test_maintainer_can_force_cancel_an_active_collaboration(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        $application = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        $collaboration = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), ['reason' => 'Spam Kolab.'])
+            ->assertRedirect(route('admin.kolabs.edit', $kolab));
+
+        $this->assertSame(
+            CollaborationStatus::Cancelled,
+            $collaboration->fresh()->status,
+        );
+    }
+
+    public function test_force_cancel_requires_a_reason(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $kolab->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), [])
+            ->assertSessionHasErrors('reason');
+    }
+
+    public function test_force_cancel_404s_when_no_collaboration_exists(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), ['reason' => 'noop'])
+            ->assertNotFound();
     }
 
     public function test_maintainer_can_edit_a_kolab(): void
@@ -92,7 +245,7 @@ class KolabManagementTest extends TestCase
     public function test_non_maintainer_cannot_touch_kolabs(): void
     {
         $user = User::factory()->create(['is_maintainer' => false]);
-        $kolab = Kolab::factory()->create();
+        Kolab::factory()->create();
 
         $this->actingAs($user, 'admin')
             ->get(route('admin.kolabs.index'))


### PR DESCRIPTION
## Summary
The Kolab admin only exposed creator-side status (draft/published/closed) — there was no visibility into whether a Kolab had **landed** (someone applied, was accepted, and the collaboration is running or done).

This PR adds a derived **Lifecycle** computed from `Application` + `Collaboration`:

- **Draft / Open / Receiving applicants / Matched / Scheduled / Active / Completed / Cancelled / Closed**

### List page (`/admin/kolabs`)
- New **Lifecycle** badge column.
- New `pending · accepted` application-counts column.
- New **Lifecycle** filter dropdown alongside the existing creator-status filter.
- Counts pulled via `selectSub` per status — no N+1.

### Edit page
- New **Lifecycle** panel above the existing form showing: per-status application counts, 8 most recent applicants, the collaboration (status, scheduled/completed dates, business + community sides, contact methods, event id, QR), and reviews (★ rating + verbatim comment, per-side, plus the average).
- **Force-cancel collaboration** form for scheduled/active collaborations — reason required, delegates to `CollaborationService::cancel` so existing invariants hold.

### Implementation notes
- New `KolabLifecycleService` (pure derivation + filter SQL via `whereExists`).
- Reuses the `Kolab.id == CollabOpportunity.id` bridge — no new FKs, no migrations.
- Read-only across the panel except for the explicit force-cancel form.

## Test plan
- [x] `php -d memory_limit=-1 vendor/bin/phpunit` — **669 passed, 3431 assertions**
- [x] Admin suite (20 tests) green; 7 new in this PR (lifecycle badge, filter, edit panel with reviews, empty state, force-cancel happy path, reason validation, 404).
- [x] `vendor/bin/pint --dirty` — clean
- [ ] Manual: visit `/admin/kolabs`, try Lifecycle filter, open a Kolab with a live collab, force-cancel with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)