### PR TITLE
feat(admin): platform stats dashboard + lifecycle transition timestamps

### DIFF
--- a/app/Console/Commands/BackfillLifecycleTimestamps.php
+++ b/app/Console/Commands/BackfillLifecycleTimestamps.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Application;
+use App\Models\Collaboration;
+use Illuminate\Console\Command;
+
+class BackfillLifecycleTimestamps extends Command
+{
+    protected $signature = 'app:backfill-lifecycle-timestamps {--dry-run : Show what would be updated without writing}';
+
+    protected $description = 'One-off: copy updated_at into the matching transition timestamp on legacy rows. Approximate.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $report = [];
+
+        $report['applications.accepted'] = $this->touch(
+            Application::query()->where('status', 'accepted')->whereNull('accepted_at'),
+            'accepted_at',
+            $dryRun,
+        );
+        $report['applications.declined'] = $this->touch(
+            Application::query()->where('status', 'declined')->whereNull('declined_at'),
+            'declined_at',
+            $dryRun,
+        );
+        $report['applications.withdrawn'] = $this->touch(
+            Application::query()->where('status', 'withdrawn')->whereNull('withdrawn_at'),
+            'withdrawn_at',
+            $dryRun,
+        );
+
+        $report['collaborations.activated'] = $this->touch(
+            Collaboration::query()
+                ->whereIn('status', ['active', 'completed'])
+                ->whereNull('activated_at'),
+            'activated_at',
+            $dryRun,
+        );
+        $report['collaborations.cancelled'] = $this->touch(
+            Collaboration::query()->where('status', 'cancelled')->whereNull('cancelled_at'),
+            'cancelled_at',
+            $dryRun,
+        );
+
+        foreach ($report as $key => $count) {
+            $this->line(sprintf('%s %s rows', $dryRun ? '[dry] would update' : 'updated', $count).' for '.$key);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Set the named timestamp column to the row's updated_at value for every row
+     * the query matches.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model>  $query
+     */
+    private function touch($query, string $column, bool $dryRun): int
+    {
+        if ($dryRun) {
+            return (int) $query->count();
+        }
+
+        // SQLite + PostgreSQL both accept this raw expression.
+        return $query->update([$column => $query->getModel()->getConnection()->raw('updated_at')]);
+    }
+}

--- a/app/Http/Controllers/Admin/KolabController.php
+++ b/app/Http/Controllers/Admin/KolabController.php
@@ -4,38 +4,71 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\ApplicationStatus;
 use App\Enums\KolabStatus;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\CancelKolabCollaborationRequest;
 use App\Http\Requests\Admin\UpdateKolabRequest;
+use App\Models\Application;
+use App\Models\Collaboration;
 use App\Models\Kolab;
+use App\Services\Admin\KolabLifecycleService;
+use App\Services\CollaborationService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class KolabController extends Controller
 {
+    public function __construct(
+        private readonly KolabLifecycleService $lifecycle,
+        private readonly CollaborationService $collaborations,
+    ) {}
+
     public function index(Request $request): View
     {
-        $kolabs = Kolab::query()
+        $query = Kolab::query()
+            ->select('kolabs.*')
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Pending->value),
+                'pending_applications_count'
+            )
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Accepted->value),
+                'accepted_applications_count'
+            )
             ->with(['creatorProfile.businessProfile', 'creatorProfile.communityProfile'])
-            ->when($request->filled('status'), fn ($query) => $query->where('status', $request->string('status')))
-            ->when($request->filled('q'), function ($query) use ($request): void {
+            ->when($request->filled('status'), fn ($q) => $q->where('kolabs.status', $request->string('status')))
+            ->when($request->filled('q'), function ($q) use ($request): void {
                 $term = '%'.$request->string('q').'%';
-                $query->where(function ($inner) use ($term): void {
+                $q->where(function ($inner) use ($term): void {
                     $inner->where('title', 'like', $term)
                         ->orWhere('preferred_city', 'like', $term);
                 });
             })
-            ->latest()
-            ->paginate(20)
-            ->withQueryString();
+            ->when($request->filled('lifecycle'), function ($q) use ($request): void {
+                $this->lifecycle->applyFilter($q, (string) $request->string('lifecycle'));
+            })
+            ->latest();
+
+        $kolabs = $query->paginate(20)->withQueryString();
+        $lifecycles = $this->lifecycle->summarizeMany($kolabs->getCollection());
 
         return view('admin.kolabs.index', [
             'kolabs' => $kolabs,
+            'lifecycles' => $lifecycles,
             'statuses' => KolabStatus::cases(),
+            'lifecycleOptions' => KolabLifecycleService::all(),
             'filters' => [
                 'status' => (string) $request->string('status'),
                 'q' => (string) $request->string('q'),
+                'lifecycle' => (string) $request->string('lifecycle'),
             ],
         ]);
     }
@@ -47,6 +80,7 @@ class KolabController extends Controller
         return view('admin.kolabs.edit', [
             'kolab' => $kolab,
             'statuses' => KolabStatus::cases(),
+            'summary' => $this->lifecycle->summarize($kolab),
         ]);
     }
 
@@ -73,5 +107,20 @@ class KolabController extends Controller
         return redirect()
             ->route('admin.kolabs.index')
             ->with('status', __('Kolab deleted.'));
+    }
+
+    public function cancelCollaboration(CancelKolabCollaborationRequest $request, Kolab $kolab): RedirectResponse
+    {
+        $collaboration = Collaboration::query()
+            ->where('collab_opportunity_id', $kolab->id)
+            ->first();
+
+        abort_if($collaboration === null, 404, 'No collaboration to cancel for this Kolab.');
+
+        $this->collaborations->cancel($collaboration, $request->validated('reason'));
+
+        return redirect()
+            ->route('admin.kolabs.edit', $kolab)
+            ->with('status', __('Collaboration cancelled.'));
     }
 }

--- a/app/Http/Controllers/Admin/StatsController.php
+++ b/app/Http/Controllers/Admin/StatsController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Admin\PlatformStatsService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class StatsController extends Controller
+{
+    public function __construct(private readonly PlatformStatsService $stats) {}
+
+    public function index(Request $request): View
+    {
+        $range = (string) $request->string('range', '30d');
+
+        if (! in_array($range, PlatformStatsService::RANGES, true)) {
+            $range = '30d';
+        }
+
+        return view('admin.stats.index', [
+            'summary' => $this->stats->summary($range),
+            'ranges' => PlatformStatsService::RANGES,
+            'range' => $range,
+        ]);
+    }
+}

--- a/app/Http/Middleware/TouchProfileActivity.php
+++ b/app/Http/Middleware/TouchProfileActivity.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Models\Profile;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TouchProfileActivity
+{
+    /**
+     * Cooldown between writes for a given profile, in seconds.
+     */
+    private const COOLDOWN_SECONDS = 300;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $profile = $request->user();
+
+        if ($profile instanceof Profile) {
+            $now = now();
+            $last = $profile->last_active_at;
+
+            if ($last === null || $last->lt($now->copy()->subSeconds(self::COOLDOWN_SECONDS))) {
+                Profile::query()
+                    ->whereKey($profile->getKey())
+                    ->update(['last_active_at' => $now]);
+            }
+        }
+
+        return $response;
+    }
+}

--- a/app/Http/Requests/Admin/CancelKolabCollaborationRequest.php
+++ b/app/Http/Requests/Admin/CancelKolabCollaborationRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CancelKolabCollaborationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'min:3', 'max:500'],
+        ];
+    }
+}

--- a/app/Models/Application.php
+++ b/app/Models/Application.php
@@ -45,6 +45,9 @@ class Application extends Model
         'message',
         'availability',
         'status',
+        'accepted_at',
+        'declined_at',
+        'withdrawn_at',
     ];
 
     /**
@@ -57,6 +60,9 @@ class Application extends Model
         return [
             'applicant_profile_type' => UserType::class,
             'status' => ApplicationStatus::class,
+            'accepted_at' => 'datetime',
+            'declined_at' => 'datetime',
+            'withdrawn_at' => 'datetime',
         ];
     }
 

--- a/app/Models/Collaboration.php
+++ b/app/Models/Collaboration.php
@@ -57,7 +57,11 @@ class Collaboration extends Model
         'community_profile_id',
         'status',
         'scheduled_date',
+        'activated_at',
         'completed_at',
+        'cancelled_at',
+        'cancellation_reason',
+        'cancelled_by_profile_id',
         'contact_methods',
         'event_id',
         'qr_code_url',
@@ -73,7 +77,9 @@ class Collaboration extends Model
         return [
             'status' => CollaborationStatus::class,
             'scheduled_date' => 'date',
+            'activated_at' => 'datetime',
             'completed_at' => 'datetime',
+            'cancelled_at' => 'datetime',
             'contact_methods' => 'array',
         ];
     }

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -86,6 +86,7 @@ class Profile extends Authenticatable
         'email_verified_at',
         'device_token',
         'device_platform',
+        'last_active_at',
     ];
 
     /**
@@ -114,6 +115,7 @@ class Profile extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'is_test_user' => 'boolean',
+            'last_active_at' => 'datetime',
         ];
     }
 

--- a/app/Services/Admin/KolabLifecycleService.php
+++ b/app/Services/Admin/KolabLifecycleService.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
+use App\Enums\KolabStatus;
+use App\Models\Application;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Kolab;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
+
+class KolabLifecycleService
+{
+    public const DRAFT = 'draft';
+
+    public const OPEN = 'open';
+
+    public const RECEIVING = 'receiving_applicants';
+
+    public const MATCHED = 'matched';
+
+    public const SCHEDULED = 'scheduled';
+
+    public const ACTIVE = 'active';
+
+    public const COMPLETED = 'completed';
+
+    public const CANCELLED = 'cancelled';
+
+    public const CLOSED = 'closed';
+
+    /**
+     * All lifecycle keys in display order.
+     *
+     * @return array<int, string>
+     */
+    public static function all(): array
+    {
+        return [
+            self::DRAFT, self::OPEN, self::RECEIVING, self::MATCHED,
+            self::SCHEDULED, self::ACTIVE, self::COMPLETED, self::CANCELLED, self::CLOSED,
+        ];
+    }
+
+    public static function label(string $lifecycle): string
+    {
+        return match ($lifecycle) {
+            self::DRAFT => 'Draft',
+            self::OPEN => 'Open',
+            self::RECEIVING => 'Receiving applicants',
+            self::MATCHED => 'Matched',
+            self::SCHEDULED => 'Scheduled',
+            self::ACTIVE => 'Active',
+            self::COMPLETED => 'Completed',
+            self::CANCELLED => 'Cancelled',
+            self::CLOSED => 'Closed',
+            default => ucfirst(str_replace('_', ' ', $lifecycle)),
+        };
+    }
+
+    public static function badgeClass(string $lifecycle): string
+    {
+        return match ($lifecycle) {
+            self::DRAFT, self::CLOSED => 'badge-secondary',
+            self::OPEN => 'badge-info',
+            self::RECEIVING => 'badge-warning',
+            self::MATCHED => 'badge-primary',
+            self::SCHEDULED => 'badge-light',
+            self::ACTIVE => 'badge-success',
+            self::COMPLETED => 'badge-dark',
+            self::CANCELLED => 'badge-danger',
+            default => 'badge-light',
+        };
+    }
+
+    /**
+     * Derive the lifecycle for one Kolab.
+     *
+     * @param  array{pending: int, accepted: int}  $counts
+     */
+    public function derive(Kolab $kolab, ?Collaboration $collaboration, array $counts): string
+    {
+        if ($kolab->status === KolabStatus::Draft) {
+            return self::DRAFT;
+        }
+
+        if ($collaboration instanceof Collaboration) {
+            return match ($collaboration->status) {
+                CollaborationStatus::Scheduled => self::SCHEDULED,
+                CollaborationStatus::Active => self::ACTIVE,
+                CollaborationStatus::Completed => self::COMPLETED,
+                CollaborationStatus::Cancelled => self::CANCELLED,
+            };
+        }
+
+        if (($counts['accepted'] ?? 0) > 0) {
+            return self::MATCHED;
+        }
+
+        if ($kolab->status === KolabStatus::Closed) {
+            return self::CLOSED;
+        }
+
+        if (($counts['pending'] ?? 0) > 0) {
+            return self::RECEIVING;
+        }
+
+        return self::OPEN;
+    }
+
+    /**
+     * Hydrate per-kolab lifecycle context for a list page.
+     *
+     * @param  \Illuminate\Pagination\LengthAwarePaginator<Kolab>|Collection<int, Kolab>  $kolabs
+     * @return SupportCollection<string, array{lifecycle: string, pending: int, accepted: int, collaboration: Collaboration|null}>
+     */
+    public function summarizeMany($kolabs): SupportCollection
+    {
+        $ids = collect($kolabs)->pluck('id');
+
+        $collaborations = Collaboration::query()
+            ->with(['businessProfile', 'communityProfile'])
+            ->whereIn('collab_opportunity_id', $ids)
+            ->get()
+            ->keyBy('collab_opportunity_id');
+
+        return collect($kolabs)->mapWithKeys(function (Kolab $kolab) use ($collaborations): array {
+            $collaboration = $collaborations->get($kolab->id);
+            $counts = [
+                'pending' => (int) ($kolab->pending_applications_count ?? 0),
+                'accepted' => (int) ($kolab->accepted_applications_count ?? 0),
+            ];
+
+            return [$kolab->id => [
+                'lifecycle' => $this->derive($kolab, $collaboration, $counts),
+                'pending' => $counts['pending'],
+                'accepted' => $counts['accepted'],
+                'collaboration' => $collaboration,
+            ]];
+        });
+    }
+
+    /**
+     * Full lifecycle payload for a single Kolab (edit page).
+     *
+     * @return array{
+     *     lifecycle: string,
+     *     counts: array<string, int>,
+     *     recent_applications: Collection<int, Application>,
+     *     collaboration: Collaboration|null,
+     *     reviews: Collection<int, CollaborationReview>,
+     *     average_rating: float|null,
+     * }
+     */
+    public function summarize(Kolab $kolab): array
+    {
+        $counts = [
+            'pending' => 0, 'accepted' => 0, 'declined' => 0, 'withdrawn' => 0,
+        ];
+
+        Application::query()
+            ->toBase()
+            ->where('collab_opportunity_id', $kolab->id)
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->get()
+            ->each(function ($row) use (&$counts): void {
+                $counts[(string) $row->status] = (int) $row->total;
+            });
+
+        $recent = Application::query()
+            ->with('applicantProfile.businessProfile', 'applicantProfile.communityProfile')
+            ->where('collab_opportunity_id', $kolab->id)
+            ->latest()
+            ->limit(8)
+            ->get();
+
+        $collaboration = Collaboration::query()
+            ->with(['businessProfile', 'communityProfile', 'event'])
+            ->where('collab_opportunity_id', $kolab->id)
+            ->first();
+
+        $reviews = $collaboration
+            ? CollaborationReview::query()
+                ->with('reviewerProfile')
+                ->where('collaboration_id', $collaboration->id)
+                ->get()
+            : new Collection;
+
+        $ratings = $reviews->pluck('rating')->filter()->values();
+        $averageRating = $ratings->isNotEmpty() ? (float) round($ratings->avg(), 1) : null;
+
+        return [
+            'lifecycle' => $this->derive($kolab, $collaboration, $counts),
+            'counts' => $counts,
+            'recent_applications' => $recent,
+            'collaboration' => $collaboration,
+            'reviews' => $reviews,
+            'average_rating' => $averageRating,
+        ];
+    }
+
+    /**
+     * Apply a lifecycle filter to a Kolab query.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<Kolab>  $query
+     */
+    public function applyFilter($query, string $lifecycle): void
+    {
+        $hasCollabWith = fn (CollaborationStatus $status) => function ($sub) use ($status): void {
+            $sub->from('collaborations')
+                ->whereColumn('collaborations.collab_opportunity_id', 'kolabs.id')
+                ->where('collaborations.status', $status->value);
+        };
+
+        $hasAnyCollab = function ($sub): void {
+            $sub->from('collaborations')
+                ->whereColumn('collaborations.collab_opportunity_id', 'kolabs.id');
+        };
+
+        $hasApplicationWith = fn (ApplicationStatus $status) => function ($sub) use ($status): void {
+            $sub->from('applications')
+                ->whereColumn('applications.collab_opportunity_id', 'kolabs.id')
+                ->where('applications.status', $status->value);
+        };
+
+        match ($lifecycle) {
+            self::DRAFT => $query->where('kolabs.status', KolabStatus::Draft->value),
+            self::CLOSED => $query->where('kolabs.status', KolabStatus::Closed->value)
+                ->whereNotExists($hasAnyCollab),
+            self::OPEN => $query->where('kolabs.status', KolabStatus::Published->value)
+                ->whereNotExists($hasAnyCollab)
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Pending))
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::RECEIVING => $query->where('kolabs.status', KolabStatus::Published->value)
+                ->whereNotExists($hasAnyCollab)
+                ->whereExists($hasApplicationWith(ApplicationStatus::Pending))
+                ->whereNotExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::MATCHED => $query->whereNotExists($hasAnyCollab)
+                ->whereExists($hasApplicationWith(ApplicationStatus::Accepted)),
+            self::SCHEDULED => $query->whereExists($hasCollabWith(CollaborationStatus::Scheduled)),
+            self::ACTIVE => $query->whereExists($hasCollabWith(CollaborationStatus::Active)),
+            self::COMPLETED => $query->whereExists($hasCollabWith(CollaborationStatus::Completed)),
+            self::CANCELLED => $query->whereExists($hasCollabWith(CollaborationStatus::Cancelled)),
+            default => null,
+        };
+    }
+}

--- a/app/Services/Admin/PlatformStatsService.php
+++ b/app/Services/Admin/PlatformStatsService.php
@@ -1,0 +1,485 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
+use App\Enums\KolabStatus;
+use App\Enums\SubscriptionStatus;
+use App\Enums\UserType;
+use App\Models\Application;
+use App\Models\BusinessSubscription;
+use App\Models\ChatMessage;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Kolab;
+use App\Models\PointLedger;
+use App\Models\Profile;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+
+class PlatformStatsService
+{
+    public const RANGES = ['7d', '30d', '90d', 'all'];
+
+    /**
+     * Build the full payload for the admin Stats dashboard.
+     *
+     * @return array<string, mixed>
+     */
+    public function summary(string $range = '30d'): array
+    {
+        $since = $this->resolveSince($range);
+
+        return [
+            'range' => $range,
+            'since' => $since?->toIso8601String(),
+            'audience' => $this->audience($since),
+            'kolabs' => $this->kolabs($since),
+            'applications' => $this->applications($since),
+            'collaborations' => $this->collaborations($since),
+            'quality' => $this->quality($since),
+            'funnel' => $this->funnel(),
+            'money' => $this->money($since),
+            'activity' => $this->activity(),
+        ];
+    }
+
+    private function resolveSince(string $range): ?CarbonImmutable
+    {
+        return match ($range) {
+            '7d' => CarbonImmutable::now()->subDays(7),
+            '30d' => CarbonImmutable::now()->subDays(30),
+            '90d' => CarbonImmutable::now()->subDays(90),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function audience(?CarbonImmutable $since): array
+    {
+        $byType = Profile::query()->toBase()
+            ->selectRaw('user_type, count(*) as total')
+            ->groupBy('user_type')
+            ->pluck('total', 'user_type');
+
+        $newInRange = Profile::query()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
+            ->count();
+
+        $weekly = $this->weeklyCounts(Profile::query(), $since);
+
+        return [
+            'total' => (int) $byType->sum(),
+            'business' => (int) ($byType[UserType::Business->value] ?? 0),
+            'community' => (int) ($byType[UserType::Community->value] ?? 0),
+            'attendee' => (int) ($byType[UserType::Attendee->value] ?? 0),
+            'new_in_range' => $newInRange,
+            'soft_deleted' => Profile::onlyTrashed()
+                ->when($since, fn ($q) => $q->where('deleted_at', '>=', $since))
+                ->count(),
+            'weekly_new' => $weekly,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function kolabs(?CarbonImmutable $since): array
+    {
+        $byStatus = Kolab::query()->toBase()
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $byIntent = Kolab::query()->toBase()
+            ->selectRaw('intent_type, count(*) as total')
+            ->groupBy('intent_type')
+            ->pluck('total', 'intent_type');
+
+        $publishedDelaysSeconds = Kolab::query()
+            ->whereNotNull('published_at')
+            ->when($since, fn ($q) => $q->where('published_at', '>=', $since))
+            ->selectRaw('AVG((julianday(published_at) - julianday(created_at)) * 86400) as avg_delay')
+            ->value('avg_delay');
+
+        $weeklyPublished = $this->weeklyCounts(
+            Kolab::query()->whereNotNull('published_at'),
+            $since,
+            'published_at',
+        );
+
+        $lifecycleService = app(KolabLifecycleService::class);
+        $live = Kolab::query()
+            ->select('kolabs.*')
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Pending->value),
+                'pending_applications_count'
+            )
+            ->selectSub(
+                Application::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('collab_opportunity_id', 'kolabs.id')
+                    ->where('status', ApplicationStatus::Accepted->value),
+                'accepted_applications_count'
+            )
+            ->get();
+        $lifecycles = $lifecycleService->summarizeMany($live);
+        $lifecycleBuckets = $lifecycles->groupBy('lifecycle')->map->count();
+
+        return [
+            'total' => (int) $byStatus->sum(),
+            'draft' => (int) ($byStatus[KolabStatus::Draft->value] ?? 0),
+            'published' => (int) ($byStatus[KolabStatus::Published->value] ?? 0),
+            'closed' => (int) ($byStatus[KolabStatus::Closed->value] ?? 0),
+            'avg_time_to_publish_days' => $publishedDelaysSeconds !== null
+                ? round(((float) $publishedDelaysSeconds) / 86400, 1)
+                : null,
+            'weekly_published' => $weeklyPublished,
+            'by_intent' => $byIntent->mapWithKeys(fn ($total, $key) => [(string) $key => (int) $total])->all(),
+            'lifecycle_distribution' => $lifecycleBuckets->all(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function applications(?CarbonImmutable $since): array
+    {
+        $base = Application::query()->toBase()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since));
+
+        $byStatus = (clone $base)
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $byType = (clone $base)
+            ->selectRaw('applicant_profile_type, count(*) as total')
+            ->groupBy('applicant_profile_type')
+            ->pluck('total', 'applicant_profile_type');
+
+        $accepted = (int) ($byStatus[ApplicationStatus::Accepted->value] ?? 0);
+        $declined = (int) ($byStatus[ApplicationStatus::Declined->value] ?? 0);
+        $withdrawn = (int) ($byStatus[ApplicationStatus::Withdrawn->value] ?? 0);
+        $resolved = $accepted + $declined + $withdrawn;
+        $acceptanceRate = $resolved > 0 ? round($accepted / $resolved * 100, 1) : null;
+
+        // Median applications per published kolab (sqlite-safe via PHP).
+        $perKolabCounts = Application::query()->toBase()
+            ->select('collab_opportunity_id')
+            ->selectRaw('count(*) as c')
+            ->groupBy('collab_opportunity_id')
+            ->pluck('c')
+            ->map(fn ($v) => (int) $v)
+            ->sort()
+            ->values();
+        $medianPerKolab = $perKolabCounts->isEmpty() ? null : (int) $perKolabCounts[(int) floor($perKolabCounts->count() / 2)];
+
+        // Average time-to-accept using new accepted_at column (Phase 2).
+        $avgTimeToAcceptSeconds = Application::query()
+            ->whereNotNull('accepted_at')
+            ->when($since, fn ($q) => $q->where('accepted_at', '>=', $since))
+            ->selectRaw('AVG((julianday(accepted_at) - julianday(created_at)) * 86400) as avg_seconds')
+            ->value('avg_seconds');
+
+        return [
+            'total' => (int) $byStatus->sum(),
+            'pending' => (int) ($byStatus[ApplicationStatus::Pending->value] ?? 0),
+            'accepted' => $accepted,
+            'declined' => $declined,
+            'withdrawn' => $withdrawn,
+            'from_business' => (int) ($byType[UserType::Business->value] ?? 0),
+            'from_community' => (int) ($byType[UserType::Community->value] ?? 0),
+            'acceptance_rate_pct' => $acceptanceRate,
+            'median_per_kolab' => $medianPerKolab,
+            'avg_time_to_accept_hours' => $avgTimeToAcceptSeconds !== null
+                ? round(((float) $avgTimeToAcceptSeconds) / 3600, 1)
+                : null,
+            'weekly' => $this->weeklyCounts(Application::query(), $since),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collaborations(?CarbonImmutable $since): array
+    {
+        $byStatus = Collaboration::query()->toBase()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
+            ->selectRaw('status, count(*) as total')
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $completed = (int) ($byStatus[CollaborationStatus::Completed->value] ?? 0);
+        $cancelled = (int) ($byStatus[CollaborationStatus::Cancelled->value] ?? 0);
+        $resolved = $completed + $cancelled;
+        $completionRate = $resolved > 0 ? round($completed / $resolved * 100, 1) : null;
+
+        $avgTimeToCompleteSeconds = Collaboration::query()
+            ->whereNotNull('completed_at')
+            ->when($since, fn ($q) => $q->where('completed_at', '>=', $since))
+            ->selectRaw('AVG((julianday(completed_at) - julianday(created_at)) * 86400) as avg_seconds')
+            ->value('avg_seconds');
+
+        $chatPerCollab = ChatMessage::query()->toBase()
+            ->select('application_id')
+            ->selectRaw('count(*) as c')
+            ->groupBy('application_id')
+            ->pluck('c')
+            ->map(fn ($v) => (int) $v)
+            ->sort()
+            ->values();
+        $medianChat = $chatPerCollab->isEmpty() ? null : (int) $chatPerCollab[(int) floor($chatPerCollab->count() / 2)];
+
+        // Cancellation reasons (top 5).
+        $cancellationReasons = Collaboration::query()->toBase()
+            ->whereNotNull('cancellation_reason')
+            ->when($since, fn ($q) => $q->where('cancelled_at', '>=', $since))
+            ->selectRaw('cancellation_reason, count(*) as total')
+            ->groupBy('cancellation_reason')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->get()
+            ->map(fn ($row) => ['reason' => $row->cancellation_reason, 'count' => (int) $row->total])
+            ->all();
+
+        return [
+            'total' => (int) $byStatus->sum(),
+            'scheduled' => (int) ($byStatus[CollaborationStatus::Scheduled->value] ?? 0),
+            'active' => (int) ($byStatus[CollaborationStatus::Active->value] ?? 0),
+            'completed' => $completed,
+            'cancelled' => $cancelled,
+            'completion_rate_pct' => $completionRate,
+            'avg_time_to_complete_days' => $avgTimeToCompleteSeconds !== null
+                ? round(((float) $avgTimeToCompleteSeconds) / 86400, 1)
+                : null,
+            'median_chat_messages' => $medianChat,
+            'weekly_completed' => $this->weeklyCounts(
+                Collaboration::query()->whereNotNull('completed_at'),
+                $since,
+                'completed_at',
+            ),
+            'top_cancellation_reasons' => $cancellationReasons,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function quality(?CarbonImmutable $since): array
+    {
+        $avgRating = CollaborationReview::query()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
+            ->avg('rating');
+
+        $perSide = CollaborationReview::query()->toBase()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
+            ->selectRaw('reviewer_role, AVG(rating) as avg_rating, count(*) as total')
+            ->groupBy('reviewer_role')
+            ->get()
+            ->mapWithKeys(fn ($r) => [(string) $r->reviewer_role => [
+                'avg' => $r->avg_rating !== null ? round((float) $r->avg_rating, 1) : null,
+                'count' => (int) $r->total,
+            ]])
+            ->all();
+
+        // Completed collabs where both sides have reviewed.
+        $completed = Collaboration::query()->where('status', CollaborationStatus::Completed->value);
+        $totalCompleted = (clone $completed)->count();
+        $bothReviewed = (clone $completed)
+            ->whereHas('reviews', fn ($q) => $q->where('reviewer_role', 'business'))
+            ->whereHas('reviews', fn ($q) => $q->where('reviewer_role', 'community'))
+            ->count();
+
+        $weekly = $this->weeklyCounts(CollaborationReview::query(), $since);
+
+        $eventMix = PointLedger::query()->toBase()
+            ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
+            ->selectRaw('event_type, count(*) as total')
+            ->groupBy('event_type')
+            ->orderByDesc('total')
+            ->get()
+            ->mapWithKeys(fn ($r) => [(string) $r->event_type => (int) $r->total])
+            ->all();
+
+        return [
+            'avg_rating' => $avgRating !== null ? round((float) $avgRating, 2) : null,
+            'per_side' => $perSide,
+            'both_sides_reviewed_pct' => $totalCompleted > 0
+                ? round($bothReviewed / $totalCompleted * 100, 1)
+                : null,
+            'weekly_reviews' => $weekly,
+            'point_event_mix' => $eventMix,
+        ];
+    }
+
+    /**
+     * The funnel asked for: % of users at each lifecycle step, split by user_type.
+     * Lifetime values — independent of the date range.
+     *
+     * @return array<string, mixed>
+     */
+    private function funnel(): array
+    {
+        $build = function (string $userType): array {
+            $created = Profile::query()
+                ->where('user_type', $userType)
+                ->count();
+
+            $onboardedRelation = $userType === UserType::Business->value ? 'businessProfile' : 'communityProfile';
+            $onboarded = Profile::query()
+                ->where('user_type', $userType)
+                ->whereHas($onboardedRelation)
+                ->count();
+
+            $publishedKolab = $userType === UserType::Business->value
+                ? Profile::query()
+                    ->where('user_type', $userType)
+                    ->whereIn('id', Kolab::query()
+                        ->whereNotNull('published_at')
+                        ->select('creator_profile_id'))
+                    ->count()
+                : null;
+
+            $applied = Profile::query()
+                ->where('user_type', $userType)
+                ->whereIn('id', Application::query()->select('applicant_profile_id'))
+                ->count();
+
+            $accepted = Profile::query()
+                ->where('user_type', $userType)
+                ->whereIn('id', Application::query()
+                    ->where('status', ApplicationStatus::Accepted->value)
+                    ->select('applicant_profile_id'))
+                ->count();
+
+            $collaborated = Profile::query()
+                ->where('user_type', $userType)
+                ->where(function ($q): void {
+                    $q->whereIn('id', Collaboration::query()->select('creator_profile_id'))
+                        ->orWhereIn('id', Collaboration::query()->select('applicant_profile_id'));
+                })
+                ->count();
+
+            $completed = Profile::query()
+                ->where('user_type', $userType)
+                ->where(function ($q): void {
+                    $completedCollabs = Collaboration::query()->where('status', CollaborationStatus::Completed->value);
+                    $q->whereIn('id', (clone $completedCollabs)->select('creator_profile_id'))
+                        ->orWhereIn('id', (clone $completedCollabs)->select('applicant_profile_id'));
+                })
+                ->count();
+
+            $reviewed = Profile::query()
+                ->where('user_type', $userType)
+                ->whereIn('id', CollaborationReview::query()->select('reviewer_profile_id'))
+                ->count();
+
+            $pct = fn (int $n) => $created > 0 ? round($n / $created * 100, 1) : null;
+
+            return [
+                'created' => ['n' => $created, 'pct' => 100.0],
+                'onboarded' => ['n' => $onboarded, 'pct' => $pct($onboarded)],
+                'published_kolab' => $publishedKolab === null
+                    ? null
+                    : ['n' => $publishedKolab, 'pct' => $pct($publishedKolab)],
+                'applied' => ['n' => $applied, 'pct' => $pct($applied)],
+                'accepted' => ['n' => $accepted, 'pct' => $pct($accepted)],
+                'collaborated' => ['n' => $collaborated, 'pct' => $pct($collaborated)],
+                'completed' => ['n' => $completed, 'pct' => $pct($completed)],
+                'reviewed' => ['n' => $reviewed, 'pct' => $pct($reviewed)],
+            ];
+        };
+
+        return [
+            'business' => $build(UserType::Business->value),
+            'community' => $build(UserType::Community->value),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function money(?CarbonImmutable $since): array
+    {
+        $active = BusinessSubscription::query()->toBase()
+            ->where('status', SubscriptionStatus::Active->value)
+            ->selectRaw('source, count(*) as total')
+            ->groupBy('source')
+            ->pluck('total', 'source');
+
+        $totalBusinesses = Profile::query()->where('user_type', UserType::Business->value)->count();
+        $activeTotal = (int) $active->sum();
+
+        $weeklyActivations = $this->weeklyCounts(
+            BusinessSubscription::query()->where('status', SubscriptionStatus::Active->value),
+            $since,
+            'updated_at',
+        );
+
+        return [
+            'active_total' => $activeTotal,
+            'active_by_source' => $active->mapWithKeys(fn ($n, $s) => [(string) $s => (int) $n])->all(),
+            'paid_penetration_pct' => $totalBusinesses > 0
+                ? round($activeTotal / $totalBusinesses * 100, 1)
+                : null,
+            'weekly_activations' => $weeklyActivations,
+        ];
+    }
+
+    /**
+     * Engagement: DAU / WAU / MAU using the new last_active_at column.
+     *
+     * @return array<string, int>
+     */
+    private function activity(): array
+    {
+        $now = CarbonImmutable::now();
+
+        $count = fn (int $days) => Profile::query()
+            ->where('last_active_at', '>=', $now->subDays($days))
+            ->count();
+
+        return [
+            'dau' => $count(1),
+            'wau' => $count(7),
+            'mau' => $count(30),
+        ];
+    }
+
+    /**
+     * Weekly count rolled by week (ISO).
+     *
+     * @param  Builder<\Illuminate\Database\Eloquent\Model>  $query
+     * @return array<int, array{week: string, count: int}>
+     */
+    private function weeklyCounts(Builder $query, ?CarbonImmutable $since, string $column = 'created_at'): array
+    {
+        $rows = $query->toBase()
+            ->when($since, fn ($q) => $q->where($column, '>=', $since))
+            ->whereNotNull($column)
+            ->orderBy($column)
+            ->pluck($column);
+
+        $buckets = [];
+        foreach ($rows as $value) {
+            $week = CarbonImmutable::parse((string) $value)->startOfWeek()->toDateString();
+            $buckets[$week] = ($buckets[$week] ?? 0) + 1;
+        }
+
+        $out = [];
+        foreach ($buckets as $week => $count) {
+            $out[] = ['week' => $week, 'count' => $count];
+        }
+
+        return $out;
+    }
+}

--- a/app/Services/ApplicationService.php
+++ b/app/Services/ApplicationService.php
@@ -88,6 +88,7 @@ class ApplicationService
         return DB::transaction(function () use ($application, $data): array {
             $application->update([
                 'status' => ApplicationStatus::Accepted,
+                'accepted_at' => now(),
             ]);
             $this->notificationReminderService->syncApplicationPendingReminder($application->fresh(['collabOpportunity']));
 
@@ -120,6 +121,7 @@ class ApplicationService
 
         $application->update([
             'status' => ApplicationStatus::Declined,
+            'declined_at' => now(),
         ]);
         $this->notificationReminderService->syncApplicationPendingReminder($application->fresh(['collabOpportunity']));
 
@@ -145,6 +147,7 @@ class ApplicationService
 
         $application->update([
             'status' => ApplicationStatus::Withdrawn,
+            'withdrawn_at' => now(),
         ]);
         $this->notificationReminderService->syncApplicationPendingReminder($application->fresh(['collabOpportunity']));
 

--- a/app/Services/CollaborationService.php
+++ b/app/Services/CollaborationService.php
@@ -95,6 +95,7 @@ class CollaborationService
 
         $collaboration->update([
             'status' => CollaborationStatus::Active,
+            'activated_at' => Carbon::now(),
         ]);
 
         return $collaboration->fresh([
@@ -141,7 +142,7 @@ class CollaborationService
      *
      * @throws CollaborationException
      */
-    public function cancel(Collaboration $collaboration, string $reason): Collaboration
+    public function cancel(Collaboration $collaboration, string $reason, ?Profile $cancelledBy = null): Collaboration
     {
         if ($collaboration->isInTerminalState()) {
             throw CollaborationException::alreadyInTerminalState($collaboration->status->value);
@@ -153,6 +154,9 @@ class CollaborationService
 
         $collaboration->update([
             'status' => CollaborationStatus::Cancelled,
+            'cancelled_at' => Carbon::now(),
+            'cancellation_reason' => $reason,
+            'cancelled_by_profile_id' => $cancelledBy?->id,
         ]);
 
         return $collaboration->fresh([

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,10 @@
 <?php
 
 use App\Http\Middleware\AddSecurityHeaders;
-use App\Http\Middleware\EnsureUserType;
 use App\Http\Middleware\EnsureAdminUserIsMaintainer;
+use App\Http\Middleware\EnsureUserType;
 use App\Http\Middleware\LogAuthTokenFirstUse;
+use App\Http\Middleware\TouchProfileActivity;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -28,6 +29,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'log_auth_token_first_use' => LogAuthTokenFirstUse::class,
             'user_type' => EnsureUserType::class,
             'maintainer' => EnsureAdminUserIsMaintainer::class,
+            'touch_profile_activity' => TouchProfileActivity::class,
         ]);
 
         // Sanctum stateful domains for API

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -326,6 +326,13 @@ return [
             'icon' => 'fas fa-fw fa-handshake',
             'active' => ['admin/kolabs', 'admin/kolabs/*'],
         ],
+        ['header' => 'INSIGHTS'],
+        [
+            'text' => 'Statistics',
+            'route' => 'admin.stats.index',
+            'icon' => 'fas fa-fw fa-chart-line',
+            'active' => ['admin/stats', 'admin/stats/*'],
+        ],
     ],
 
     /*

--- a/database/migrations/2026_05_31_212534_add_lifecycle_tracking_columns.php
+++ b/database/migrations/2026_05_31_212534_add_lifecycle_tracking_columns.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table): void {
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('declined_at')->nullable();
+            $table->timestamp('withdrawn_at')->nullable();
+        });
+
+        Schema::table('collaborations', function (Blueprint $table): void {
+            $table->timestamp('activated_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->string('cancellation_reason', 500)->nullable();
+            $table->foreignUuid('cancelled_by_profile_id')->nullable()
+                ->constrained('profiles')->nullOnDelete();
+        });
+
+        Schema::table('profiles', function (Blueprint $table): void {
+            $table->timestamp('last_active_at')->nullable();
+            $table->index('last_active_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table): void {
+            $table->dropIndex(['last_active_at']);
+            $table->dropColumn('last_active_at');
+        });
+
+        Schema::table('collaborations', function (Blueprint $table): void {
+            $table->dropForeign(['cancelled_by_profile_id']);
+            $table->dropColumn(['activated_at', 'cancelled_at', 'cancellation_reason', 'cancelled_by_profile_id']);
+        });
+
+        Schema::table('applications', function (Blueprint $table): void {
+            $table->dropColumn(['accepted_at', 'declined_at', 'withdrawn_at']);
+        });
+    }
+};

--- a/docs/plans/2026-05-31-admin-stats-dashboard.md
+++ b/docs/plans/2026-05-31-admin-stats-dashboard.md
@@ -1,0 +1,353 @@
+# Admin Stats Dashboard — Plan + Status
+
+**Date:** 2026-05-31
+**Status:** Phases 1 and 2 **shipped on backend**. Phase 3 (app-side) **not started** — that's the work this doc hands off.
+
+**Goal:** A platform-wide admin analytics surface at `/admin/stats` that tells maintainers how Kolabing is actually being used, where the funnel leaks, and what to improve for businesses vs. communities.
+
+This doc covers three phases — what's shippable from existing data (Phase 1, **done**), cheap backend additions to unlock richer signals (Phase 2, **done**), and what the mobile app needs to instrument so the picture is complete (Phase 3, **for the app-side agent**). The **app-side section is self-contained** so it can be handed straight to the mobile-app agent.
+
+---
+
+## Architecture of the admin dashboard (read this for context)
+
+The Kolabing admin dashboard is a **server-rendered Blade app inside the existing Laravel 12 backend** — no separate SPA, no separate repo. It lives under `/admin/*` on the same domain as the marketing site and the mobile API. The stack is intentionally boring:
+
+- **Auth:** a dedicated `admin` guard (`config/auth.php`) backed by the `users` table (separate from the customer-facing `profiles` table). A `maintainer` middleware (`App\Http\Middleware\EnsureAdminUserIsMaintainer`) further gates routes to users whose `is_maintainer = true`. Both gates are applied to the whole admin route group in [routes/web.php](../../routes/web.php).
+- **UI framework:** [jeroennoten/laravel-adminlte](https://github.com/jeroennoten/Laravel-AdminLTE) — Bootstrap 4–based AdminLTE theme, configured via `config/adminlte.php`. The sidebar `menu` array there is the source of truth for nav entries (Dashboard / Users / Kolabs / **Statistics** / etc.). Every admin page extends `resources/views/admin/layout.blade.php`, which extends `adminlte::page` and exposes page_title / page_subtitle / page_actions / admin_content slots.
+- **Page structure:** each admin feature is a `Controller` under `app/Http/Controllers/Admin/` + a Blade view tree under `resources/views/admin/<feature>/`. Heavy logic lives in **services** under `app/Services/Admin/` (`ManagedProfileService`, `KolabLifecycleService`, `PlatformStatsService`). FormRequests handle validation. No JS framework — interactivity is small vanilla blocks or HTML form posts.
+- **CSP:** strict (see [`AddSecurityHeaders.php`](../../app/Http/Middleware/AddSecurityHeaders.php)). `script-src 'self' 'unsafe-inline'` plus the Tailwind CDN host. The stats dashboard intentionally **avoids Chart.js or any third-party JS lib** — every chart is rendered with Bootstrap progress bars, info-boxes, and HTML tables so no CSP carve-outs are needed.
+- **Data source:** the same PostgreSQL/SQLite the rest of the app uses. The admin reads through Eloquent (with `selectSub` / `toBase()` for aggregations to avoid N+1) and reuses existing services (`CollaborationService::cancel`, `KolabLifecycleService::derive`, etc.) rather than reinventing business rules.
+- **Existing admin features** (chronological): User Management (create/edit/delete/grant/revoke subscription) → Kolab Management (list/edit/delete + lifecycle panel + force-cancel) → **Statistics (this doc)**.
+- **Route map under `/admin`**:
+  - `GET /admin` → Dashboard
+  - `GET /admin/users` + `users/create|edit|destroy` + `users/{p}/subscription/grant|revoke`
+  - `GET /admin/kolabs` + `kolabs/{k}/edit|destroy` + `kolabs/{k}/collaboration/cancel`
+  - **`GET /admin/stats`** ← new
+- **What the dashboard isn't:** it isn't a customer surface, it isn't an API, and it does not push events out. It's a read-only operator console. The app-side agent's work (Phase 3) feeds **PostHog**, not this dashboard.
+
+---
+
+## 0. State of the system today
+
+- **There is no platform-wide stats system.** `app/Services/DashboardService.php` is per-user, mobile-facing (a business sees their own opportunities; a community sees their own sends). It does not roll up across users.
+- **No analytics SDK is wired anywhere** (no PostHog / Mixpanel / Amplitude in `composer.json` or app dependencies).
+- **No login history, no `last_active_at`, no screen-view tracking, no impression/view counts on kolabs.**
+- **No status-transition timestamps.** Application + Collaboration rows mutate `updated_at` in place — you can't reliably ask "how long does it take a creator to accept?" because the timestamp moves on every edit.
+- What *does* exist that helps: `collaborations.completed_at`, `kolabs.published_at`, `point_ledger` (event-typed append-only log: collaboration_complete, first_kolab_bonus, review_posted, etc.), `chat_messages.created_at` as a conversation-volume proxy, `collaboration_reviews` for quality, and the `Kolab.id == CollabOpportunity.id` bridge so we can count applications per kolab cleanly.
+
+The schema covers ~80% of v1; the missing 20% comes from cheap backend additions (Phase 2) plus app-side events (Phase 3).
+
+---
+
+## 1. Phase 1 — Stats Dashboard v1 ✅ Shipped
+
+**Scope:** A single admin page that surfaces every stat we can compute from current data. Backend-only — no app changes required. Estimated **~½ day**.
+
+### 1.1 Deliverables
+
+- `app/Services/Admin/PlatformStatsService.php` — pure aggregator. All methods take an optional `\Carbon\CarbonInterval` (or date range) and return primitive arrays so the view stays dumb.
+- `app/Http/Controllers/Admin/StatsController.php` — single `index(Request)` action; passes payload to view; accepts `?range=7d|30d|90d|all` query param.
+- `resources/views/admin/stats/index.blade.php` — AdminLTE cards + small Chart.js charts (Chart.js via CDN, allowed by current CSP: `script-src 'self' 'unsafe-inline'` plus we'd add the cdn host).
+- Sidebar entry in `config/adminlte.php` under a new **"INSIGHTS"** header, route `admin.stats.index`.
+- Route: `GET /admin/stats` in the existing `auth:admin + maintainer` group.
+- Feature tests: one happy-path test per stats card (~6 tests).
+
+### 1.2 Metrics shipped in v1
+
+#### A. Audience volume
+- Total profiles, split by `user_type` (business / community / attendee)
+- New profiles in selected range, weekly time-series
+- Active business subscriptions (active count, by `source`: stripe / apple_iap / **maintainer**)
+- Soft-deleted users in range
+
+#### B. Kolab activity
+- Total kolabs by `kolabs.status` (draft / published / closed)
+- New kolabs published per week (time-series)
+- Average time-to-publish (`published_at − created_at`) on kolabs that were ever published
+- Lifecycle distribution today (reuse `KolabLifecycleService::derive` on the live set — buckets: draft / open / receiving / matched / scheduled / active / completed / cancelled / closed)
+- Kolabs by intent type (venue_promotion / product_promotion / community_seeking)
+
+#### C. Applications (the funnel)
+- Total applications by status (pending / accepted / declined / withdrawn)
+- Applications by `applicant_profile_type` (business vs community) — the count the user explicitly asked for
+- Applications per week, split by applicant type
+- **Acceptance rate** = `accepted / (accepted + declined + withdrawn)`
+- **Decline rate** by reason category (only `status` is recorded today, so this is a placeholder until reasons are captured)
+- Median applications per published kolab
+
+#### D. Collaborations
+- Total collaborations by `collaborations.status`
+- Weekly completions and cancellations
+- **Completion rate** = `completed / (completed + cancelled)`
+- Average time-to-complete (`completed_at − created_at`)
+- Median chat messages per collaboration (engagement proxy via `chat_messages`)
+
+#### E. Quality & engagement
+- Average `collaboration_reviews.rating`, plus per-side averages (business→community vs community→business)
+- % of completed collabs with **both** reviews submitted
+- Reviews per week (time-series)
+- Points-ledger event mix (collaboration_complete vs review_posted vs ugc_posted vs referral_conversion) — gives a free engagement narrative since the table is already append-only
+
+#### F. The percentage-of-users funnel (the user's primary ask)
+For each user type:
+1. **Created** — profile exists
+2. **Onboarded** — has a populated `business_profile` / `community_profile`
+3. **Published a kolab** *(business only)* — appears as `kolabs.creator_profile_id`
+4. **Applied** — appears as `applications.applicant_profile_id`
+5. **Accepted** — has at least one accepted application
+6. **Collaborated** — appears in `collaborations`
+7. **Completed** — has at least one `completed` collaboration
+8. **Reviewed** — has at least one `collaboration_reviews` row
+
+Each step shows count + % retained from the previous step. Same view, two columns (business / community).
+
+#### G. Money
+- Active subscriptions count, split by source (gives visibility into maintainer-granted volume — the lever you just added)
+- New paid activations per week
+- Churned subs per week (transitions to `cancelled` — best-effort using `updated_at` until Phase 2)
+
+### 1.3 UX
+
+```
+ADMIN · INSIGHTS · /admin/stats          [ Last 7d | 30d | 90d | All ]
+┌──────────────────────────────────────────────────────────────────────┐
+│  AUDIENCE                                                            │
+│  ╔═══════════╗  ╔═══════════╗  ╔═══════════╗  ╔═════════════════╗   │
+│  ║ Total     ║  ║ Business  ║  ║ Community ║  ║ Active subs     ║   │
+│  ║ profiles  ║  ║ profiles  ║  ║ profiles  ║  ║                 ║   │
+│  ║  1,248    ║  ║   312     ║  ║   894     ║  ║ 47 (12 maint.)  ║   │
+│  ╚═══════════╝  ╚═══════════╝  ╚═══════════╝  ╚═════════════════╝   │
+│                                                                       │
+│  Weekly new profiles  [line chart, business vs community]            │
+│                                                                       │
+│  FUNNEL                  Business         Community                   │
+│  ──────────────────────────────────────────────────────              │
+│  Created                 312 (100%)       894 (100%)                  │
+│  Onboarded               240  (77%)       640  (72%)                  │
+│  Published a kolab       142  (46%)       —                           │
+│  Applied                  62  (20%)       411  (46%)                  │
+│  Accepted                 48  (15%)       287  (32%)                  │
+│  Collaborated             47  (15%)       284  (32%)                  │
+│  Completed                31  (10%)       198  (22%)                  │
+│  Reviewed                 22   (7%)       154  (17%)                  │
+│                                                                       │
+│  APPLICATIONS                                                         │
+│  ╔════════════════╗  ╔════════════════╗  ╔═══════════════════╗      │
+│  ║ Total          ║  ║ Acceptance     ║  ║ Median per Kolab  ║      │
+│  ║ 1,432          ║  ║ rate  67%      ║  ║       3.1         ║      │
+│  ╚════════════════╝  ╚════════════════╝  ╚═══════════════════╝      │
+│  By applicant type:  Community 1,121 · Business 311                  │
+│  Weekly applications  [stacked bar chart]                            │
+│                                                                       │
+│  COLLABORATIONS                                                       │
+│  Completed: 198   Cancelled: 41   Completion rate: 83%               │
+│  Avg time-to-complete: 11.4 days                                     │
+│  Lifecycle distribution today  [donut chart]                         │
+│                                                                       │
+│  QUALITY                                                              │
+│  Avg ★ 4.3  ·  Both-sides-reviewed: 62%                              │
+│  Business → Community  ★ 4.5 · Community → Business  ★ 4.2          │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 1.4 Out of scope for v1
+
+Anything that needs data we don't capture yet — those land in Phase 2 / 3 below.
+
+---
+
+## 2. Phase 2 — Backend additions to unlock richer stats ✅ Shipped
+
+**Scope:** One migration + a handful of service-line edits to stamp transition timestamps and a few activity fields. Estimated **~½ day**. Strictly additive; nothing breaking.
+
+### 2.1 Migration
+
+```php
+Schema::table('applications', function (Blueprint $table) {
+    $table->timestamp('accepted_at')->nullable()->after('status');
+    $table->timestamp('declined_at')->nullable()->after('accepted_at');
+    $table->timestamp('withdrawn_at')->nullable()->after('declined_at');
+});
+
+Schema::table('collaborations', function (Blueprint $table) {
+    $table->timestamp('activated_at')->nullable()->after('scheduled_date');
+    $table->timestamp('cancelled_at')->nullable()->after('completed_at');
+    $table->string('cancellation_reason', 500)->nullable()->after('cancelled_at');
+    $table->foreignUuid('cancelled_by_profile_id')->nullable()->after('cancellation_reason')
+        ->constrained('profiles')->nullOnDelete();
+});
+
+Schema::table('profiles', function (Blueprint $table) {
+    $table->timestamp('last_active_at')->nullable()->after('email_verified_at');
+    $table->index('last_active_at');
+});
+```
+
+### 2.2 Service edits
+
+- `ApplicationService::accept|decline|withdraw` → stamp the matching timestamp.
+- `CollaborationService::cancel` → stamp `cancelled_at`, persist `cancellation_reason` (the **force-cancel form already collects this** but currently throws it away), set `cancelled_by_profile_id`.
+- `CollaborationService` (or wherever the scheduled→active transition lives) → stamp `activated_at`.
+- New middleware `TouchProfileActivity` on the `auth:sanctum` group → `update last_active_at = now()` at most once per 5 minutes per profile (rate-limited to avoid hammering the table).
+- Backfill: a one-off `BackfillApplicationTransitionsCommand` that copies `updated_at` to the timestamp matching the current `status`. Documented as approximate.
+
+### 2.3 New stats this unlocks
+
+- **DAU / WAU / MAU** (from `last_active_at`)
+- **Time-to-accept** (creator responsiveness)
+- **Time-to-decline / time-to-withdraw**
+- **Time-from-scheduled-to-active**
+- **Cancellation reasons report** — top reasons, % of collabs cancelled by maintainer vs by participants
+- **Engagement cohort** — % of users active in last 7 / 30 days, by signup cohort
+
+---
+
+---
+
+## 2.5 What was actually executed on the backend (as of 2026-05-31)
+
+This section is the **definitive list** of what already exists; the app-side agent (Phase 3) can safely assume all of it.
+
+**Migration:** `database/migrations/2026_05_31_212534_add_lifecycle_tracking_columns.php`
+- `applications.accepted_at`, `applications.declined_at`, `applications.withdrawn_at` — all nullable timestamps
+- `collaborations.activated_at`, `collaborations.cancelled_at`, `collaborations.cancellation_reason` (string 500), `collaborations.cancelled_by_profile_id` (FK to `profiles`, nullable; **null = cancelled by maintainer**)
+- `profiles.last_active_at` (nullable, indexed)
+
+**Service edits**
+- `app/Services/ApplicationService.php` → `accept()` stamps `accepted_at`, `decline()` stamps `declined_at`, `withdraw()` stamps `withdrawn_at`.
+- `app/Services/CollaborationService.php` → `activate()` stamps `activated_at`. `cancel()` now persists `cancelled_at`, `cancellation_reason`, and `cancelled_by_profile_id` (optional 3rd param `?Profile $cancelledBy`). The existing admin force-cancel form already collects the reason — it now actually lands in the DB.
+- `app/Console/Commands/BackfillLifecycleTimestamps.php` (signature `app:backfill-lifecycle-timestamps`, supports `--dry-run`) — one-off backfill that copies `updated_at` into the matching transition column for legacy rows. Run once per environment after deploy.
+
+**Activity middleware**
+- `app/Http/Middleware/TouchProfileActivity.php` (alias `touch_profile_activity` registered in `bootstrap/app.php`).
+- Attached to the API auth group in `routes/api.php` on the `auth:sanctum` middleware stack. Writes `profiles.last_active_at` at most once per **5 minutes** per profile to avoid hammering the table.
+
+**Stats infrastructure**
+- `app/Services/Admin/PlatformStatsService.php` — single entry point `summary(string $range)`. Range one of `7d|30d|90d|all`. Returns a structured array consumed by the view. Methods are tested directly so the controller stays a thin shell.
+- `app/Http/Controllers/Admin/StatsController.php` — `index(Request)` only. Invalid ranges fall back to `30d`.
+- `resources/views/admin/stats/index.blade.php` — server-rendered Bootstrap/AdminLTE markup. Info-boxes for headline numbers; progress bars for distributions; HTML tables for the funnel. **No JS chart lib.**
+- Sidebar entry under a new **INSIGHTS** header in `config/adminlte.php`.
+- Route: `GET /admin/stats` named `admin.stats.index` in the existing `auth:admin + maintainer` group.
+
+**What the stats view actually shows today**
+
+| Section | Metrics |
+|---|---|
+| Audience | Total profiles, split by user_type, new in range, soft-deleted |
+| Activity | **DAU / WAU / MAU** (from `last_active_at`) |
+| Funnel | Lifetime % of users at each step (Created → Onboarded → Published a kolab → Applied → Accepted → Collaborated → Completed → Reviewed), split Business vs Community |
+| Kolabs | Total + by status, avg time-to-publish, by intent type, lifecycle distribution of the live set |
+| Applications | Total, by status, by applicant type (Business vs Community), acceptance rate, median per kolab, avg time-to-accept |
+| Collaborations | Completed / Cancelled / Completion rate, avg time-to-complete, median chat messages, **top cancellation reasons** |
+| Quality | Avg ★ rating, per-side averages (Business → Community vs Community → Business), % of completed collabs with both reviews, point-ledger event mix |
+| Subscriptions | Active total, by source (stripe / apple_iap / **maintainer**), paid penetration % |
+
+**Tests** — added two suites:
+- `tests/Feature/Admin/StatsDashboardTest.php` — 8 tests (route gating, audience split, applications by type + acceptance rate, funnel per type, money split by source, kolab lifecycle distribution, range fallback, DAU/WAU/MAU).
+- `tests/Feature/Admin/LifecycleTimestampsTest.php` — 5 tests (accept stamps, decline stamps, withdraw stamps, cancel persists reason+timestamp, API auth touches `last_active_at`).
+- **Final state: 682 tests, 3472 assertions, all green. Pint clean.**
+
+**Known caveat about DAU/WAU/MAU** — these will read **0 immediately after deploy** because no users have hit the API after the middleware was wired. They'll fill in naturally as traffic flows. There is no backfill — by definition we don't know what "last active" was for legacy users.
+
+**Caveat about `cancelled_by_profile_id`** — null indicates "cancelled by maintainer through the admin panel". When/if the mobile app ever exposes a participant-cancel flow, that controller must pass `$cancelledBy = $request->user()->profile`. Otherwise we lose the participant-vs-maintainer signal.
+
+---
+
+## 3. Phase 3 — App-side instrumentation (read this if you own the mobile app)
+
+> **TL;DR for the app-side agent: integrate PostHog and emit a small, fixed set of events. The backend will consume some of those signals (or PostHog dashboards will, directly). Everything below is what's missing today and only the app can produce.**
+
+The Kolabing backend currently has **zero visibility into what users do inside the app between API calls**. Database rows tell us a user created an application or completed a collaboration — they tell us nothing about whether the user saw 80 kolabs before applying, abandoned onboarding on step 2, or pressed Apply and then bailed at the confirm modal. Those answers come from app-side events.
+
+### What we need from the app
+
+1. **Integrate PostHog** (recommended) on the mobile app. Open-source, self-hostable, generous free tier, privacy-friendly. Alternative: Mixpanel or Amplitude — pick one and be consistent.
+   - Identify users with their profile UUID (`profile.id`) so events join with backend data.
+   - Set super-properties at identify time: `user_type` (business / community / attendee), `city`, `subscription_active` (for business), `signup_week`.
+
+2. **Emit a small, fixed event catalog** — keep it disciplined; ~15–20 events total is plenty for v1.
+
+   **Lifecycle / onboarding**
+   - `signup_started` (carries provider — google / apple)
+   - `signup_completed`
+   - `onboarding_step_viewed` (`step: 1|2|3|...`, `flow: business|community`)
+   - `onboarding_completed`
+   - `onboarding_abandoned` (fired on app background after step view)
+
+   **Discovery / browsing**
+   - `feed_viewed` (`screen: explore|recommended|nearby`)
+   - `feed_filter_applied` (`filters: {category, city, ...}`)
+   - `feed_search_performed` (`query`)
+   - `kolab_impression` (`kolab_id`, `position_in_feed`, `screen`) — fired when a card scrolls into view; debounce so each id only fires once per session per screen
+   - `kolab_detail_viewed` (`kolab_id`, `time_on_screen_seconds`)
+
+   **Funnel actions**
+   - `apply_tapped` (`kolab_id`, `source_screen`)
+   - `apply_submitted` (`kolab_id`, `application_id`)
+   - `apply_abandoned` (`kolab_id`, `step: message|availability|review`) — if the user backed out
+   - `application_decision_made` (`application_id`, `decision: accept|decline`, `time_since_received_seconds`) — fires when a creator acts on it
+   - `paywall_hit` (`feature: publish_kolab|...`)
+   - `paywall_dismissed` / `paywall_subscribed`
+
+   **Collaboration usage**
+   - `collaboration_chat_opened` (`collaboration_id`)
+   - `collaboration_checked_in` (`collaboration_id`)
+   - `collaboration_marked_complete` (`collaboration_id`, `by_side: business|community`)
+   - `review_submitted` (`collaboration_id`, `rating`)
+
+   **Session**
+   - `app_opened` (Posthog handles session naturally; just ensure identify is called early)
+
+3. **Backend-side hooks the app will indirectly benefit from**
+   - The backend will stamp `last_active_at` on any authenticated API call (Phase 2). That gives us a server-side floor on DAU/WAU even if PostHog is down.
+   - The backend will fire one synthetic PostHog event per significant state transition (`application_accepted_server_side`, `collaboration_cancelled_server_side`) so PostHog funnels can join app-side and server-side events without ambiguity.
+
+4. **Privacy / consent**
+   - PostHog event payloads must **not** include free-text user content (no chat messages, no review bodies, no email addresses) — only ids and enum-typed metadata.
+   - Respect a `analytics_opt_out` flag (boolean) added to the profile — the app should read it from `/me`, persist locally, and skip emit when true. Backend will gate the synthetic events the same way.
+
+5. **What "done" looks like for the app side**
+   - PostHog SDK initialised; `identify` called on login with the profile UUID and super-properties.
+   - All events above are emitted, with the exact event names and property keys spelled as listed (so dashboards work without translation).
+   - A short doc in the app repo listing the catalog so future event additions follow the same conventions.
+
+Once this is in place, the admin Stats dashboard can either embed PostHog charts (via signed iframes) or just keep its current backend-rendered charts while you do the deep funnel analysis in PostHog directly.
+
+---
+
+## 4. Order of work (status)
+
+1. **Phase 1** — ✅ done on backend.
+2. **Phase 2** — ✅ done on backend (one migration, service edits, middleware, backfill command).
+3. **Phase 3** — ⏳ **pending, owned by the app-side agent**. PostHog integration + event catalog per §3.
+
+---
+
+## 5. Acceptance criteria for Phases 1 + 2
+
+- [x] `/admin/stats` reachable by maintainers, 403 for everyone else, 302 to login when unauthenticated.
+- [x] Sidebar shows an "Insights → Statistics" link under a new "INSIGHTS" header.
+- [x] Date-range filter (7d / 30d / 90d / all) re-runs all range-sensitive aggregations; invalid ranges fall back to 30d.
+- [x] Audience / Kolabs / Applications / Collaborations / Quality / Funnel / Subscriptions / Activity (DAU/WAU/MAU) sections all render.
+- [x] Aggregations avoid N+1 (subselects + `toBase()`); pagination not needed at v1 scale.
+- [x] Migration adds `accepted_at` / `declined_at` / `withdrawn_at` on `applications`, `activated_at` / `cancelled_at` / `cancellation_reason` / `cancelled_by_profile_id` on `collaborations`, `last_active_at` on `profiles`.
+- [x] `ApplicationService::accept|decline|withdraw` stamp the matching column. `CollaborationService::activate` stamps `activated_at`. `CollaborationService::cancel` persists reason, `cancelled_at`, and optional `cancelled_by_profile_id`.
+- [x] `TouchProfileActivity` middleware on the API `auth:sanctum` group; 5-minute cooldown per profile.
+- [x] One-off backfill command `app:backfill-lifecycle-timestamps` (with `--dry-run`).
+- [x] Feature tests: 8 stats + 5 timestamp = 13 new. Total project suite: **682 passed / 3472 assertions.**
+- [x] `vendor/bin/pint --dirty` clean.
+
+---
+
+## 6. Operational checklist for deploy
+
+1. Pull the merge into the deploy branch.
+2. `php artisan migrate` — runs the new lifecycle-tracking migration. Strictly additive; safe to roll forward.
+3. (Optional, recommended) `php artisan app:backfill-lifecycle-timestamps --dry-run` — print how many legacy rows would be updated, then re-run without `--dry-run` to apply.
+4. Verify `/admin/stats` renders end-to-end. DAU/WAU/MAU will start at 0 and grow as the API receives traffic.
+5. Tell the app-side agent: read §3 of this doc.
+
+---
+
+*The backend half is done. Hand §3 (or this whole doc) to whoever owns the mobile app to ship the PostHog instrumentation.*

--- a/resources/views/admin/kolabs/_lifecycle.blade.php
+++ b/resources/views/admin/kolabs/_lifecycle.blade.php
@@ -1,0 +1,188 @@
+@php
+    use App\Services\Admin\KolabLifecycleService;
+
+    $lifecycle = $summary['lifecycle'];
+    $counts = $summary['counts'];
+    $collaboration = $summary['collaboration'];
+    $reviews = $summary['reviews'];
+    $averageRating = $summary['average_rating'];
+    $recentApplications = $summary['recent_applications'];
+@endphp
+
+<div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="card-title mb-0">Lifecycle</h3>
+        <span class="badge {{ KolabLifecycleService::badgeClass($lifecycle) }} text-uppercase">
+            {{ KolabLifecycleService::label($lifecycle) }}
+        </span>
+    </div>
+
+    <div class="card-body">
+        {{-- Applications --}}
+        <h5 class="mb-2">Applications</h5>
+        <div class="row text-center mb-3">
+            <div class="col">
+                <div class="text-muted small">Pending</div>
+                <div class="h4 mb-0">{{ $counts['pending'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Accepted</div>
+                <div class="h4 mb-0 text-success">{{ $counts['accepted'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Declined</div>
+                <div class="h4 mb-0">{{ $counts['declined'] }}</div>
+            </div>
+            <div class="col">
+                <div class="text-muted small">Withdrawn</div>
+                <div class="h4 mb-0">{{ $counts['withdrawn'] }}</div>
+            </div>
+        </div>
+
+        @if ($recentApplications->isEmpty())
+            <p class="text-muted small mb-0">Nobody has applied yet.</p>
+        @else
+            <div class="table-responsive mb-3">
+                <table class="table table-sm table-borderless mb-0">
+                    <thead>
+                        <tr class="text-muted">
+                            <th class="font-weight-normal small">Applicant</th>
+                            <th class="font-weight-normal small">Status</th>
+                            <th class="font-weight-normal small">When</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($recentApplications as $app)
+                            @php
+                                $applicant = $app->applicantProfile;
+                                $applicantLabel = $applicant?->businessProfile?->name
+                                    ?? $applicant?->communityProfile?->name
+                                    ?? $applicant?->email
+                                    ?? '—';
+                                $appBadge = match ($app->status->value) {
+                                    'accepted' => 'badge-success',
+                                    'declined' => 'badge-secondary',
+                                    'withdrawn' => 'badge-light',
+                                    default => 'badge-warning',
+                                };
+                            @endphp
+                            <tr>
+                                <td>{{ $applicantLabel }}</td>
+                                <td><span class="badge {{ $appBadge }} text-uppercase">{{ $app->status->value }}</span></td>
+                                <td class="text-muted small">{{ $app->created_at?->diffForHumans() ?? '—' }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+
+        {{-- Collaboration --}}
+        <h5 class="mb-2 mt-4">Collaboration</h5>
+        @if ($collaboration === null)
+            <p class="text-muted small mb-0">No collaboration yet — no accepted match has produced an active deal.</p>
+        @else
+            @php
+                $business = $collaboration->businessProfile;
+                $community = $collaboration->communityProfile;
+                $collabBadge = match ($collaboration->status->value) {
+                    'active' => 'badge-success',
+                    'scheduled' => 'badge-info',
+                    'completed' => 'badge-dark',
+                    'cancelled' => 'badge-danger',
+                    default => 'badge-light',
+                };
+                $canCancel = in_array($collaboration->status->value, ['scheduled', 'active'], true);
+            @endphp
+            <dl class="row mb-2">
+                <dt class="col-sm-3">Status</dt>
+                <dd class="col-sm-9"><span class="badge {{ $collabBadge }} text-uppercase">{{ $collaboration->status->value }}</span></dd>
+                <dt class="col-sm-3">Scheduled date</dt>
+                <dd class="col-sm-9">{{ $collaboration->scheduled_date?->toFormattedDateString() ?? '—' }}</dd>
+                <dt class="col-sm-3">Completed at</dt>
+                <dd class="col-sm-9">{{ $collaboration->completed_at?->toDayDateTimeString() ?? '—' }}</dd>
+                <dt class="col-sm-3">Business side</dt>
+                <dd class="col-sm-9">
+                    @if ($business)
+                        {{ $business->name ?? '—' }}
+                        <span class="text-muted small">{{ $business->profile?->email ? '· '.$business->profile->email : '' }}</span>
+                    @else
+                        —
+                    @endif
+                </dd>
+                <dt class="col-sm-3">Community side</dt>
+                <dd class="col-sm-9">
+                    @if ($community)
+                        {{ $community->name ?? '—' }}
+                        <span class="text-muted small">{{ $community->profile?->email ? '· '.$community->profile->email : '' }}</span>
+                    @else
+                        —
+                    @endif
+                </dd>
+                @if ($collaboration->contact_methods)
+                    <dt class="col-sm-3">Contact methods</dt>
+                    <dd class="col-sm-9 small text-muted">{{ implode(', ', array_keys(array_filter($collaboration->contact_methods))) }}</dd>
+                @endif
+                @if ($collaboration->event_id)
+                    <dt class="col-sm-3">Event linked</dt>
+                    <dd class="col-sm-9 small text-muted">{{ $collaboration->event_id }}</dd>
+                @endif
+                @if ($collaboration->qr_code_url)
+                    <dt class="col-sm-3">QR</dt>
+                    <dd class="col-sm-9 small"><a href="{{ $collaboration->qr_code_url }}" target="_blank" rel="noopener">{{ $collaboration->qr_code_url }}</a></dd>
+                @endif
+            </dl>
+
+            @if ($canCancel)
+                <form method="POST" action="{{ route('admin.kolabs.collaboration.cancel', $kolab) }}" class="mt-3"
+                      onsubmit="return confirm('Force-cancel this collaboration? Both parties will be affected.');">
+                    @csrf
+                    <div class="form-row align-items-end">
+                        <div class="form-group col-md-9 mb-0">
+                            <label for="cancel-reason" class="small text-muted mb-1">Cancellation reason (required)</label>
+                            <input type="text" name="reason" id="cancel-reason" class="form-control" minlength="3" maxlength="500" required placeholder="Why is this being cancelled?">
+                            @error('reason')
+                                <small class="text-danger">{{ $message }}</small>
+                            @enderror
+                        </div>
+                        <div class="form-group col-md-3 mb-0">
+                            <button type="submit" class="btn btn-outline-danger btn-block">
+                                <i class="fas fa-ban mr-1"></i>
+                                Force-cancel
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            @endif
+        @endif
+
+        {{-- Reviews --}}
+        @if ($collaboration !== null)
+            <h5 class="mb-2 mt-4">Reviews</h5>
+            @if ($reviews->isEmpty())
+                <p class="text-muted small mb-0">No reviews submitted yet.</p>
+            @else
+                <p class="mb-2 small">
+                    {{ $reviews->count() }} review{{ $reviews->count() === 1 ? '' : 's' }}
+                    @if ($averageRating !== null)
+                        · average <strong>★ {{ number_format($averageRating, 1) }}</strong>
+                    @endif
+                </p>
+                <ul class="list-unstyled mb-0">
+                    @foreach ($reviews as $review)
+                        @php
+                            $reviewText = $review->body ?: $review->note;
+                            $roleLabel = $review->reviewer_role === 'business' ? 'Business → Community' : 'Community → Business';
+                        @endphp
+                        <li class="mb-2 pl-3 border-left">
+                            <div class="small text-muted">{{ $roleLabel }} · ★ {{ $review->rating ?? '—' }}</div>
+                            @if ($reviewText)
+                                <div class="small">{{ $reviewText }}</div>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        @endif
+    </div>
+</div>

--- a/resources/views/admin/kolabs/edit.blade.php
+++ b/resources/views/admin/kolabs/edit.blade.php
@@ -40,6 +40,8 @@
         </div>
     </div>
 
+    @include('admin.kolabs._lifecycle', ['summary' => $summary, 'kolab' => $kolab])
+
     <form method="POST" action="{{ route('admin.kolabs.update', $kolab) }}">
         @csrf
         @method('PUT')

--- a/resources/views/admin/kolabs/index.blade.php
+++ b/resources/views/admin/kolabs/index.blade.php
@@ -7,12 +7,12 @@
     <div class="card mb-3">
         <div class="card-body">
             <form method="GET" action="{{ route('admin.kolabs.index') }}" class="form-row align-items-end">
-                <div class="form-group col-md-5">
+                <div class="form-group col-md-4">
                     <label for="q" class="small text-muted mb-1">Search</label>
                     <input type="text" name="q" id="q" value="{{ $filters['q'] }}" class="form-control" placeholder="Title or city…">
                 </div>
-                <div class="form-group col-md-4">
-                    <label for="status" class="small text-muted mb-1">Status</label>
+                <div class="form-group col-md-3">
+                    <label for="status" class="small text-muted mb-1">Creator status</label>
                     <select name="status" id="status" class="form-control">
                         <option value="">All</option>
                         @foreach ($statuses as $status)
@@ -23,6 +23,17 @@
                     </select>
                 </div>
                 <div class="form-group col-md-3">
+                    <label for="lifecycle" class="small text-muted mb-1">Lifecycle</label>
+                    <select name="lifecycle" id="lifecycle" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($lifecycleOptions as $lifecycle)
+                            <option value="{{ $lifecycle }}" {{ $filters['lifecycle'] === $lifecycle ? 'selected' : '' }}>
+                                {{ \App\Services\Admin\KolabLifecycleService::label($lifecycle) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-2">
                     <button type="submit" class="btn btn-primary btn-block">Filter</button>
                 </div>
             </form>
@@ -40,6 +51,8 @@
                             <th>City</th>
                             <th>Intent</th>
                             <th>Status</th>
+                            <th>Lifecycle</th>
+                            <th class="text-center">Apps <small class="text-muted">(pending · accepted)</small></th>
                             <th>Created</th>
                             <th class="text-right pr-4">Actions</th>
                         </tr>
@@ -57,6 +70,9 @@
                                     'closed' => 'badge-secondary',
                                     default => 'badge-warning',
                                 };
+                                $summary = $lifecycles[$kolab->id] ?? ['lifecycle' => 'open', 'pending' => 0, 'accepted' => 0];
+                                $lifecycleClass = \App\Services\Admin\KolabLifecycleService::badgeClass($summary['lifecycle']);
+                                $lifecycleLabel = \App\Services\Admin\KolabLifecycleService::label($summary['lifecycle']);
                             @endphp
                             <tr>
                                 <td>
@@ -71,6 +87,12 @@
                                 <td>
                                     <span class="badge {{ $statusClass }} text-uppercase">{{ $kolab->status->value }}</span>
                                 </td>
+                                <td>
+                                    <span class="badge {{ $lifecycleClass }} text-uppercase">{{ $lifecycleLabel }}</span>
+                                </td>
+                                <td class="text-center">
+                                    <span class="text-muted">{{ $summary['pending'] }} · {{ $summary['accepted'] }}</span>
+                                </td>
                                 <td>{{ $kolab->created_at?->toDateString() ?? '—' }}</td>
                                 <td class="text-right pr-4">
                                     <a href="{{ route('admin.kolabs.edit', $kolab) }}" class="btn btn-sm btn-outline-primary">Edit</a>
@@ -83,7 +105,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="7" class="text-center text-muted py-4">No Kolabs found.</td>
+                                <td colspan="9" class="text-center text-muted py-4">No Kolabs found.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/admin/stats/index.blade.php
+++ b/resources/views/admin/stats/index.blade.php
@@ -1,0 +1,369 @@
+@extends('admin.layout', ['title' => 'Statistics'])
+
+@section('page_title', 'Statistics')
+@section('page_subtitle', 'Platform-wide health, funnels, and quality signals.')
+
+@section('page_actions')
+    <div class="btn-group" role="group" aria-label="Date range">
+        @foreach ($ranges as $r)
+            @php
+                $label = match ($r) {
+                    '7d' => 'Last 7d',
+                    '30d' => 'Last 30d',
+                    '90d' => 'Last 90d',
+                    'all' => 'All time',
+                    default => $r,
+                };
+            @endphp
+            <a href="{{ route('admin.stats.index', ['range' => $r]) }}"
+               class="btn {{ $range === $r ? 'btn-primary' : 'btn-outline-secondary' }}">{{ $label }}</a>
+        @endforeach
+    </div>
+@endsection
+
+@php
+    $a = $summary['audience'];
+    $k = $summary['kolabs'];
+    $apps = $summary['applications'];
+    $col = $summary['collaborations'];
+    $q = $summary['quality'];
+    $f = $summary['funnel'];
+    $m = $summary['money'];
+    $act = $summary['activity'];
+
+    $fmt = fn ($n) => $n === null ? '—' : (is_numeric($n) ? number_format((float) $n, is_int($n + 0) ? 0 : 1) : $n);
+    $pct = fn ($n) => $n === null ? '—' : number_format((float) $n, 1).'%';
+@endphp
+
+@section('admin_content')
+    <h4 class="mb-3">Audience</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Total profiles</span>
+                <span class="info-box-number">{{ $fmt($a['total']) }}</span>
+                <span class="text-muted small">+{{ $fmt($a['new_in_range']) }} in range</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Businesses</span>
+                <span class="info-box-number">{{ $fmt($a['business']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Communities</span>
+                <span class="info-box-number">{{ $fmt($a['community']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Attendees</span>
+                <span class="info-box-number">{{ $fmt($a['attendee']) }}</span>
+                <span class="text-muted small">soft-deleted: {{ $fmt($a['soft_deleted']) }}</span>
+            </div></div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-4">
+            <div class="info-box bg-success"><div class="info-box-content">
+                <span class="info-box-text">DAU</span>
+                <span class="info-box-number">{{ $fmt($act['dau']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-4">
+            <div class="info-box bg-info"><div class="info-box-content">
+                <span class="info-box-text">WAU</span>
+                <span class="info-box-number">{{ $fmt($act['wau']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-4">
+            <div class="info-box bg-primary"><div class="info-box-content">
+                <span class="info-box-text">MAU</span>
+                <span class="info-box-number">{{ $fmt($act['mau']) }}</span>
+            </div></div>
+        </div>
+    </div>
+
+    <h4 class="mb-3 mt-3">Funnel — % of users who reach each step</h4>
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>Step</th>
+                            <th class="text-right">Business</th>
+                            <th class="text-right">Community</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (['created' => 'Created', 'onboarded' => 'Onboarded', 'published_kolab' => 'Published a kolab', 'applied' => 'Applied', 'accepted' => 'Accepted somewhere', 'collaborated' => 'In a collaboration', 'completed' => 'Completed a collaboration', 'reviewed' => 'Left a review'] as $key => $label)
+                            <tr>
+                                <td>{{ $label }}</td>
+                                <td class="text-right">
+                                    @if (isset($f['business'][$key]) && $f['business'][$key] !== null)
+                                        {{ $fmt($f['business'][$key]['n']) }}
+                                        <span class="text-muted small">({{ $pct($f['business'][$key]['pct']) }})</span>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                                <td class="text-right">
+                                    @if (isset($f['community'][$key]) && $f['community'][$key] !== null)
+                                        {{ $fmt($f['community'][$key]['n']) }}
+                                        <span class="text-muted small">({{ $pct($f['community'][$key]['pct']) }})</span>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <h4 class="mb-3 mt-4">Kolabs</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Total</span>
+                <span class="info-box-number">{{ $fmt($k['total']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Draft</span>
+                <span class="info-box-number">{{ $fmt($k['draft']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Published</span>
+                <span class="info-box-number">{{ $fmt($k['published']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Avg time-to-publish</span>
+                <span class="info-box-number">{{ $k['avg_time_to_publish_days'] === null ? '—' : $k['avg_time_to_publish_days'].'d' }}</span>
+            </div></div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">Lifecycle distribution (live set)</h5></div>
+                <div class="card-body">
+                    @foreach ($k['lifecycle_distribution'] as $lifecycle => $count)
+                        <div class="mb-2">
+                            <div class="d-flex justify-content-between small">
+                                <span>{{ \App\Services\Admin\KolabLifecycleService::label($lifecycle) }}</span>
+                                <span class="text-muted">{{ $count }}</span>
+                            </div>
+                            <div class="progress" style="height: 6px;">
+                                <div class="progress-bar bg-primary" style="width: {{ $k['total'] > 0 ? round($count / $k['total'] * 100, 1) : 0 }}%"></div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">Kolabs by intent</h5></div>
+                <div class="card-body">
+                    @foreach ($k['by_intent'] as $intent => $count)
+                        <div class="mb-2">
+                            <div class="d-flex justify-content-between small">
+                                <span>{{ ucfirst(str_replace('_', ' ', $intent)) }}</span>
+                                <span class="text-muted">{{ $count }}</span>
+                            </div>
+                            <div class="progress" style="height: 6px;">
+                                <div class="progress-bar bg-info" style="width: {{ $k['total'] > 0 ? round($count / $k['total'] * 100, 1) : 0 }}%"></div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h4 class="mb-3 mt-4">Applications</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Total</span>
+                <span class="info-box-number">{{ $fmt($apps['total']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Acceptance rate</span>
+                <span class="info-box-number">{{ $pct($apps['acceptance_rate_pct']) }}</span>
+                <span class="text-muted small">{{ $fmt($apps['accepted']) }} accepted / {{ $fmt($apps['declined']) }} declined</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Median per kolab</span>
+                <span class="info-box-number">{{ $apps['median_per_kolab'] === null ? '—' : $apps['median_per_kolab'] }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Avg time-to-accept</span>
+                <span class="info-box-number">{{ $apps['avg_time_to_accept_hours'] === null ? '—' : $apps['avg_time_to_accept_hours'].'h' }}</span>
+            </div></div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">By applicant type</h5></div>
+                <div class="card-body">
+                    <p class="mb-2"><strong>Community:</strong> {{ $fmt($apps['from_community']) }}</p>
+                    <p class="mb-2"><strong>Business:</strong> {{ $fmt($apps['from_business']) }}</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header"><h5 class="card-title mb-0">By status</h5></div>
+                <div class="card-body">
+                    <p class="mb-1"><span class="badge badge-warning">PENDING</span> {{ $fmt($apps['pending']) }}</p>
+                    <p class="mb-1"><span class="badge badge-success">ACCEPTED</span> {{ $fmt($apps['accepted']) }}</p>
+                    <p class="mb-1"><span class="badge badge-secondary">DECLINED</span> {{ $fmt($apps['declined']) }}</p>
+                    <p class="mb-1"><span class="badge badge-light">WITHDRAWN</span> {{ $fmt($apps['withdrawn']) }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h4 class="mb-3 mt-4">Collaborations</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Completed</span>
+                <span class="info-box-number">{{ $fmt($col['completed']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Cancelled</span>
+                <span class="info-box-number">{{ $fmt($col['cancelled']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Completion rate</span>
+                <span class="info-box-number">{{ $pct($col['completion_rate_pct']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Avg time-to-complete</span>
+                <span class="info-box-number">{{ $col['avg_time_to_complete_days'] === null ? '—' : $col['avg_time_to_complete_days'].'d' }}</span>
+            </div></div>
+        </div>
+    </div>
+
+    @if (! empty($col['top_cancellation_reasons']))
+        <div class="card">
+            <div class="card-header"><h5 class="card-title mb-0">Top cancellation reasons</h5></div>
+            <div class="card-body">
+                <ul class="list-unstyled mb-0">
+                    @foreach ($col['top_cancellation_reasons'] as $row)
+                        <li class="mb-1"><span class="badge badge-secondary mr-2">{{ $row['count'] }}</span>{{ $row['reason'] }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    @endif
+
+    <h4 class="mb-3 mt-4">Quality</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Avg rating</span>
+                <span class="info-box-number">★ {{ $q['avg_rating'] === null ? '—' : $q['avg_rating'] }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Both sides reviewed</span>
+                <span class="info-box-number">{{ $pct($q['both_sides_reviewed_pct']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Business → Community</span>
+                <span class="info-box-number">★ {{ $q['per_side']['business']['avg'] ?? '—' }}</span>
+                <span class="text-muted small">{{ $q['per_side']['business']['count'] ?? 0 }} reviews</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Community → Business</span>
+                <span class="info-box-number">★ {{ $q['per_side']['community']['avg'] ?? '—' }}</span>
+                <span class="text-muted small">{{ $q['per_side']['community']['count'] ?? 0 }} reviews</span>
+            </div></div>
+        </div>
+    </div>
+
+    @if (! empty($q['point_event_mix']))
+        <div class="card">
+            <div class="card-header"><h5 class="card-title mb-0">Engagement (point-ledger events)</h5></div>
+            <div class="card-body">
+                @foreach ($q['point_event_mix'] as $event => $count)
+                    <p class="mb-1"><span class="badge badge-info mr-2">{{ $count }}</span>{{ ucfirst(str_replace('_', ' ', $event)) }}</p>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    <h4 class="mb-3 mt-4">Subscriptions</h4>
+    <div class="row">
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Active subs</span>
+                <span class="info-box-number">{{ $fmt($m['active_total']) }}</span>
+            </div></div>
+        </div>
+        <div class="col-md-3">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">Paid penetration</span>
+                <span class="info-box-number">{{ $pct($m['paid_penetration_pct']) }}</span>
+                <span class="text-muted small">vs. all business profiles</span>
+            </div></div>
+        </div>
+        <div class="col-md-6">
+            <div class="info-box bg-light"><div class="info-box-content">
+                <span class="info-box-text">By source</span>
+                <span>
+                    @foreach ($m['active_by_source'] as $source => $count)
+                        <span class="badge badge-{{ $source === 'maintainer' ? 'warning' : 'success' }} mr-1">{{ $source }}: {{ $count }}</span>
+                    @endforeach
+                </span>
+            </div></div>
+        </div>
+    </div>
+
+    <p class="text-muted small mt-4">
+        Range:
+        @if ($range === 'all')
+            all time
+        @else
+            since {{ $summary['since'] }}
+        @endif
+        · Funnel counts are lifetime values regardless of range.
+        DAU/WAU/MAU use the <code>last_active_at</code> column populated by the API <code>touch_profile_activity</code> middleware; counts will build over time as users hit the API.
+    </p>
+@endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -114,7 +114,7 @@ Route::prefix('v1')->group(function (): void {
     |--------------------------------------------------------------------------
     */
 
-    Route::middleware(['auth:sanctum', 'log_auth_token_first_use'])->group(function (): void {
+    Route::middleware(['auth:sanctum', 'log_auth_token_first_use', 'touch_profile_activity'])->group(function (): void {
         // City suggestions
         Route::post('cities/suggest', [LookupController::class, 'suggestCity'])
             ->name('api.v1.cities.suggest');

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::get('/kolabs/{kolab}/edit', [AdminKolabController::class, 'edit'])->name('kolabs.edit');
     Route::put('/kolabs/{kolab}', [AdminKolabController::class, 'update'])->name('kolabs.update');
     Route::delete('/kolabs/{kolab}', [AdminKolabController::class, 'destroy'])->name('kolabs.destroy');
+    Route::post('/kolabs/{kolab}/collaboration/cancel', [AdminKolabController::class, 'cancelCollaboration'])->name('kolabs.collaboration.cancel');
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Admin\AuthController as AdminAuthController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\KolabController as AdminKolabController;
 use App\Http\Controllers\Admin\ManagedUserController;
+use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -33,6 +34,8 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::put('/kolabs/{kolab}', [AdminKolabController::class, 'update'])->name('kolabs.update');
     Route::delete('/kolabs/{kolab}', [AdminKolabController::class, 'destroy'])->name('kolabs.destroy');
     Route::post('/kolabs/{kolab}/collaboration/cancel', [AdminKolabController::class, 'cancelCollaboration'])->name('kolabs.collaboration.cancel');
+
+    Route::get('/stats', [AdminStatsController::class, 'index'])->name('stats.index');
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/tests/Feature/Admin/KolabManagementTest.php
+++ b/tests/Feature/Admin/KolabManagementTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Admin;
 
+use App\Enums\CollaborationStatus;
 use App\Enums\KolabStatus;
+use App\Models\Application;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
 use App\Models\Kolab;
 use App\Models\Profile;
 use App\Models\User;
@@ -20,9 +24,25 @@ class KolabManagementTest extends TestCase
         return User::factory()->create(['is_maintainer' => true]);
     }
 
+    /**
+     * Build a Kolab + its paired CollabOpportunity (shared id) so applications
+     * and collaborations can reference the same UUID without FK violations.
+     */
+    private function kolabWithOpportunity(array $kolabOverrides = []): Kolab
+    {
+        $kolab = Kolab::factory()->published()->create($kolabOverrides);
+
+        CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        return $kolab;
+    }
+
     public function test_maintainer_sees_kolab_list(): void
     {
-        $kolab = Kolab::factory()->create(['title' => 'Beach club takeover']);
+        Kolab::factory()->create(['title' => 'Beach club takeover']);
 
         $this->actingAs($this->maintainer(), 'admin')
             ->get(route('admin.kolabs.index'))
@@ -30,7 +50,7 @@ class KolabManagementTest extends TestCase
             ->assertSee('Beach club takeover');
     }
 
-    public function test_index_filters_by_status(): void
+    public function test_index_filters_by_creator_status(): void
     {
         Kolab::factory()->create(['status' => KolabStatus::Draft, 'title' => 'Draft Kolab Alpha']);
         Kolab::factory()->published()->create(['title' => 'Published Kolab Beta']);
@@ -40,6 +60,139 @@ class KolabManagementTest extends TestCase
 
         $response->assertSee('Published Kolab Beta');
         $response->assertDontSee('Draft Kolab Alpha');
+    }
+
+    public function test_index_shows_lifecycle_badge_and_application_counts(): void
+    {
+        $kolab = $this->kolabWithOpportunity(['title' => 'Receiving Kolab']);
+
+        Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index'));
+
+        $response->assertOk();
+        $response->assertSee('Receiving applicants', false);
+        $response->assertSee('2 · 0', false);
+    }
+
+    public function test_lifecycle_filter_active_returns_only_kolabs_with_active_collaboration(): void
+    {
+        $active = $this->kolabWithOpportunity(['title' => 'Has Active Collab']);
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $active->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $active->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $active->creator_profile_id,
+        ]);
+
+        Kolab::factory()->published()->create(['title' => 'No Collab Kolab']);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index', ['lifecycle' => 'active']));
+
+        $response->assertSee('Has Active Collab');
+        $response->assertDontSee('No Collab Kolab');
+    }
+
+    public function test_edit_page_shows_collaboration_details_and_reviews(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        $application = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        $collaboration = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+            'scheduled_date' => now()->addDays(7),
+        ]);
+
+        $collaboration->reviews()->create([
+            'reviewer_profile_id' => $kolab->creator_profile_id,
+            'reviewed_profile_id' => $application->applicant_profile_id,
+            'reviewer_role' => 'business',
+            'rating' => 5,
+            'body' => 'Smooth, brought 30 people.',
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.edit', $kolab));
+
+        $response->assertOk();
+        $response->assertSee('Lifecycle');
+        $response->assertSee('Collaboration');
+        $response->assertSee('Smooth, brought 30 people.', false);
+        $response->assertSee('Force-cancel', false);
+    }
+
+    public function test_edit_page_with_no_collaboration_shows_empty_state(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.edit', $kolab))
+            ->assertOk()
+            ->assertSee('No collaboration yet', false);
+    }
+
+    public function test_maintainer_can_force_cancel_an_active_collaboration(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        $application = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+        $collaboration = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), ['reason' => 'Spam Kolab.'])
+            ->assertRedirect(route('admin.kolabs.edit', $kolab));
+
+        $this->assertSame(
+            CollaborationStatus::Cancelled,
+            $collaboration->fresh()->status,
+        );
+    }
+
+    public function test_force_cancel_requires_a_reason(): void
+    {
+        $kolab = $this->kolabWithOpportunity();
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $kolab->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), [])
+            ->assertSessionHasErrors('reason');
+    }
+
+    public function test_force_cancel_404s_when_no_collaboration_exists(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.cancel', $kolab), ['reason' => 'noop'])
+            ->assertNotFound();
     }
 
     public function test_maintainer_can_edit_a_kolab(): void
@@ -92,7 +245,7 @@ class KolabManagementTest extends TestCase
     public function test_non_maintainer_cannot_touch_kolabs(): void
     {
         $user = User::factory()->create(['is_maintainer' => false]);
-        $kolab = Kolab::factory()->create();
+        Kolab::factory()->create();
 
         $this->actingAs($user, 'admin')
             ->get(route('admin.kolabs.index'))

--- a/tests/Feature/Admin/LifecycleTimestampsTest.php
+++ b/tests/Feature/Admin/LifecycleTimestampsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\SubscriptionSource;
+use App\Enums\SubscriptionStatus;
+use App\Enums\UserType;
+use App\Models\Application;
+use App\Models\BusinessSubscription;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Services\ApplicationService;
+use App\Services\CollaborationService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class LifecycleTimestampsTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_accepting_an_application_stamps_accepted_at(): void
+    {
+        $kolab = $this->kolab();
+        $application = Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(ApplicationService::class)->accept($application);
+
+        $this->assertNotNull($application->fresh()->accepted_at);
+        $this->assertNull($application->fresh()->declined_at);
+    }
+
+    public function test_declining_an_application_stamps_declined_at(): void
+    {
+        $kolab = $this->kolab();
+        $application = Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(ApplicationService::class)->decline($application, 'not a fit');
+
+        $this->assertNotNull($application->fresh()->declined_at);
+    }
+
+    public function test_withdrawing_an_application_stamps_withdrawn_at(): void
+    {
+        $kolab = $this->kolab();
+        $application = Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(ApplicationService::class)->withdraw($application);
+
+        $this->assertNotNull($application->fresh()->withdrawn_at);
+    }
+
+    public function test_cancelling_a_collaboration_persists_reason_and_timestamp(): void
+    {
+        $kolab = $this->kolab();
+        $application = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+        $collaboration = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        app(CollaborationService::class)->cancel($collaboration, 'duplicate Kolab');
+
+        $fresh = $collaboration->fresh();
+        $this->assertNotNull($fresh->cancelled_at);
+        $this->assertSame('duplicate Kolab', $fresh->cancellation_reason);
+        $this->assertNull($fresh->cancelled_by_profile_id);
+    }
+
+    public function test_authenticated_api_request_touches_last_active_at(): void
+    {
+        $profile = Profile::factory()->community()->create(['last_active_at' => null]);
+
+        $this->actingAs($profile)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->get('/api/v1/auth/me');
+
+        $this->assertNotNull($profile->fresh()->last_active_at);
+    }
+
+    private function kolab(): Kolab
+    {
+        $kolab = Kolab::factory()->published()->create();
+        CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        // The creator must have an active subscription to accept applications.
+        BusinessSubscription::query()->updateOrCreate(
+            ['profile_id' => $kolab->creator_profile_id],
+            ['source' => SubscriptionSource::Maintainer, 'status' => SubscriptionStatus::Active],
+        );
+
+        return $kolab;
+    }
+}

--- a/tests/Feature/Admin/StatsDashboardTest.php
+++ b/tests/Feature/Admin/StatsDashboardTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\KolabStatus;
+use App\Enums\UserType;
+use App\Models\Application;
+use App\Models\BusinessSubscription;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Models\User;
+use App\Services\Admin\PlatformStatsService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class StatsDashboardTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_route_is_protected_and_renders_for_maintainer(): void
+    {
+        $this->get(route('admin.stats.index'))->assertRedirect();
+
+        $user = User::factory()->create(['is_maintainer' => false]);
+        $this->actingAs($user, 'admin')->get(route('admin.stats.index'))->assertForbidden();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.stats.index'))
+            ->assertOk()
+            ->assertSee('Statistics');
+    }
+
+    public function test_summary_returns_audience_counts_split_by_user_type(): void
+    {
+        Profile::factory()->business()->count(3)->create();
+        Profile::factory()->community()->count(5)->create();
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(8, $summary['audience']['total']);
+        $this->assertSame(3, $summary['audience']['business']);
+        $this->assertSame(5, $summary['audience']['community']);
+    }
+
+    public function test_applications_split_by_applicant_type_and_acceptance_rate(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+        CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $kolab->creator_profile_id,
+        ]);
+
+        Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+        Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+            'applicant_profile_type' => UserType::Community,
+        ]);
+        Application::factory()->declined()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => Profile::factory()->business(),
+            'applicant_profile_type' => UserType::Business,
+        ]);
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(3, $summary['applications']['total']);
+        $this->assertSame(2, $summary['applications']['accepted']);
+        $this->assertSame(1, $summary['applications']['declined']);
+        $this->assertSame(2, $summary['applications']['from_community']);
+        $this->assertSame(1, $summary['applications']['from_business']);
+        $this->assertEqualsWithDelta(66.7, $summary['applications']['acceptance_rate_pct'], 0.1);
+    }
+
+    public function test_funnel_reports_per_user_type_step_counts(): void
+    {
+        $businesses = Profile::factory()->business()->count(4)->create();
+        $publishing = $businesses->first();
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $publishing->id]);
+        CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $publishing->id,
+        ]);
+
+        $communities = Profile::factory()->community()->count(3)->create();
+        $acceptedApp = Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => $communities->get(0)->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+        Application::factory()->pending()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'applicant_profile_id' => $communities->get(1)->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+        Collaboration::factory()->completed()->create([
+            'collab_opportunity_id' => $kolab->id,
+            'application_id' => $acceptedApp->id,
+            'creator_profile_id' => $publishing->id,
+            'applicant_profile_id' => $communities->get(0)->id,
+        ]);
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(4, $summary['funnel']['business']['created']['n']);
+        $this->assertSame(1, $summary['funnel']['business']['published_kolab']['n']);
+
+        $this->assertSame(3, $summary['funnel']['community']['created']['n']);
+        $this->assertSame(2, $summary['funnel']['community']['applied']['n']);
+        $this->assertSame(1, $summary['funnel']['community']['accepted']['n']);
+        $this->assertSame(1, $summary['funnel']['community']['collaborated']['n']);
+        $this->assertSame(1, $summary['funnel']['community']['completed']['n']);
+    }
+
+    public function test_money_counts_active_subs_split_by_source(): void
+    {
+        $business = Profile::factory()->business()->create();
+        BusinessSubscription::query()->updateOrCreate(
+            ['profile_id' => $business->id],
+            ['source' => 'maintainer', 'status' => 'active'],
+        );
+        Profile::factory()->business()->count(3)->create();
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(1, $summary['money']['active_total']);
+        $this->assertSame(1, $summary['money']['active_by_source']['maintainer']);
+        $this->assertEqualsWithDelta(25.0, $summary['money']['paid_penetration_pct'], 0.1);
+    }
+
+    public function test_kolab_section_includes_lifecycle_distribution(): void
+    {
+        Kolab::factory()->create(['status' => KolabStatus::Draft]);
+        Kolab::factory()->published()->count(2)->create();
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(3, $summary['kolabs']['total']);
+        $this->assertSame(1, $summary['kolabs']['draft']);
+        $this->assertSame(2, $summary['kolabs']['published']);
+        $this->assertArrayHasKey('draft', $summary['kolabs']['lifecycle_distribution']);
+        $this->assertArrayHasKey('open', $summary['kolabs']['lifecycle_distribution']);
+    }
+
+    public function test_range_parameter_falls_back_to_30d_on_invalid_input(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.stats.index', ['range' => 'nonsense']))
+            ->assertOk()
+            ->assertSee('Last 30d');
+    }
+
+    public function test_dau_wau_mau_count_active_profiles_using_last_active_at(): void
+    {
+        Profile::factory()->business()->create(['last_active_at' => now()->subHours(2)]);
+        Profile::factory()->community()->create(['last_active_at' => now()->subDays(3)]);
+        Profile::factory()->community()->create(['last_active_at' => now()->subDays(15)]);
+        Profile::factory()->community()->create(['last_active_at' => null]);
+
+        $summary = app(PlatformStatsService::class)->summary('all');
+
+        $this->assertSame(1, $summary['activity']['dau']);
+        $this->assertSame(2, $summary['activity']['wau']);
+        $this->assertSame(3, $summary['activity']['mau']);
+    }
+}


### PR DESCRIPTION
## Summary
A platform-wide admin analytics surface at `/admin/stats`, plus the small backend additions that make richer signals possible. Together this covers all of the user-asked metrics (% of users at each funnel step, applications from each side, accepted, etc.) and lays the rails for app-side instrumentation.

### Stats dashboard
- Audience volume + DAU / WAU / MAU
- Per-user-type funnel: Created → Onboarded → Published a kolab (business only) → Applied → Accepted → Collaborated → Completed → Reviewed
- Kolabs (status, intent type, avg time-to-publish, live lifecycle distribution)
- Applications (status, applicant type, acceptance rate, median per kolab, time-to-accept)
- Collaborations (completion rate, time-to-complete, **top cancellation reasons** now that they're persisted, median chat messages)
- Quality (per-side review averages, % both-sides-reviewed, point-ledger event mix)
- Subscriptions (active, by source incl. maintainer-granted, paid penetration)
- Range filter 7d / 30d / 90d / all

### Backend additions (Phase 2)
- Migration: `accepted_at` / `declined_at` / `withdrawn_at` on `applications`; `activated_at` / `cancelled_at` / `cancellation_reason` / `cancelled_by_profile_id` on `collaborations`; `last_active_at` on `profiles`.
- `ApplicationService::accept|decline|withdraw` stamp the matching column.
- `CollaborationService::activate` stamps `activated_at`. `cancel(reason, by?)` persists the previously-discarded reason + optional actor (null = maintainer-cancelled via the admin panel).
- `TouchProfileActivity` middleware on the API `auth:sanctum` group writes `last_active_at` once per 5min per profile.
- `app:backfill-lifecycle-timestamps` one-off command (with `--dry-run`) for legacy rows.

### Implementation notes
- `PlatformStatsService` is a pure aggregator. The controller is a 12-line shell.
- No N+1: aggregations use `selectSub` and `toBase()` to bypass model hydration.
- No JS chart lib — Bootstrap progress bars + info-boxes + HTML tables. CSP unchanged.

### Operator-facing doc
`docs/plans/2026-05-31-admin-stats-dashboard.md` — covers the dashboard architecture, exactly what shipped, the deploy checklist (`php artisan migrate` + optional backfill), and a self-contained **Phase 3** spec for the app-side agent (PostHog event catalog, identify rules, privacy gates).

## Test plan
- [x] `php -d memory_limit=-1 vendor/bin/phpunit` — **682 passed / 3472 assertions**
- [x] 13 new feature tests covering stats route, audience split, funnel per type, money split, lifecycle distribution, range fallback, DAU/WAU/MAU, plus accept/decline/withdraw/cancel timestamp stamping and `last_active_at` touch.
- [x] `vendor/bin/pint --dirty` clean
- [ ] Manual: log in to `/admin/stats`, switch ranges, force-cancel a collaboration and verify it appears under top cancellation reasons.

## Deploy
1. Merge → CI/CD → `php artisan migrate` runs the new migration (strictly additive).
2. Optional: `php artisan app:backfill-lifecycle-timestamps --dry-run` then without `--dry-run`.
3. DAU/WAU/MAU will read 0 on day 1 and fill in as the API takes traffic. By design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)