### PR TITLE
docs: audit roles & permissions docs (2026-06-01)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## MUST READ — Roles & Permissions (before planning OR executing changes)
 
-Before planning or writing any code that touches **user roles, permissions, the paywall, the Explore feed, profiles, onboarding, or the create/apply flows**, read BOTH:
-1. [`docs/ROLES-AND-PERMISSIONS.md`](docs/ROLES-AND-PERMISSIONS.md) — the authoritative *what* (exactly what Business and Community users can see and do).
+Before planning or writing any code that touches **user roles, permissions, the paywall, the Explore feed, profiles, onboarding, the create/apply flows, the admin operator surfaces, the attendee gamification track, or subscription state**, read BOTH:
+1. [`docs/ROLES-AND-PERMISSIONS.md`](docs/ROLES-AND-PERMISSIONS.md) — the authoritative *what* (Business, Community, and the attendee §7 first-pass).
 2. [`docs/ROLES-BACKEND-DB-MAP.md`](docs/ROLES-BACKEND-DB-MAP.md) — the authoritative *where* (how each rule maps to backend code + DB tables/columns, plus every known role-handling mistake).
+
+These docs cover the Business / Community / Attendee taxonomy, the two-action paywall, the subscription-lapse re-gate, **maintainer-granted subscriptions** (`source = maintainer`), the **admin operator routes** under `/admin/*`, the lifecycle-observability timestamps, and the open mistakes-to-fix checklist.
+
+**Update rule (non-optional, applies to every role-affecting PR):** when you change any of the surfaces above, you MUST update both docs in the same change — adjust the affected sections, bump the *Last updated* date at the top of each file, and tick / add items in the mistakes-to-fix checklist. If the change adds or removes a role surface entirely, also update this `CLAUDE.md` block and mirror everything into the `kolabing-app` repo's copy of the same two files. Treat this as part of the change, not optional housekeeping.
 
 Most regressions come from applying one role's rules to the other (for example paywalling a community, which must never happen). Do not change role behaviour without checking both documents first; if a fix seems to contradict them, ask before proceeding.
 

--- a/docs/ROLES-AND-PERMISSIONS.md
+++ b/docs/ROLES-AND-PERMISSIONS.md
@@ -1,8 +1,8 @@
 # Kolabing — Roles, Permissions & Features (Canonical Reference)
 
-**Last updated:** 2026-05-22
+**Last updated:** 2026-06-01
 **Status:** Authoritative. This document overrides assumptions.
-**Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical. When role behaviour changes, update both.
+**Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical. When role behaviour changes, update both **and bump the Last updated date** in both.
 
 > **Read this before touching any code that affects Explore, profiles, the paywall, permissions, onboarding, or the create/apply flows.**
 >
@@ -18,7 +18,7 @@ Kolabing has three user types. Only two are in launch scope.
 |---|---|---|---|
 | Business | Yes | Yes, €29/month or €96 per 4-month plan | A venue or a product/service sponsor that wants community foot traffic and exposure. |
 | Community | Yes | No, free always | A real-life community (running club, yoga group, book club, and so on) that hosts events and needs venues or sponsors. |
-| Attendee | No (deferred) | n/a | An individual who attends events. Gamification feature, NOT in launch scope. Do not modify attendee code unless explicitly asked. |
+| Attendee | **[VERIFY]** code-live but spec-unconfirmed | Free for now | An individual who attends events. Gamification track (check-ins, challenges, badges, leaderboards, reward wallet) is **shipped in the backend**; see §7 and the backend map's §11. Whether attendees are formally part of launch and what the pricing/withdrawal model is needs to be confirmed with Daniel before any client-facing changes. |
 
 ---
 
@@ -37,6 +37,8 @@ Kolabing has three user types. Only two are in launch scope.
 
 ### 2.1 Identity and pricing
 Businesses are venues (café, restaurant, bar, bakery, coworking, coliving, gym, salon, retail, hotel) or product/service sponsors. They are the paying side. Price: €29/month, or €96 per 4-month plan. Registration and exploration are free; the subscription unlocks the two gated actions only.
+
+> **Backend note:** `coliving` is part of the spec list but is **not currently in `BusinessOnboardingRequest::BUSINESS_TYPES`**. Adding it is tracked in the backend map's mistakes-to-fix checklist. Until added, a `coliving` business onboarding payload will fail server-side validation.
 
 ### 2.2 Onboarding
 - Path: "I'm a Business."
@@ -101,6 +103,16 @@ If a business's subscription lapses (expires or is cancelled), the business is *
 
 The **community counterparty is NEVER affected**: communities keep full access to the shared collaboration and chat regardless of the business's subscription state. Re-gating is one-sided (business only). This refines §2.7: create/apply are the only first-contact paywalls, but a lapse additionally withdraws ongoing business-side access.
 
+### 2.9 Maintainer-granted access — added 2026-06-01
+A Kolabing maintainer can grant a business **12 months of subscription access** from the admin panel (`/admin/users/{profile}/subscription/grant`). This produces a `business_subscriptions` row with `status = active` and **`source = maintainer`**. The grant bypasses Stripe/Apple IAP but is identical to a paid subscription as far as the paywall and re-gating logic are concerned — the business gets full subscribed-business capabilities until the period ends or a maintainer revokes it.
+
+A revoke (`/subscription/revoke`) flips the row to `status = inactive` with `cancel_at_period_end = true`. After revoke, the standard subscription-lapse re-gate (§2.8) kicks in.
+
+**Maintainer grants are auditable** via the `source = maintainer` value. There is no other way for an active subscription row to appear without payment.
+
+### 2.10 Test users — back-channel
+A profile with `profiles.is_test_user = true` is treated as having an active subscription regardless of whether a `business_subscriptions` row exists. This is reserved for Kolabing internal QA accounts. Never set this flag on real customer profiles.
+
 ---
 
 ## 3. Community role
@@ -157,18 +169,19 @@ Nothing. There is no paywall and no gated action on the community side. If code 
 
 ## 5. Permission matrix
 
-| Capability | Free Business | Subscribed Business | Community |
-|---|---|---|---|
-| Register and onboard | Yes | Yes | Yes |
-| Browse Explore | Yes | Yes | Yes |
-| See the other side's post details | Yes | Yes | Yes |
-| See the other side's name and logo | No, blurred | Yes | Yes |
-| Open the other side's full profile | No | Yes | Yes |
-| Create a post (collaboration / Kolab) | No, paywall | Yes | Yes, free |
-| Apply to a post | No, paywall | Yes | Yes, free |
-| Chat | No | Yes | Yes |
-| Reviews and feedback | No | Yes | Yes |
-| Earn credits, refer, withdraw | n/a | Business referral perks exist, tracked separately | Yes |
+| Capability | Free Business | Subscribed Business | Community | Attendee |
+|---|---|---|---|---|
+| Register and onboard | Yes | Yes | Yes | Yes |
+| Browse Explore (marketplace feed) | Yes | Yes | Yes | **No** — attendees do not use the marketplace |
+| See the other side's post details | Yes | Yes | Yes | n/a |
+| See the other side's name and logo | No, blurred | Yes | Yes | n/a |
+| Open the other side's full profile | No | Yes | Yes | n/a |
+| Create a post (collaboration / Kolab) | No, paywall | Yes | Yes, free | **No** |
+| Apply to a post | No, paywall | Yes | Yes, free | **No** |
+| Chat | No | Yes | Yes | **No** |
+| Reviews and feedback | No | Yes | Yes | n/a |
+| Check into events, complete challenges, earn badges | n/a | n/a | n/a | **Yes** — gamification track |
+| Earn credits, refer, withdraw | n/a | Business referral perks exist, tracked separately | Yes (€0.25/pt, €75 threshold) | **[VERIFY]** whether attendee wallet redeems to cash |
 
 ---
 
@@ -184,3 +197,46 @@ These are specific errors that have happened in past fixes. Do not repeat them.
 - **Do not change what a free business sees in Explore beyond the blur.** They see all Kolab details; only the community identity is blurred.
 - **Do not paywall registration, onboarding, or browsing.** Only creating and applying are paywalled, and only for the Business role.
 - **When a fix touches Explore, profiles, the paywall, or onboarding, re-read sections 1, 2, and 3 of this document before writing code.**
+
+---
+
+## 7. Attendee role — first pass (added 2026-06-01, scope [VERIFY] with Daniel)
+
+The attendee role's backend track has shipped and the canonical position that attendees are "deferred / out of scope" is no longer accurate. This section captures what the code currently allows pending product confirmation.
+
+### 7.1 What an attendee can do today (verified against `routes/api.php` and the gamification services)
+- Register via email/password (`POST /api/v1/auth/register/attendee`) or Google / Apple OAuth.
+- Be a member of an `attendee_profiles` row (`total_points`, `total_challenges_completed`, `total_events_attended`, `global_rank`).
+- Check into events by scanning the organiser-generated QR (`POST /checkin`). Each check-in increments `total_events_attended`.
+- Take part in challenges per event: list, initiate peer-to-peer, verify / reject, see own completion history.
+- Earn points (`point_ledger` — append-only) and badges (`BadgeService` awards on milestones like `LoyalAttendee = total_events_attended >= N`).
+- See per-event and global leaderboards.
+- Hold a reward wallet and redeem rewards.
+
+### 7.2 What an attendee CANNOT do (confirmed at the service layer)
+- Create or publish kolabs / opportunities — neither service path accepts an attendee creator.
+- Apply to kolabs — `applications.applicant_profile_type` enum is business / community only.
+- Subscribe — the paywall and the admin grant route both reject non-business profiles.
+- Chat — chat is bound to an accepted application between a business and a community.
+
+### 7.3 Decisions still needed
+- Is the attendee role part of launch, or held back?
+- Do attendee points convert to real money through the wallet / withdrawal flow (the way §3.5 describes for communities — €0.25/point, €75 threshold) or is the wallet community-only?
+- Should this section grow into a full §4-equivalent (Identity, Onboarding, Explore, Profile, Capabilities matrix) once those decisions land?
+
+Until those are resolved, treat **§0 attendee row as the stale legacy** and this §7 as the working reference, in sync with the backend map's §11.
+
+---
+
+## 8. Maintaining this document
+
+This file and `docs/ROLES-BACKEND-DB-MAP.md` are read by every Claude session that touches role-affecting code (see the project `CLAUDE.md`). They are also duplicated in the `kolabing-app` repo.
+
+**When you change role behaviour, paywalling, or admin operator capabilities:**
+1. Update this document — adjust the affected section, the permission matrix in §5, and the golden rules if they shift.
+2. Update `docs/ROLES-BACKEND-DB-MAP.md` — update the line numbers, schema map, and mistakes-to-fix checklist.
+3. Bump the **Last updated** date at the top of both files.
+4. Mirror the change into the `kolabing-app` copy of both files.
+5. If the change adds or removes a role surface entirely, update the project `CLAUDE.md` "MUST READ" block too.
+
+Treat this maintenance as part of the change, not optional.

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -1,8 +1,8 @@
 # Kolabing — Roles → Backend → Database Map (Ground-Truth)
 
-**Last updated:** 2026-05-22
+**Last updated:** 2026-06-01
 **Status:** Authoritative companion to [`ROLES-AND-PERMISSIONS.md`](./ROLES-AND-PERMISSIONS.md). Read that first (the *what*), then this (the *where*).
-**Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical.
+**Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical, and **bump the Last updated date in both** when role behaviour or backend wiring changes.
 
 > This document maps each role rule from `ROLES-AND-PERMISSIONS.md` to the exact backend code and database tables/columns that implement it, and flags every place the current code mis-handles roles. Cite this map (file:line, table.column) before changing anything that touches Explore, profiles, the paywall, permissions, onboarding, or create/apply. Items marked **[VERIFY]** still need a live confirmation.
 
@@ -10,11 +10,16 @@
 
 ## 0. TL;DR — the role-confusion hot spots
 
-1. **Two parallel post systems exist** (`collab_opportunities` *and* `kolabs`). They are reached by two different client flows and gated by two different services with **different paywall logic**. This duplication is the single biggest source of role bugs. See §2.
-2. **`KolabService::publish` has no `isBusiness()` guard** (`app/Services/KolabService.php:171`). A community is protected only by intent type, not by role. This is the latent "community blocked from creating" path. See §3.
-3. **The blur does not exist.** Server returns full community identity to everyone; the client computes a `hideCreatorIdentity` flag but never renders a blur. Free businesses are instead hard-blocked. Violates golden rules 4 & 5. See §4.
-4. **Account deletion is soft-delete only** — email is never freed and related collaborations/opportunities are orphaned (DB cascades don't fire on soft delete). See §6.
-5. **Profile logo lives in two columns** (`profiles.avatar_url` vs `{business,community}_profiles.profile_photo`) and may be returned as a non-absolute URL → logos don't load. See §5.
+> Fixed-since-last-update marked ✅; still-open marked ⚠️.
+
+1. ⚠️ **Two parallel post systems exist** (`collab_opportunities` *and* `kolabs`). They share a `id` UUID via `LegacyOpportunityBridgeService` so applications and collaborations (which FK to `collab_opportunities.id`) still resolve when a `kolab` is the actual post. The duplication is still the single biggest source of role bugs. See §2.
+2. ✅ **`KolabService::publish` now has the `isBusiness()` guard** — `app/Services/KolabService.php:190`. A community publishing a non-`CommunitySeeking` kolab no longer hits the freemium gate.
+3. ⚠️ **The blur still does not exist.** `app/Http/Resources/Api/V1/DiscoveryOpportunityResource.php` returns full `creator_profile.display_name` + `avatar_url` to every viewer; no `identity_locked` / `hide_creator_identity` flag is emitted. Violates golden rules 4 & 5. See §4.
+4. ✅ **Account deletion now frees the email, closes posts on both systems, cancels active collaborations, and revokes tokens.** `ProfileService::deleteProfile()` (`app/Services/ProfileService.php:111`) renames the soft-deleted profile's email to `deleted+{id}@kolabing.invalid` so the unique index releases the original address. See §6.
+5. ✅ **Profile logos serialize as absolute URLs from the correct column.** `PublicProfileResource::absoluteUrl()` resolves the URL from the extended profile's `profile_photo` first, falling back to `profiles.avatar_url`. See §5.
+6. ⚠️ **NEW — attendee gamification track has shipped** but the canonical permissions doc still describes attendees as "deferred / out of scope". `AttendeeProfile`, `Wallet`, `EarnedBadge`, `EventCheckin`, `ChallengeCompletion`, and ~40 gamification endpoints are live. See §11.
+7. ⚠️ **NEW — `coliving` is in the canonical role spec (`ROLES-AND-PERMISSIONS.md` §2.1) but missing from `BusinessOnboardingRequest::BUSINESS_TYPES`.** A `coliving` onboarding payload is rejected server-side. Trivial fix; see §8 checklist.
+8. ⚠️ **NEW — admin operator surfaces.** Maintainers can grant a 12-month subscription with `source = maintainer` and force-cancel collaborations from `/admin/*`. Make sure new gate code accounts for `source = maintainer` (still an `active` row; behaves identically to a Stripe-paid sub). See §9.
 
 ---
 
@@ -22,12 +27,13 @@
 
 | Concept | Table.Column | Notes |
 |---|---|---|
-| **User role** | `profiles.user_type` (varchar 20) | `Business` / `Community` / `Attendee`. Read via `Profile::isBusiness()` (`app/Models/Profile.php:355`), `isCommunity()` (`:363`). |
-| **Subscription state** | `business_subscriptions.status` (varchar) | `inactive`/`active`/`trial`/`cancelled`; 1:1 to `profiles` via `profile_id` (unique). |
-| **Active-sub check** | `Profile::hasActiveSubscription()` (`:380`) | Correctly returns `false` for any non-business (`if (!$this->isBusiness()) return false;`). ✅ |
-| **Free-kolab-used check** | `Profile::hasUsedFreeKolab()` (`:400`) | True if the profile has a **published** kolab with `intent_type` in (VenuePromotion, ProductPromotion). Role-agnostic — see §3. |
+| **User role** | `profiles.user_type` (varchar 20) | Stored as enum value `business` / `community` / `attendee`. Read via `Profile::isBusiness()` (`app/Models/Profile.php:357`), `isCommunity()` (`:365`), `isAttendee()` (`:373`). |
+| **Subscription state** | `business_subscriptions.status` (varchar 20) | Real values: `active` / `cancelled` / `past_due` / `inactive` (default `inactive`). **There is no `trial` state.** 1:1 to `profiles` via `profile_id` (unique). |
+| **Subscription source** | `business_subscriptions.source` (varchar) | `stripe` / `apple_iap` / **`maintainer`**. The `maintainer` value indicates an admin-granted sub (see §9). Same gating logic — same paywall result. |
+| **Active-sub check** | `Profile::hasActiveSubscription()` (`:382`) | Correctly returns `false` for any non-business. **Backdoor:** returns `true` when `profiles.is_test_user = true` *regardless* of any subscription row — reserved for internal QA accounts, must never be set on real users. |
+| **Free-kolab-used check** | `Profile::hasUsedFreeKolab()` (`:402`) | True if the profile has a **published** kolab with `intent_type` in (VenuePromotion, ProductPromotion). Role-agnostic — but the caller is now properly role-guarded (see §3). |
 
-Role helpers are consistent; the bugs are in *where they are (not) applied*, not in the helpers themselves.
+Role helpers are consistent; the remaining bugs are in *where they are (not) applied* (Explore blur, §4), not in the helpers themselves.
 
 ---
 
@@ -44,7 +50,8 @@ There are **two** "post" tables plus the accepted-match table. Per `ROLES-AND-PE
 
 - `collab_opportunities.creator_profile_type` (enum Business|Community) encodes authorship in System A.
 - `kolabs.intent_type` (CommunitySeeking | VenuePromotion | ProductPromotion) encodes authorship in System B: **CommunitySeeking = community-authored; Venue/ProductPromotion = business-authored.**
-- **[VERIFY] Which system is canonical for the live marketplace?** Discovery (§4) queries `kolabs`. But `applications.collab_opportunity_id` and `collaborations.collab_opportunity_id` FK to `collab_opportunities` (System A), not `kolabs`. Confirm how an applied-to `kolab` becomes an `application`/`collaboration`, or whether one system is dead. **This reconciliation is sprint task 0** — most "wrong role / wrong data" bugs trace here.
+- **The bridge — partially resolved.** `App\Services\LegacyOpportunityBridgeService::resolveOrFail($id, $persistFromKolab)` mints a compatibility `collab_opportunities` row **with the same UUID as the kolab** when an application is filed against a kolab id. This is why `applications.collab_opportunity_id == kolab.id` works downstream. So both systems coexist at runtime; **the canonical authoring source is `kolabs`**, and System A is now effectively a denormalized projection used for the apply / collaboration FK chain.
+- **Practical implication:** when in doubt about "which model is the post?" → it's the **Kolab**. When you need to query applications/collaborations, you can do so by `kolab.id` directly because the bridge ensures the row exists. Eliminating System A entirely is the long-running cleanup; until then, do not change the bridge invariant (kolab.id == collab_opportunity.id).
 
 ---
 
@@ -54,17 +61,15 @@ Spec: paywall is **Business-only**, on **exactly two actions** (create a collabo
 
 | Action | Code | Gates whom | Verdict |
 |---|---|---|---|
-| Create opportunity (System A) | `OpportunityService::hasReachedFreemiumCollabLimit()` `:144`; early-out `if (!$creator->isBusiness()) return false;` `:146` | Business w/o sub, >1 collab | ✅ correct |
-| Publish opportunity (System A) | `OpportunityService::publish()` `:275` `if ($creator->isBusiness() && !$creator->hasActiveSubscription())` | Business only | ✅ correct |
-| Create kolab (System B) | `KolabService::create()` `:74` — no sub check | nobody | ✅ correct |
-| **Publish kolab (System B)** | `KolabService::publish()` **`:171`** `intent_type !== CommunitySeeking && !hasActiveSubscription() && hasUsedFreeKolab()` | **role-agnostic** | ⚠️ **VIOLATION RISK** — no `isBusiness()` guard. A community publishing a non-CommunitySeeking kolab (e.g. via any path that sets Venue/ProductPromotion) hits this. Add `&& $creator->isBusiness()`. |
-| Apply to a post | `ApplicationController` | **[VERIFY]** confirm a free business is gated and a community is **never** gated | [VERIFY] |
-| Client: create entry (intent) | `intent_selection_screen.dart:53` `businessRequiresSubscription = isBusiness && !isSubscribed` → `_LockedBusinessCreateState` (`:82`) | Business only | ✅ role-correct, but it's a **full-screen hard block** (acceptable for the *create* action per spec; do not copy this pattern to Explore) |
+| Create opportunity (System A) | `OpportunityService::hasReachedFreemiumCollabLimit()`; early-out `if (!$creator->isBusiness()) return false;` | Business w/o sub, >1 collab | ✅ correct |
+| Publish opportunity (System A) | `OpportunityService::publish()` `if ($creator->isBusiness() && !$creator->hasActiveSubscription())` | Business only | ✅ correct |
+| Create kolab (System B) | `KolabService::create()` — no sub check | nobody | ✅ correct |
+| Publish kolab (System B) | `KolabService::publish()` `:190` — `$creator->isBusiness() && intent_type !== CommunitySeeking && !hasActiveSubscription() && hasUsedFreeKolab()` | Business only | ✅ correct (fixed since 2026-05-22) |
+| Accept application | `ApplicationService::accept()` `:86` — `$opportunity->creatorProfile->isBusiness() && ! hasActiveSubscription()` throws `RuntimeException('An active subscription is required to accept applications.')` | Business creator without sub | ✅ correct |
+| Apply to a post | `ApplicationController::store()` `:78` → catches `SubscriptionRequiredException` and returns HTTP **402** so the client renders the paywall. The community side throws no such exception. | Business applier without sub | ✅ correct |
+| Client: create entry (intent) | `intent_selection_screen.dart` shows the paywall for unsubscribed business; communities only see the FREE CommunitySeeking option | Business only | ✅ correct |
 
-**Community-blocked-from-creating ("Create opportunity still blocked for communities"):** the new-master `intent_selection_screen` correctly offers communities only the FREE communitySeeking option, so the obvious client path is clean. Prime suspects, in order:
-1. **`KolabService::publish:171`** missing `isBusiness()` guard (fix regardless).
-2. **Profile-type resolution**: `intent_selection_screen.dart:51-52` compares `userType?.name == 'community'` / `'business'` (lowercase). If the profile API returns `user_type` capitalized (`Community`) or the client enum casing differs, **both** flags go false → a community falls into the business `else` branch / mis-gates. **[VERIFY]** the exact `user_type` casing the API returns vs the client enum.
-3. The legacy `create_opportunity_screen` path (System A) — confirmed `isBusiness`-guarded server-side, so unlikely.
+All four backend gates now follow the same pattern: `if ($profile->isBusiness() && ! $profile->hasActiveSubscription())`. **Never copy this gate into community or attendee paths.**
 
 ---
 
@@ -97,46 +102,168 @@ Spec: paywall is **Business-only**, on **exactly two actions** (create a collabo
 
 ---
 
-## 6. Account deletion & data integrity (critical)
+## 6. Account deletion & data integrity ✅ FIXED
 
-- **Endpoint:** `ProfileController::destroy()` (`:137`) → `ProfileService::deleteProfile()` (`app/Services/ProfileService.php:89`): revokes tokens + `$profile->delete()` only.
-- **Soft delete:** `Profile` uses `SoftDeletes` (`app/Models/Profile.php:64`); `deleted_at` added by `2026_01_26_000002_add_deleted_at_to_profiles_table.php`. So:
-  - **Email never freed:** `profiles.email` has a `unique()` index (`2026_01_24_000002_create_profiles_table.php:15`); the soft-deleted row keeps the email → re-registration fails.
-  - **Orphans:** FKs (`collaborations`, `collab_opportunities`, `applications`, `chat_messages`) are `cascadeOnDelete`, but **DB cascade only fires on a hard delete**. Soft delete leaves all of them live, pointing at a dead profile.
-- **Fix direction:** on delete, within a transaction — close/cancel live collaborations & opportunities and soft/force-delete dependent rows explicitly; and free the email (either hard-delete, or null/rename the email e.g. `deleted+{id}@…`, or make the unique index `deleted_at`-aware). Decide soft vs hard with Daniel (audit/retention vs reuse).
+- **Endpoint:** `ProfileController::destroy()` → `ProfileService::deleteProfile()` (`app/Services/ProfileService.php:111`). All actions run in one DB transaction.
+- **What now happens, in order:**
+  1. The profile's `email` is force-filled to `deleted+{profile.id}@kolabing.invalid` so the unique-index lock is released and the original address can re-register.
+  2. The user's open **kolabs** (draft / published) are closed (`kolabs.status → closed`).
+  3. The user's open **collab_opportunities** (System A — draft / published) are closed (`status → closed`).
+  4. Scheduled / active **collaborations** are cancelled via `cancelActiveCollaborations()`, and the counterparty receives an in-app notification.
+  5. All Sanctum tokens are revoked.
+  6. The profile is soft-deleted (`Profile` still uses `SoftDeletes`).
+- **What still uses soft-delete:** the profile row itself remains for audit/recovery. Related rows are *closed*, not destroyed, so collaboration history stays intact on the counterparty's side.
+- **Admin equivalent:** `Admin\ManagedUserController::destroy()` → `ManagedProfileService::delete()` just calls `$profile->delete()` without the cleanup transaction above. **[VERIFY]** whether the admin delete path should also run the full cleanup — currently it bypasses the email-free + collaboration-cancel side effects.
 
 ---
 
 ## 7. Database schema map (roles & marketplace core)
 
 ```
-profiles (id uuid PK, email UNIQUE, user_type[Business|Community|Attendee], avatar_url, deleted_at?)
- ├─1:1─ business_profiles  (profile_id FK, company_name, business_type slug, profile_photo)
- ├─1:1─ community_profiles (profile_id FK, community_name, community_type slug, member_count, profile_photo)
- ├─1:1─ attendee_profiles  (out of scope)
- ├─1:1─ business_subscriptions (profile_id FK UNIQUE, status[inactive|active|trial|cancelled], plan_type, renews_at)
- ├─1:N─ collab_opportunities (creator_profile_id FK, creator_profile_type[Business|Community], status, business_offer, community_deliverables, venue_mode, address, preferred_city, offer_photo)   ← System A
- ├─1:N─ kolabs (creator_profile_id FK, intent_type[CommunitySeeking|VenuePromotion|ProductPromotion], status, media json, needs json, community_types json, venue_preference, offering json)        ← System B (discovery source)
- ├─1:N─ events (profile_id FK, partner_id FK, event_date, attendee_count)   ← past events
- └─1:N─ applications (applicant_profile_id FK, collab_opportunity_id FK, status[pending|accepted|rejected])
-            └─1:1─ collaborations (application_id FK UNIQUE, collab_opportunity_id FK, creator_profile_id, applicant_profile_id, business_profile_id nullOnDelete, community_profile_id nullOnDelete, status[scheduled|active|completed|cancelled], scheduled_date, completed_at, event_id)
-                       └─1:N─ collaboration_reviews / chat_messages (application_id FK)
-lookups: business_types, community_types
+profiles (id uuid PK, email UNIQUE, user_type[business|community|attendee], avatar_url,
+          is_test_user, last_active_at, deleted_at?)
+ ├─1:1─ business_profiles      (profile_id FK, name, business_type slug, profile_photo, …)
+ ├─1:1─ community_profiles     (profile_id FK, name, community_type slug, profile_photo, instagram, …)
+ ├─1:1─ attendee_profiles      (profile_id FK, total_points, total_challenges_completed,
+ │                              total_events_attended, global_rank)                ← gamification (§11)
+ ├─1:1─ business_subscriptions (profile_id FK UNIQUE,
+ │                              status[active|cancelled|past_due|inactive],
+ │                              source[stripe|apple_iap|maintainer],
+ │                              stripe_customer_id, stripe_subscription_id,
+ │                              current_period_start, current_period_end, cancel_at_period_end,
+ │                              apple_original_transaction_id, apple_transaction_id, apple_product_id)
+ ├─1:N─ collab_opportunities   (creator_profile_id FK, creator_profile_type[business|community],
+ │                              status[draft|published|closed|completed], business_offer json,
+ │                              community_deliverables json, venue_mode, preferred_city)         ← System A
+ ├─1:N─ kolabs                 (creator_profile_id FK, intent_type[community_seeking|venue_promotion|
+ │                              product_promotion], status[draft|published|closed], media json,
+ │                              needs json, community_types json, venue_preference, offering json,
+ │                              published_at)                                                    ← System B (canonical)
+ ├─1:N─ events                 (profile_id FK, partner_id FK, event_date, attendee_count)        ← past events
+ └─1:N─ applications           (applicant_profile_id FK, applicant_profile_type[business|community],
+                                collab_opportunity_id FK, status[pending|accepted|declined|withdrawn],
+                                accepted_at?, declined_at?, withdrawn_at?)                       ← (§10)
+            └─1:1─ collaborations (application_id FK UNIQUE, collab_opportunity_id FK,
+                                   creator_profile_id, applicant_profile_id,
+                                   business_profile_id nullOnDelete, community_profile_id nullOnDelete,
+                                   status[scheduled|active|completed|cancelled],
+                                   scheduled_date, activated_at?, completed_at?,
+                                   cancelled_at?, cancellation_reason?, cancelled_by_profile_id? nullOnDelete,
+                                   event_id, qr_code_url)                                        ← (§10)
+                       ├─1:N─ collaboration_reviews (collaboration_id FK, reviewer_profile_id,
+                       │                              reviewed_profile_id, reviewer_role, rating,
+                       │                              body, note, would_collaborate_again)
+                       └─1:N─ chat_messages         (application_id FK, sender_profile_id, …)
+
+Gamification / wallets (§11):
+ ├─ wallets, withdrawal_requests, point_ledger
+ ├─ badges, badge_awards, earned_badges
+ ├─ event_checkins, event_photos, event_rewards
+ └─ collaboration_challenges, challenge_completions, referral_codes, referral_redemptions
+
+Lookups / admin:
+ ├─ cities, city_suggestions
+ └─ users (admin/maintainer auth — separate from profiles, see §9)
 ```
 
-**Role lives in `profiles.user_type`. Subscription lives in `business_subscriptions.status`.** Everything else branches off those two.
+**Role lives in `profiles.user_type`. Subscription lives in `business_subscriptions.status` (with `source` as audit trail).** Everything else branches off those two.
 
 ---
 
 ## 8. Mistakes-to-fix checklist (role-handling)
 
-- [ ] `KolabService::publish` add `&& $creator->isBusiness()` to the gate (§3).
-- [ ] Confirm/repro the community create-block; fix profile `user_type` casing mismatch if present (§3).
-- [ ] Implement the **blur** (name+logo) for free businesses on Explore; remove the hard-block (§4).
-- [ ] Account deletion: free the email + clean up collaborations/opportunities (§6).
-- [ ] Profile logo: return absolute URL from the correct column (§5).
-- [ ] Past events linked to collaborations + `completed_at` populated (§5).
-- [ ] "View profile" passes a `profiles.id` (§5).
-- [ ] Type tags formatted on exactly one side (§4/§5).
-- [ ] **Reconcile the two post systems** (`collab_opportunities` vs `kolabs`) — sprint task 0 (§2).
+Fixed since the last revision:
+
+- [x] `KolabService::publish` gated by `isBusiness()` (`:190`). (§3)
+- [x] Account deletion frees the email + closes posts on both systems + cancels active collaborations. (§6)
+- [x] Profile logo returns an absolute URL via `PublicProfileResource::absoluteUrl()` from the correct column. (§5)
+- [x] Collaboration cancellation now persists `cancellation_reason`, `cancelled_at`, and `cancelled_by_profile_id` (§10).
+
+Still open:
+
+- [ ] Implement the **blur** (name + logo) for free businesses on Explore. Server should emit an `identity_locked` flag (or null the identity for free businesses) and the client should render an actual blur. **No hard block on Explore.** (§4)
+- [ ] Past events linked to collaborations and `completed_at` populated.
+- [ ] "View profile" deep-link confirmed to pass a `profiles.id` (not a `business_profile.id` or `collaboration.id`).
+- [ ] Type tags formatted on exactly one side (discovery formats server-side; profiles format client-side — pick one).
+- [ ] **Reconcile the two post systems** — bridge is in place via `LegacyOpportunityBridgeService`, but the long-running cleanup is to delete System A entirely. (§2)
+- [ ] **Add `coliving` to `BusinessOnboardingRequest::BUSINESS_TYPES`** so the spec list in `ROLES-AND-PERMISSIONS.md` §2.1 actually validates. (Hot spot #7)
+- [ ] **`Admin\ManagedUserController::destroy()` should run the full `ProfileService::deleteProfile()` cleanup**, not a bare soft-delete (§6).
+- [ ] **Document the attendee role in `ROLES-AND-PERMISSIONS.md`** — track is shipped (§11) but the canonical doc still says "deferred / out of scope". A first-pass §7 has been added; confirm scope, pricing (free?), and gating with Daniel.
 - [ ] Never paywall communities anywhere; never remove either role's ability to post/apply (golden rules).
+
+---
+
+## 9. Admin operator surfaces — added 2026-06-01
+
+The admin panel is a **server-rendered Blade surface inside this Laravel backend**, mounted under `/admin/*` and gated by two layers:
+
+1. `auth:admin` — a dedicated `admin` guard (`config/auth.php:44`) backed by the `users` table (separate from `profiles`). Login at `GET /admin/login`.
+2. `maintainer` middleware (`App\Http\Middleware\EnsureAdminUserIsMaintainer`) — requires `users.is_maintainer = true`.
+
+| Action | Route | Backend | Effect |
+|---|---|---|---|
+| Soft-delete user | `DELETE /admin/users/{profile}` → `Admin\ManagedUserController::destroy` | `ManagedProfileService::delete()` → `$profile->delete()` | Bare soft-delete. **Does not run the full cleanup** that the user-facing endpoint does (see §6 — open checklist item). |
+| Grant subscription | `POST /admin/users/{profile}/subscription/grant` → `::grantSubscription` | `ManagedProfileService::grantSubscription($profile, $months = 12)` | `updateOrCreate` `business_subscriptions` with `status = active`, `source = maintainer`, `current_period_start = now()`, `current_period_end = now()+12mo`. Aborts 422 if profile is not `business`. |
+| Revoke subscription | `POST /admin/users/{profile}/subscription/revoke` → `::revokeSubscription` | `ManagedProfileService::revokeSubscription` | Sets `status = inactive`, `cancel_at_period_end = true`. Standard re-gate (`ROLES-AND-PERMISSIONS.md §2.8`) then applies. |
+| Force-cancel collaboration | `POST /admin/kolabs/{kolab}/collaboration/cancel` → `Admin\KolabController::cancelCollaboration` | `CollaborationService::cancel($collab, $reason, $cancelledBy = null)` | Requires a reason (min 3 chars). Persists `cancellation_reason`, `cancelled_at`, leaves `cancelled_by_profile_id` null — **`null` = cancelled by maintainer**. |
+
+**Key invariant for the role logic:** an admin-granted subscription is indistinguishable from a paid sub at the gate level. `Profile::hasActiveSubscription()` checks `status == active`; it does not branch on `source`. The `source` column is purely for audit and analytics. **Do not** add `source == stripe` checks anywhere — that would silently lock out maintainer-granted users.
+
+---
+
+## 10. Lifecycle observability columns — added 2026-06-01
+
+Added by the 2026-05-31 admin stats sprint. These columns are **observability-only** — no role logic reads them, and no gate behaviour depends on them. They exist so the admin stats dashboard can compute time-to-accept, time-to-complete, and cancellation reports.
+
+| Column | Type | Stamped by |
+|---|---|---|
+| `applications.accepted_at` | timestamp nullable | `ApplicationService::accept()` |
+| `applications.declined_at` | timestamp nullable | `ApplicationService::decline()` |
+| `applications.withdrawn_at` | timestamp nullable | `ApplicationService::withdraw()` |
+| `collaborations.activated_at` | timestamp nullable | `CollaborationService::activate()` |
+| `collaborations.cancelled_at` | timestamp nullable | `CollaborationService::cancel()` |
+| `collaborations.cancellation_reason` | varchar 500 nullable | `CollaborationService::cancel()` |
+| `collaborations.cancelled_by_profile_id` | foreignUuid nullable | `CollaborationService::cancel()` — **null = maintainer-cancelled** |
+| `profiles.last_active_at` | timestamp nullable (indexed) | `TouchProfileActivity` middleware on the API `auth:sanctum` group; throttled to once per 5 minutes per profile |
+
+Backfill for legacy rows: `php artisan app:backfill-lifecycle-timestamps [--dry-run]` copies `updated_at` into the matching transition column. Run once per environment after deploy.
+
+---
+
+## 11. Attendee role — first-pass map (added 2026-06-01, [VERIFY] scope with Daniel)
+
+The attendee track ships substantial code despite `ROLES-AND-PERMISSIONS.md §0` still labelling attendees "deferred". Audit summary:
+
+**Identity & registration**
+- `profiles.user_type = 'attendee'`, 1:1 to `attendee_profiles` (`total_points`, `total_challenges_completed`, `total_events_attended`, `global_rank`).
+- Email/password registration: `POST /api/v1/auth/register/attendee` → `AuthController::registerAttendee` → `AuthService::registerAttendee` (`:443`).
+- Google / Apple OAuth path: `AuthService` handles `user_type = attendee` alongside business and community (`:223`, `:253`).
+
+**Gates already applied (audited)**
+- `Profile::hasActiveSubscription()` returns `false` for any non-business — so an attendee can never satisfy the business paywall, by design.
+- `Application` and `Kolab` policies / services do not allow attendees to apply or publish (verify per-policy: **[VERIFY]** confirm `ApplicationPolicy` / `KolabPolicy` deny attendees explicitly rather than relying on user_type discrimination upstream).
+
+**Endpoints attendees can hit (live in `routes/api.php`)**
+- **Check-in:** `POST /events/{event}/generate-qr` (organizer), `POST /checkin` (attendee scans), `GET /events/{event}/checkins`. Handled by `CheckinController` + `CheckinService` — `CheckinService::__invoke()` bumps `attendee_profiles.total_events_attended`.
+- **Challenges:** system + custom challenges per event (`ChallengeController`), peer-to-peer initiation, verify / reject (`ChallengeCompletionController`), per-attendee history `GET /me/challenge-completions`. `ChallengeCompletionService::verify()` writes to `point_ledger` and bumps `attendee_profiles.total_challenges_completed`.
+- **Leaderboards:** per-event and global (`LeaderboardController`).
+- **Badges:** system badge list + my badges (`BadgeController`). Awarded by `BadgeService` on milestone thresholds (e.g. `BadgeMilestoneType::LoyalAttendee` triggers at `total_events_attended >= milestone_value`).
+- **Reward wallet:** `GET /me/rewards`, redemption flow (`RewardWalletController`).
+
+**Points & money**
+- `point_ledger` is append-only with `event_type` enum (`CollaborationComplete`, `FirstKolabBonus`, `ReviewPosted`, `UgcPosted`, `ReferralConversion`, `Withdrawal`). Attendees accrue points via `CheckinService`, `ChallengeCompletionService`, and `BadgeService`.
+- `wallets` and `withdrawal_requests` exist with `profile_id` FK — **[VERIFY] with Daniel** whether attendees can actually withdraw cash, or whether withdrawals are community-only (the `ROLES-AND-PERMISSIONS.md §3.5` mentions €0.25/point with €75 threshold for the community side; the attendee equivalent is unspecified).
+
+**What attendees CANNOT do (confirmed by code paths)**
+- Create kolabs or opportunities (creator-resolution paths route to business / community profiles only).
+- Apply to kolabs (no `applicant_profile_type = attendee` exists in `applications.applicant_profile_type` enum).
+- Subscribe (attendees are not businesses; the paywall and grant routes both reject non-business profiles).
+- Chat (chat is between matched business and community on an accepted application).
+
+**Outstanding decisions for the user**
+- Are attendees in launch scope? (Code says yes — endpoints are live. Spec says no.)
+- Pricing model? (Code currently treats attendees as free — no paywall, no subscription path. Confirm intentional.)
+- Should attendee gamification credits convert to real money via `wallets` + `withdrawal_requests`, or is that community-only?
+- Should the canonical permissions doc grow a full §4 covering attendees, replacing the "deferred" stub?
+
+Until those are resolved, treat this section as the source of truth for what attendees can do, and treat `ROLES-AND-PERMISSIONS.md §0` (attendee = deferred) as **stale**.


### PR DESCRIPTION
## Summary
Bring `docs/ROLES-AND-PERMISSIONS.md` and `docs/ROLES-BACKEND-DB-MAP.md` current. Both were last touched 2026-05-22; substantial role-affecting code has shipped since (admin operator surfaces, lifecycle timestamps, maintainer-granted subscriptions). Code is unchanged in this PR — docs only.

### Fixed-since-last-revision (now reflected in the docs)
- `KolabService::publish` gated by `isBusiness()` (line 190).
- `ProfileService::deleteProfile` frees the email, closes posts on both systems, cancels active collaborations, revokes tokens.
- `PublicProfileResource` serializes logos as absolute URLs via a helper.

### Still open (now in the mistakes-to-fix checklist)
- `DiscoveryOpportunityResource` still returns full identity to every viewer — the **blur still doesn't exist** server-side.
- `coliving` is in the spec but not in `BusinessOnboardingRequest::BUSINESS_TYPES`.
- `Admin\ManagedUserController::destroy()` is a bare soft-delete and bypasses the cleanup the user-facing delete runs.

### New surfaces documented
- **Maintainer-granted subscriptions** (`SubscriptionSource::Maintainer`, `/admin/users/{p}/subscription/grant|revoke`).
- **Admin operator routes** including force-cancel collaboration with reason.
- **Lifecycle observability columns** (`accepted_at/declined_at/withdrawn_at`, `activated_at/cancelled_at/cancellation_reason/cancelled_by_profile_id`, `profiles.last_active_at`) + the `TouchProfileActivity` middleware.
- **`is_test_user` backdoor** on `hasActiveSubscription()`.
- **`LegacyOpportunityBridgeService`** — explains why `kolab.id == collab_opportunity.id`.

### Schema-map corrections
- `business_subscriptions` has **no `trial`** status. Real values: `active/cancelled/past_due/inactive`.
- `business_subscriptions` has no `plan_type` / `renews_at` columns. Actual columns + the new `source` enum (stripe/apple_iap/**maintainer**) are now in the map.

### Attendee role — first pass added
The attendee gamification track (check-ins, challenges, badges, leaderboards, reward wallet) is fully shipped in the backend, but the canonical doc still labelled attendees "deferred / out of scope." Added `§7` to `ROLES-AND-PERMISSIONS.md` and `§11` to `ROLES-BACKEND-DB-MAP.md` capturing what attendees can/cannot do today, with explicit `[VERIFY]` markers for the decisions still pending: launch scope, pricing model, and whether the attendee wallet redeems to cash.

### `CLAUDE.md` connection tightened
- MUST READ list now explicitly includes admin surfaces, attendees, and subscription state.
- New **Update rule** makes it non-optional to bump dates and adjust both docs in the same PR that touches role behaviour.
- Explicit call-out about mirroring into `kolabing-app`.
- A matching `§8 Maintaining this document` block at the end of `ROLES-AND-PERMISSIONS.md` codifies the workflow.

## Test plan
- [x] No code changed — 52 admin/application/lifecycle tests still pass.
- [x] No broken cross-references in either doc.
- [ ] Manual: resolve the `[VERIFY]` items on attendees (scope, pricing, withdrawal) with Daniel.
- [ ] Mirror the changes into the `kolabing-app` repo's copies of both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)