### PR TITLE
feat(collaborations): forced rich feedback gates completion + admin force-complete + mirror

### DIFF
--- a/app/Console/Commands/AutoCompleteStaleCollaborations.php
+++ b/app/Console/Commands/AutoCompleteStaleCollaborations.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\CollaborationStatus;
+use App\Models\Collaboration;
+use App\Models\CollaborationFeedback;
+use App\Services\CollaborationService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class AutoCompleteStaleCollaborations extends Command
+{
+    protected $signature = 'app:auto-complete-stale-collaborations {--dry-run : Report what would be completed without writing}';
+
+    protected $description = 'Auto-complete scheduled/active collaborations whose scheduled_date passed the configured threshold and have at least one feedback row.';
+
+    public function handle(CollaborationService $collaborations): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $thresholdDays = (int) config('collaborations.auto_complete_threshold_days', 7);
+        $requireFeedback = (bool) config('collaborations.auto_complete_requires_feedback_rows', true);
+
+        $cutoff = Carbon::now()->subDays($thresholdDays)->toDateString();
+
+        $query = Collaboration::query()
+            ->whereIn('status', [
+                CollaborationStatus::Scheduled->value,
+                CollaborationStatus::Active->value,
+            ])
+            ->whereNotNull('scheduled_date')
+            ->where('scheduled_date', '<=', $cutoff);
+
+        if ($requireFeedback) {
+            $query->whereIn('id', CollaborationFeedback::query()->select('collaboration_id'));
+        }
+
+        $candidates = $query->get();
+
+        if ($candidates->isEmpty()) {
+            $this->info('No stale collaborations to auto-complete.');
+
+            return self::SUCCESS;
+        }
+
+        $completed = 0;
+        foreach ($candidates as $collaboration) {
+            if ($dryRun) {
+                $this->line(sprintf('[dry] would auto-complete %s (scheduled %s)', $collaboration->id, $collaboration->scheduled_date?->toDateString() ?? '—'));
+                $completed++;
+
+                continue;
+            }
+
+            try {
+                $collaborations->autoComplete($collaboration);
+                $completed++;
+            } catch (\Throwable $e) {
+                $this->warn(sprintf('Skipped %s: %s', $collaboration->id, $e->getMessage()));
+            }
+        }
+
+        $this->info(sprintf('%s %d collaboration(s).', $dryRun ? '[dry] would complete' : 'Completed', $completed));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Exceptions/CollaborationException.php
+++ b/app/Exceptions/CollaborationException.php
@@ -93,4 +93,61 @@ class CollaborationException extends Exception
             Response::HTTP_CONFLICT,
         );
     }
+
+    public static function notAParticipant(): self
+    {
+        return new self(
+            __('You are not a participant in this collaboration.'),
+            Response::HTTP_FORBIDDEN,
+            ['error_code' => 'not_a_participant'],
+        );
+    }
+
+    public static function feedbackAlreadySubmitted(): self
+    {
+        return new self(
+            __('Feedback already submitted for this collaboration.'),
+            Response::HTTP_CONFLICT,
+            ['error_code' => 'feedback_already_submitted'],
+        );
+    }
+
+    public static function feedbackNotYetSubmitted(): self
+    {
+        return new self(
+            __('No feedback row exists to update for this collaboration.'),
+            Response::HTTP_NOT_FOUND,
+            ['error_code' => 'feedback_not_yet_submitted'],
+        );
+    }
+
+    public static function feedbackLocked(): self
+    {
+        return new self(
+            __('Feedback can no longer be edited because the partner has submitted theirs.'),
+            Response::HTTP_LOCKED,
+            ['error_code' => 'feedback_locked'],
+        );
+    }
+
+    public static function awaitingOwnFeedback(): self
+    {
+        return new self(
+            __('Submit your feedback before completing the collaboration.'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            ['error_code' => 'awaiting_own_feedback'],
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $pendingRoles
+     */
+    public static function awaitingPartnerFeedback(array $pendingRoles): self
+    {
+        return new self(
+            __('Waiting on the other party to submit their feedback.'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            ['error_code' => 'awaiting_partner_feedback', 'pending_feedback_from' => $pendingRoles],
+        );
+    }
 }

--- a/app/Http/Controllers/Admin/KolabController.php
+++ b/app/Http/Controllers/Admin/KolabController.php
@@ -8,6 +8,7 @@ use App\Enums\ApplicationStatus;
 use App\Enums\KolabStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\CancelKolabCollaborationRequest;
+use App\Http\Requests\Admin\CompleteKolabCollaborationRequest;
 use App\Http\Requests\Admin\UpdateKolabRequest;
 use App\Models\Application;
 use App\Models\Collaboration;
@@ -122,5 +123,20 @@ class KolabController extends Controller
         return redirect()
             ->route('admin.kolabs.edit', $kolab)
             ->with('status', __('Collaboration cancelled.'));
+    }
+
+    public function completeCollaboration(CompleteKolabCollaborationRequest $request, Kolab $kolab): RedirectResponse
+    {
+        $collaboration = Collaboration::query()
+            ->where('collab_opportunity_id', $kolab->id)
+            ->first();
+
+        abort_if($collaboration === null, 404, 'No collaboration to complete for this Kolab.');
+
+        $this->collaborations->adminForceComplete($collaboration, $request->validated('reason'));
+
+        return redirect()
+            ->route('admin.kolabs.edit', $kolab)
+            ->with('status', __('Collaboration force-completed.'));
     }
 }

--- a/app/Http/Controllers/Api/V1/CollaborationController.php
+++ b/app/Http/Controllers/Api/V1/CollaborationController.php
@@ -9,12 +9,15 @@ use App\Exceptions\CollaborationException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CancelCollaborationRequest;
 use App\Http\Requests\Api\V1\CompleteCollaborationRequest;
+use App\Http\Requests\Api\V1\StoreCollaborationFeedbackRequest;
 use App\Http\Requests\Api\V1\StoreCollaborationReviewRequest;
+use App\Http\Requests\Api\V1\UpdateCollaborationFeedbackRequest;
 use App\Http\Resources\Api\V1\CollaborationCollection;
 use App\Http\Resources\Api\V1\CollaborationResource;
 use App\Models\Collaboration;
 use App\Models\CollaborationReview;
 use App\Models\Profile;
+use App\Services\CollaborationFeedbackService;
 use App\Services\CollaborationService;
 use App\Services\GamificationWalletService;
 use Illuminate\Http\JsonResponse;
@@ -25,6 +28,7 @@ class CollaborationController extends Controller
     public function __construct(
         private readonly CollaborationService $collaborationService,
         private readonly GamificationWalletService $gamificationService,
+        private readonly CollaborationFeedbackService $feedbackService,
     ) {}
 
     /**
@@ -126,14 +130,19 @@ class CollaborationController extends Controller
         $this->authorize('complete', $collaboration);
         $request->validated();
 
+        /** @var Profile $caller */
+        $caller = $request->user();
+
         try {
-            $collaboration = $this->collaborationService->complete($collaboration);
+            $collaboration = $this->collaborationService->complete($collaboration, $caller);
         } catch (CollaborationException $e) {
+            $context = $e->getContext();
+
             return response()->json([
                 'success' => false,
                 'message' => $e->getMessage(),
-                'error_code' => 'invalid_status_transition',
-                'errors' => $e->getContext(),
+                'error_code' => $context['error_code'] ?? 'invalid_status_transition',
+                'errors' => $context,
             ], $e->getStatusCode());
         }
 
@@ -141,6 +150,76 @@ class CollaborationController extends Controller
             'success' => true,
             'message' => __('collaboration.completed'),
             'data' => new CollaborationResource($collaboration),
+        ]);
+    }
+
+    /**
+     * Submit the caller's rich completion feedback. Per the 2026-06-01 feedback
+     * gate plan (§Q7): XP fires per party here, not on /complete.
+     *
+     * POST /api/v1/collaborations/{collaboration}/feedback
+     */
+    public function feedback(
+        StoreCollaborationFeedbackRequest $request,
+        Collaboration $collaboration,
+    ): JsonResponse {
+        /** @var Profile $reviewer */
+        $reviewer = $request->user();
+
+        $this->authorize('view', $collaboration);
+
+        try {
+            $feedback = $this->feedbackService->submit($collaboration, $reviewer, $request->validated());
+        } catch (CollaborationException $e) {
+            $context = $e->getContext();
+
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                'error_code' => $context['error_code'] ?? 'feedback_error',
+                'errors' => $context,
+            ], $e->getStatusCode());
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => __('Feedback submitted.'),
+            'data' => $feedback,
+        ], 201);
+    }
+
+    /**
+     * Edit the caller's existing feedback row. Allowed only while the partner
+     * has NOT yet submitted their own — once both rows exist, both lock.
+     *
+     * PUT /api/v1/collaborations/{collaboration}/feedback
+     */
+    public function updateFeedback(
+        UpdateCollaborationFeedbackRequest $request,
+        Collaboration $collaboration,
+    ): JsonResponse {
+        /** @var Profile $reviewer */
+        $reviewer = $request->user();
+
+        $this->authorize('view', $collaboration);
+
+        try {
+            $feedback = $this->feedbackService->edit($collaboration, $reviewer, $request->validated());
+        } catch (CollaborationException $e) {
+            $context = $e->getContext();
+
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+                'error_code' => $context['error_code'] ?? 'feedback_error',
+                'errors' => $context,
+            ], $e->getStatusCode());
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => __('Feedback updated.'),
+            'data' => $feedback,
         ]);
     }
 
@@ -200,11 +279,16 @@ class CollaborationController extends Controller
 
         $this->authorize('view', $collaboration);
 
-        if (! $collaboration->isCompleted()) {
+        // Reviews used to require completed status. Relaxed to active|completed
+        // so a legacy client (which calls /review before /complete) can write a
+        // review that the mirror promotes into a stub /feedback row — letting
+        // the new gate succeed. Scheduled and cancelled collabs remain out of
+        // scope.
+        if (! ($collaboration->isCompleted() || $collaboration->isActive())) {
             return response()->json([
                 'success' => false,
-                'message' => 'Reviews can only be left for completed collaborations.',
-                'error_code' => 'collaboration_not_completed',
+                'message' => 'Reviews can only be left for active or completed collaborations.',
+                'error_code' => 'collaboration_not_reviewable',
             ], 422);
         }
 
@@ -261,6 +345,15 @@ class CollaborationController extends Controller
             $collaboration->id,
             'Left a review for a completed Kolab',
         );
+
+        // Mirror the review into a stub /feedback row so legacy clients still
+        // satisfy the new /complete gate. No-op if a real /feedback row already
+        // exists (post-mirror, post-new-app user).
+        $this->feedbackService->mirrorFromReview($collaboration, $reviewer, [
+            'rating' => $validated['rating'],
+            'body' => $validated['body'] ?? null,
+            'would_collaborate_again' => $validated['would_collaborate_again'] ?? null,
+        ]);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Requests/Admin/CompleteKolabCollaborationRequest.php
+++ b/app/Http/Requests/Admin/CompleteKolabCollaborationRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CompleteKolabCollaborationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'min:3', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreCollaborationFeedbackRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCollaborationFeedbackRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\Profile;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class StoreCollaborationFeedbackRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        /** @var Profile|null $reviewer */
+        $reviewer = $this->user();
+        $isBusiness = $reviewer?->isBusiness() ?? false;
+
+        return [
+            'rating' => ['required', 'integer', 'between:1,5'],
+            'expectation_match' => ['required', 'boolean'],
+            'would_recommend' => ['required', 'boolean'],
+            'posts_reels' => ['nullable', 'integer', 'min:0', 'max:10000'],
+
+            // Business-only.
+            'stories_posted' => [$isBusiness ? 'nullable' : 'prohibited', 'integer', 'min:0', 'max:10000'],
+            'revenue' => [$isBusiness ? 'nullable' : 'prohibited', 'numeric', 'min:0', 'max:9999999.99'],
+
+            // Community-only.
+            'benefits' => [$isBusiness ? 'prohibited' : 'nullable', 'string', 'max:2000'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'stories_posted.prohibited' => 'Only business users can submit `stories_posted`.',
+            'revenue.prohibited' => 'Only business users can submit `revenue`.',
+            'benefits.prohibited' => 'Only community users can submit `benefits`.',
+        ];
+    }
+
+    /**
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): never
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => __('Validation failed'),
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateCollaborationFeedbackRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateCollaborationFeedbackRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\Profile;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Same shape as Store, but every field is optional on PUT — the caller may
+ * be correcting a single field. Role-only fields stay role-locked.
+ */
+class UpdateCollaborationFeedbackRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        /** @var Profile|null $reviewer */
+        $reviewer = $this->user();
+        $isBusiness = $reviewer?->isBusiness() ?? false;
+
+        return [
+            'rating' => ['sometimes', 'integer', 'between:1,5'],
+            'expectation_match' => ['sometimes', 'boolean'],
+            'would_recommend' => ['sometimes', 'boolean'],
+            'posts_reels' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:10000'],
+
+            'stories_posted' => [$isBusiness ? 'sometimes' : 'prohibited', 'nullable', 'integer', 'min:0', 'max:10000'],
+            'revenue' => [$isBusiness ? 'sometimes' : 'prohibited', 'nullable', 'numeric', 'min:0', 'max:9999999.99'],
+
+            'benefits' => [$isBusiness ? 'prohibited' : 'sometimes', 'nullable', 'string', 'max:2000'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'stories_posted.prohibited' => 'Only business users can submit `stories_posted`.',
+            'revenue.prohibited' => 'Only business users can submit `revenue`.',
+            'benefits.prohibited' => 'Only community users can submit `benefits`.',
+        ];
+    }
+
+    /**
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): never
+    {
+        throw new HttpResponseException(response()->json([
+            'success' => false,
+            'message' => __('Validation failed'),
+            'errors' => $validator->errors(),
+        ], 422));
+    }
+}

--- a/app/Http/Resources/Api/V1/CollaborationResource.php
+++ b/app/Http/Resources/Api/V1/CollaborationResource.php
@@ -6,7 +6,9 @@ namespace App\Http\Resources\Api\V1;
 
 use App\Enums\CollaborationStatus;
 use App\Models\Collaboration;
+use App\Models\CollaborationFeedback;
 use App\Models\CollaborationReview;
+use App\Services\CollaborationFeedbackService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -97,6 +99,13 @@ class CollaborationResource extends JsonResource
                 return $this->challenges->pluck('id')->values();
             }),
             'completed_at' => $this->completed_at?->toIso8601String(),
+            'completion_reason' => $this->completion_reason,
+            'completed_by_profile_id' => $this->completed_by_profile_id,
+            'auto_completed_at' => $this->auto_completed_at?->toIso8601String(),
+            'pending_feedback_from' => $this->pendingFeedbackFrom(),
+            'viewer_must_submit_feedback' => $this->viewerMustSubmitFeedback($currentProfile),
+            'own_feedback' => $this->ownFeedback($currentProfile),
+            'partner_feedback' => $this->partnerFeedback($currentProfile),
             'reviews' => $this->whenLoaded('reviews', function () {
                 return $this->reviews->map(fn ($review): array => [
                     'reviewer_role' => $review->reviewer_role,
@@ -180,5 +189,111 @@ class CollaborationResource extends JsonResource
         }
 
         return null;
+    }
+
+    /**
+     * Cache and return the feedback rows for this collaboration.
+     *
+     * @return \Illuminate\Support\Collection<int, CollaborationFeedback>
+     */
+    private function feedbackRows(): \Illuminate\Support\Collection
+    {
+        /** @var \Illuminate\Support\Collection<int, CollaborationFeedback>|null $cached */
+        static $cache = [];
+
+        if (! isset($cache[$this->id])) {
+            $cache[$this->id] = CollaborationFeedback::query()
+                ->where('collaboration_id', $this->id)
+                ->get();
+        }
+
+        return $cache[$this->id];
+    }
+
+    /**
+     * Reviewer types ('business' | 'community') of participants who have NOT
+     * yet submitted feedback. Mirrored stubs count as submitted.
+     *
+     * @return array<int, string>
+     */
+    private function pendingFeedbackFrom(): array
+    {
+        /** @var Collaboration $collab */
+        $collab = $this->resource;
+
+        return app(CollaborationFeedbackService::class)->pendingFeedbackFrom($collab);
+    }
+
+    /**
+     * @param  \App\Models\Profile|null  $profile
+     */
+    private function viewerMustSubmitFeedback($profile): bool
+    {
+        if ($profile === null) {
+            return false;
+        }
+
+        return in_array($profile->user_type->value, $this->pendingFeedbackFrom(), true);
+    }
+
+    /**
+     * The caller's own feedback row, in full (including private fields).
+     *
+     * @param  \App\Models\Profile|null  $profile
+     * @return array<string, mixed>|null
+     */
+    private function ownFeedback($profile): ?array
+    {
+        if ($profile === null) {
+            return null;
+        }
+
+        $row = $this->feedbackRows()->firstWhere('reviewer_profile_id', $profile->id);
+        if ($row === null) {
+            return null;
+        }
+
+        return [
+            'id' => $row->id,
+            'reviewer_role' => $row->reviewer_role,
+            'reviewer_type' => $row->reviewer_type,
+            'rating' => $row->rating,
+            'expectation_match' => $row->expectation_match,
+            'would_recommend' => $row->would_recommend,
+            'posts_reels' => $row->posts_reels,
+            'stories_posted' => $row->stories_posted,
+            'revenue' => $row->revenue,
+            'benefits' => $row->benefits,
+            'mirrored_from_review' => $row->mirrored_from_review,
+            'created_at' => $row->created_at?->toIso8601String(),
+            'updated_at' => $row->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * The partner's feedback — public subset only — and only when BOTH parties
+     * have a non-mirrored row (Q10). Mirrored stubs do not unlock cross-visibility.
+     *
+     * @param  \App\Models\Profile|null  $profile
+     * @return array<string, mixed>|null
+     */
+    private function partnerFeedback($profile): ?array
+    {
+        if ($profile === null) {
+            return null;
+        }
+
+        $rows = $this->feedbackRows();
+        $real = $rows->where('mirrored_from_review', false);
+        if ($real->count() < 2) {
+            return null;
+        }
+
+        $partner = $real->first(fn (CollaborationFeedback $row): bool => $row->reviewer_profile_id !== $profile->id);
+        if ($partner === null) {
+            return null;
+        }
+
+        return $partner->publicSubset();
     }
 }

--- a/app/Models/Collaboration.php
+++ b/app/Models/Collaboration.php
@@ -59,6 +59,9 @@ class Collaboration extends Model
         'scheduled_date',
         'activated_at',
         'completed_at',
+        'completion_reason',
+        'completed_by_profile_id',
+        'auto_completed_at',
         'cancelled_at',
         'cancellation_reason',
         'cancelled_by_profile_id',
@@ -79,6 +82,7 @@ class Collaboration extends Model
             'scheduled_date' => 'date',
             'activated_at' => 'datetime',
             'completed_at' => 'datetime',
+            'auto_completed_at' => 'datetime',
             'cancelled_at' => 'datetime',
             'contact_methods' => 'array',
         ];
@@ -173,6 +177,16 @@ class Collaboration extends Model
     public function reviews(): HasMany
     {
         return $this->hasMany(CollaborationReview::class);
+    }
+
+    /**
+     * Get the rich feedback rows submitted by participants for this collaboration.
+     *
+     * @return HasMany<CollaborationFeedback, $this>
+     */
+    public function feedbacks(): HasMany
+    {
+        return $this->hasMany(CollaborationFeedback::class);
     }
 
     /**

--- a/app/Models/CollaborationFeedback.php
+++ b/app/Models/CollaborationFeedback.php
@@ -20,11 +20,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $reviewer_role
  * @property int $rating
  * @property int|null $posts_reels
- * @property bool $expectation_match
- * @property bool $would_recommend
+ * @property bool|null $expectation_match
+ * @property bool|null $would_recommend
  * @property int|null $stories_posted
  * @property string|null $revenue
  * @property string|null $benefits
+ * @property bool $mirrored_from_review
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read Collaboration $collaboration
@@ -60,6 +61,7 @@ class CollaborationFeedback extends Model
         'stories_posted',
         'revenue',
         'benefits',
+        'mirrored_from_review',
     ];
 
     /**
@@ -76,6 +78,22 @@ class CollaborationFeedback extends Model
             'would_recommend' => 'boolean',
             'stories_posted' => 'integer',
             'revenue' => 'decimal:2',
+            'mirrored_from_review' => 'boolean',
+        ];
+    }
+
+    /**
+     * Cross-visible subset of the feedback that the partner can see once both
+     * rows exist. See ROLES-AND-PERMISSIONS.md §4 (Q10 in the design plan).
+     *
+     * @return array<string, mixed>
+     */
+    public function publicSubset(): array
+    {
+        return [
+            'rating' => $this->rating,
+            'expectation_match' => $this->expectation_match,
+            'would_recommend' => $this->would_recommend,
         ];
     }
 

--- a/app/Services/CollaborationFeedbackService.php
+++ b/app/Services/CollaborationFeedbackService.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\PointEventType;
+use App\Exceptions\CollaborationException;
+use App\Models\Collaboration;
+use App\Models\CollaborationFeedback;
+use App\Models\Profile;
+use Illuminate\Support\Facades\DB;
+
+class CollaborationFeedbackService
+{
+    public function __construct(
+        private readonly GamificationWalletService $walletService,
+    ) {}
+
+    /**
+     * Submit the caller's rich feedback row. Awards XP on first submission.
+     * If a mirrored stub already exists for this caller, this upgrades it in
+     * place (without re-awarding XP) — the rich-fields just fill in.
+     *
+     * @param  array<string, mixed>  $payload  Validated feedback fields.
+     *
+     * @throws CollaborationException
+     */
+    public function submit(Collaboration $collaboration, Profile $reviewer, array $payload): CollaborationFeedback
+    {
+        $role = $this->resolveReviewerRole($collaboration, $reviewer);
+
+        if ($role === null) {
+            throw CollaborationException::notAParticipant();
+        }
+
+        $existing = $this->ownRow($collaboration, $reviewer);
+
+        if ($existing !== null && ! $existing->mirrored_from_review) {
+            throw CollaborationException::feedbackAlreadySubmitted();
+        }
+
+        return DB::transaction(function () use ($collaboration, $reviewer, $payload, $role, $existing): CollaborationFeedback {
+            $attributes = $this->attributesForRole($reviewer, $payload);
+            $attributes['reviewer_role'] = $role;
+            $attributes['reviewer_type'] = $reviewer->user_type->value;
+            $attributes['mirrored_from_review'] = false;
+
+            if ($existing !== null) {
+                $existing->fill($attributes);
+                $existing->save();
+
+                return $existing->fresh();
+            }
+
+            $feedback = CollaborationFeedback::create(array_merge($attributes, [
+                'collaboration_id' => $collaboration->id,
+                'reviewer_profile_id' => $reviewer->id,
+            ]));
+
+            // Per Q7: XP fires per party on /feedback POST, not on /complete.
+            $this->walletService->awardPoints(
+                $reviewer->id,
+                PointEventType::CollaborationComplete->defaultPoints(),
+                PointEventType::CollaborationComplete,
+                $collaboration->id,
+                'Submitted collaboration feedback',
+            );
+
+            return $feedback;
+        });
+    }
+
+    /**
+     * Update the caller's existing feedback row. Only permitted while the
+     * partner has NOT yet submitted their own row.
+     *
+     * @param  array<string, mixed>  $payload
+     *
+     * @throws CollaborationException
+     */
+    public function edit(Collaboration $collaboration, Profile $reviewer, array $payload): CollaborationFeedback
+    {
+        $role = $this->resolveReviewerRole($collaboration, $reviewer);
+
+        if ($role === null) {
+            throw CollaborationException::notAParticipant();
+        }
+
+        $existing = $this->ownRow($collaboration, $reviewer);
+
+        if ($existing === null) {
+            throw CollaborationException::feedbackNotYetSubmitted();
+        }
+
+        if ($this->partnerRow($collaboration, $reviewer) !== null) {
+            throw CollaborationException::feedbackLocked();
+        }
+
+        $attributes = $this->attributesForRole($reviewer, $payload);
+        $attributes['mirrored_from_review'] = false;
+
+        $existing->fill($attributes);
+        $existing->save();
+
+        return $existing->fresh();
+    }
+
+    /**
+     * Create a minimal stub feedback row from a legacy /review payload, so the
+     * /complete gate can succeed for clients that haven't migrated to the rich
+     * /feedback endpoint. No-op if the caller already has any feedback row.
+     *
+     * No XP is awarded here — the review controller already awards
+     * ReviewPosted XP for the review itself; the stub is purely for the gate.
+     *
+     * @param  array{rating: int, body?: string|null, would_collaborate_again?: bool|null}  $reviewPayload
+     */
+    public function mirrorFromReview(Collaboration $collaboration, Profile $reviewer, array $reviewPayload): ?CollaborationFeedback
+    {
+        $role = $this->resolveReviewerRole($collaboration, $reviewer);
+
+        if ($role === null) {
+            return null;
+        }
+
+        if ($this->ownRow($collaboration, $reviewer) !== null) {
+            return null;
+        }
+
+        $attributes = [
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $reviewer->id,
+            'reviewer_type' => $reviewer->user_type->value,
+            'reviewer_role' => $role,
+            'rating' => $reviewPayload['rating'],
+            'would_recommend' => $reviewPayload['would_collaborate_again'] ?? null,
+            'expectation_match' => null,
+            'mirrored_from_review' => true,
+        ];
+
+        if ($reviewer->isCommunity() && isset($reviewPayload['body'])) {
+            $attributes['benefits'] = $reviewPayload['body'];
+        }
+
+        return CollaborationFeedback::create($attributes);
+    }
+
+    /**
+     * Reviewer types ('business' | 'community') of participants who have NOT
+     * yet submitted feedback. Mirrored stubs count as submitted (the row
+     * exists, so the gate doesn't block).
+     *
+     * Driven by the creator + applicant profiles' user_type — robust to the
+     * `business_profile_id` / `community_profile_id` columns being null (they
+     * can be when an extended profile row isn't filled in yet).
+     *
+     * @return array<int, string> Subset of ['business', 'community'].
+     */
+    public function pendingFeedbackFrom(Collaboration $collaboration): array
+    {
+        $collaboration->loadMissing(['creatorProfile', 'applicantProfile']);
+
+        $participantTypes = collect([
+            $collaboration->creatorProfile?->user_type?->value,
+            $collaboration->applicantProfile?->user_type?->value,
+        ])->filter()->unique()->values()->all();
+
+        $submittedTypes = CollaborationFeedback::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->pluck('reviewer_type')
+            ->all();
+
+        return array_values(array_diff($participantTypes, $submittedTypes));
+    }
+
+    /**
+     * Number of feedback rows (including mirrored stubs) attached to this
+     * collaboration. Used by the auto-timeout scheduler.
+     */
+    public function feedbackCount(Collaboration $collaboration): int
+    {
+        return CollaborationFeedback::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->count();
+    }
+
+    public function ownRow(Collaboration $collaboration, Profile $reviewer): ?CollaborationFeedback
+    {
+        return CollaborationFeedback::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $reviewer->id)
+            ->first();
+    }
+
+    public function partnerRow(Collaboration $collaboration, Profile $reviewer): ?CollaborationFeedback
+    {
+        return CollaborationFeedback::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', '!=', $reviewer->id)
+            ->first();
+    }
+
+    private function resolveReviewerRole(Collaboration $collaboration, Profile $reviewer): ?string
+    {
+        return match (true) {
+            $reviewer->id === $collaboration->creator_profile_id => 'creator',
+            $reviewer->id === $collaboration->applicant_profile_id => 'applicant',
+            default => null,
+        };
+    }
+
+    /**
+     * Drop fields the reviewer's role isn't allowed to set. The FormRequest
+     * already 422s on these, but defence-in-depth on the service side too.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function attributesForRole(Profile $reviewer, array $payload): array
+    {
+        $shared = [
+            'rating' => $payload['rating'] ?? null,
+            'expectation_match' => $payload['expectation_match'] ?? null,
+            'would_recommend' => $payload['would_recommend'] ?? null,
+            'posts_reels' => $payload['posts_reels'] ?? null,
+        ];
+
+        if ($reviewer->isBusiness()) {
+            return array_merge($shared, [
+                'stories_posted' => $payload['stories_posted'] ?? null,
+                'revenue' => $payload['revenue'] ?? null,
+                'benefits' => null,
+            ]);
+        }
+
+        return array_merge($shared, [
+            'stories_posted' => null,
+            'revenue' => null,
+            'benefits' => $payload['benefits'] ?? null,
+        ]);
+    }
+}

--- a/app/Services/CollaborationService.php
+++ b/app/Services/CollaborationService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\CollaborationStatus;
-use App\Enums\PointEventType;
 use App\Exceptions\CollaborationException;
 use App\Models\Application;
 use App\Models\Collaboration;
@@ -19,7 +18,8 @@ use Illuminate\Support\Facades\DB;
 class CollaborationService
 {
     public function __construct(
-        private readonly GamificationWalletService $walletService
+        private readonly GamificationWalletService $walletService,
+        private readonly CollaborationFeedbackService $feedbackService,
     ) {}
 
     /**
@@ -107,11 +107,17 @@ class CollaborationService
     }
 
     /**
-     * Complete an active collaboration.
+     * Complete an active collaboration. The caller must have submitted their
+     * own feedback row and the partner must have too. XP is NOT awarded here
+     * — each party's CollaborationComplete XP fires when they POST /feedback.
+     *
+     * Gating can be disabled via the `collaborations.complete_requires_feedback`
+     * config (true by default) — provides a soft-rollout knob if a mobile
+     * cutover regresses.
      *
      * @throws CollaborationException
      */
-    public function complete(Collaboration $collaboration): Collaboration
+    public function complete(Collaboration $collaboration, ?Profile $caller = null): Collaboration
     {
         if ($collaboration->isInTerminalState()) {
             throw CollaborationException::alreadyInTerminalState($collaboration->status->value);
@@ -121,13 +127,14 @@ class CollaborationService
             throw CollaborationException::cannotComplete($collaboration->status->value);
         }
 
+        if (config('collaborations.complete_requires_feedback', true) === true) {
+            $this->enforceFeedbackGate($collaboration, $caller);
+        }
+
         $collaboration->update([
             'status' => CollaborationStatus::Completed,
             'completed_at' => Carbon::now(),
         ]);
-
-        // Award points to both parties
-        $this->awardCollaborationPoints($collaboration);
 
         return $collaboration->fresh([
             'collabOpportunity',
@@ -135,6 +142,77 @@ class CollaborationService
             'applicantProfile',
             'application',
         ]);
+    }
+
+    /**
+     * Maintainer-only escape hatch. Force-completes a collaboration without
+     * the feedback gate, recording the reason for the admin audit trail.
+     * No XP is awarded — by design, force-complete bypasses the participation
+     * reward path.
+     */
+    public function adminForceComplete(Collaboration $collaboration, string $reason): Collaboration
+    {
+        if ($collaboration->isInTerminalState()) {
+            throw CollaborationException::alreadyInTerminalState($collaboration->status->value);
+        }
+
+        $collaboration->update([
+            'status' => CollaborationStatus::Completed,
+            'completed_at' => Carbon::now(),
+            'completion_reason' => $reason,
+            'completed_by_profile_id' => null,
+        ]);
+
+        return $collaboration->fresh([
+            'collabOpportunity',
+            'creatorProfile',
+            'applicantProfile',
+            'application',
+        ]);
+    }
+
+    /**
+     * Scheduled-command path. Used by app:auto-complete-stale-collaborations
+     * when scheduled_date + threshold has passed AND at least one feedback
+     * row exists. Sets auto_completed_at as the audit marker.
+     */
+    public function autoComplete(Collaboration $collaboration): Collaboration
+    {
+        if ($collaboration->isInTerminalState()) {
+            throw CollaborationException::alreadyInTerminalState($collaboration->status->value);
+        }
+
+        $now = Carbon::now();
+        $collaboration->update([
+            'status' => CollaborationStatus::Completed,
+            'completed_at' => $now,
+            'auto_completed_at' => $now,
+        ]);
+
+        return $collaboration->fresh([
+            'collabOpportunity',
+            'creatorProfile',
+            'applicantProfile',
+            'application',
+        ]);
+    }
+
+    /**
+     * @throws CollaborationException
+     */
+    private function enforceFeedbackGate(Collaboration $collaboration, ?Profile $caller): void
+    {
+        $pending = $this->feedbackService->pendingFeedbackFrom($collaboration);
+
+        if ($pending === []) {
+            return;
+        }
+
+        if ($caller !== null && in_array($caller->user_type->value, $pending, true)) {
+            throw CollaborationException::awaitingOwnFeedback();
+        }
+
+        throw CollaborationException::awaitingPartnerFeedback($pending);
     }
 
     /**
@@ -308,30 +386,5 @@ class CollaborationService
         }
 
         return null;
-    }
-
-    /**
-     * Award collaboration completion points to both parties.
-     */
-    private function awardCollaborationPoints(Collaboration $collaboration): void
-    {
-        $collaboration->loadMissing(['collabOpportunity']);
-        $title = $collaboration->collabOpportunity?->title ?? 'a collaboration';
-
-        $this->walletService->awardPoints(
-            $collaboration->creator_profile_id,
-            PointEventType::CollaborationComplete->defaultPoints(),
-            PointEventType::CollaborationComplete,
-            $collaboration->id,
-            "Collaboration completed: {$title}"
-        );
-
-        $this->walletService->awardPoints(
-            $collaboration->applicant_profile_id,
-            PointEventType::CollaborationComplete->defaultPoints(),
-            PointEventType::CollaborationComplete,
-            $collaboration->id,
-            "Collaboration completed: {$title}"
-        );
     }
 }

--- a/config/collaborations.php
+++ b/config/collaborations.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Feedback gate on /complete
+    |--------------------------------------------------------------------------
+    |
+    | When true (default), POST /api/v1/collaborations/{id}/complete refuses to
+    | transition status -> completed until both participants have a
+    | collaboration_feedback row. Soft-rollout knob: flip via env var
+    | COLLABORATIONS_COMPLETE_REQUIRES_FEEDBACK=false if a mobile cutover
+    | regresses and you need the gate temporarily off.
+    |
+    */
+    'complete_requires_feedback' => env('COLLABORATIONS_COMPLETE_REQUIRES_FEEDBACK', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-completion window
+    |--------------------------------------------------------------------------
+    |
+    | The scheduled command app:auto-complete-stale-collaborations completes
+    | collabs where scheduled_date + days threshold has passed AND at least one
+    | feedback row exists. Per Q9 in the 2026-06-01 feedback-gate plan.
+    |
+    */
+    'auto_complete_threshold_days' => env('COLLABORATIONS_AUTO_COMPLETE_DAYS', 7),
+
+    'auto_complete_requires_feedback_rows' => env('COLLABORATIONS_AUTO_COMPLETE_REQUIRES_FEEDBACK', true),
+];

--- a/database/migrations/2026_05_31_231723_add_completion_gate_and_feedback_mirror_columns.php
+++ b/database/migrations/2026_05_31_231723_add_completion_gate_and_feedback_mirror_columns.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('collaborations', function (Blueprint $table): void {
+            $table->string('completion_reason', 500)->nullable();
+            $table->foreignUuid('completed_by_profile_id')->nullable()
+                ->constrained('profiles')->nullOnDelete();
+            $table->timestamp('auto_completed_at')->nullable();
+        });
+
+        // Mirror flag on existing collaboration_feedback table (created earlier;
+        // still in prod even though the controller was rolled back).
+        Schema::table('collaboration_feedback', function (Blueprint $table): void {
+            $table->boolean('mirrored_from_review')->default(false)->after('benefits');
+        });
+
+        // Relax the two boolean fields so mirrored rows can sit alongside rich
+        // ones without forcing a value the legacy client doesn't know to send.
+        // SQLite/PostgreSQL portable: drop NOT NULL by re-issuing the column with
+        // nullable(). For sqlite we use doctrine-free raw because the bundled
+        // schema builder cannot ALTER COLUMN; for everything else use change().
+        if (DB::connection()->getDriverName() === 'sqlite') {
+            // SQLite via Laravel: create a shadow column, copy, drop, rename.
+            Schema::table('collaboration_feedback', function (Blueprint $table): void {
+                $table->boolean('expectation_match_new')->nullable()->after('expectation_match');
+                $table->boolean('would_recommend_new')->nullable()->after('would_recommend');
+            });
+
+            DB::statement('UPDATE collaboration_feedback SET expectation_match_new = expectation_match, would_recommend_new = would_recommend');
+
+            Schema::table('collaboration_feedback', function (Blueprint $table): void {
+                $table->dropColumn('expectation_match');
+                $table->dropColumn('would_recommend');
+            });
+
+            Schema::table('collaboration_feedback', function (Blueprint $table): void {
+                $table->renameColumn('expectation_match_new', 'expectation_match');
+                $table->renameColumn('would_recommend_new', 'would_recommend');
+            });
+        } else {
+            Schema::table('collaboration_feedback', function (Blueprint $table): void {
+                $table->boolean('expectation_match')->nullable()->change();
+                $table->boolean('would_recommend')->nullable()->change();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('collaboration_feedback', function (Blueprint $table): void {
+            $table->dropColumn('mirrored_from_review');
+        });
+
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            Schema::table('collaboration_feedback', function (Blueprint $table): void {
+                $table->boolean('expectation_match')->nullable(false)->change();
+                $table->boolean('would_recommend')->nullable(false)->change();
+            });
+        }
+
+        Schema::table('collaborations', function (Blueprint $table): void {
+            $table->dropForeign(['completed_by_profile_id']);
+            $table->dropColumn(['completion_reason', 'completed_by_profile_id', 'auto_completed_at']);
+        });
+    }
+};

--- a/docs/ROLES-AND-PERMISSIONS.md
+++ b/docs/ROLES-AND-PERMISSIONS.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles, Permissions & Features (Canonical Reference)
 
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-01 (feedback gate + admin force-complete shipped same day)
 **Status:** Authoritative. This document overrides assumptions.
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical. When role behaviour changes, update both **and bump the Last updated date** in both.
 
@@ -103,14 +103,21 @@ If a business's subscription lapses (expires or is cancelled), the business is *
 
 The **community counterparty is NEVER affected**: communities keep full access to the shared collaboration and chat regardless of the business's subscription state. Re-gating is one-sided (business only). This refines §2.7: create/apply are the only first-contact paywalls, but a lapse additionally withdraws ongoing business-side access.
 
-### 2.9 Maintainer-granted access — added 2026-06-01
+### 2.9 Maintainer admin actions — added 2026-06-01
+
+The admin panel (`/admin/*`, `auth:admin + maintainer` guard) exposes these collaboration-level actions:
+- **Force-cancel** (`POST /admin/kolabs/{kolab}/collaboration/cancel`): persists `cancellation_reason` and stamps `cancelled_at`. `cancelled_by_profile_id = null` indicates maintainer action.
+- **Force-complete** (`POST /admin/kolabs/{kolab}/collaboration/complete`): bypasses the feedback gate. Persists `completion_reason` and stamps `completed_at`. `completed_by_profile_id = null` indicates maintainer action. No XP is awarded.
+- **Auto-complete (system)**: a scheduled job (`app:auto-complete-stale-collaborations`, default `dailyAt('03:00')`) completes collaborations whose `scheduled_date` is more than `config('collaborations.auto_complete_threshold_days', 7)` days in the past **and** that have at least one feedback row. Stamps `auto_completed_at`.
+
+### 2.10 Maintainer-granted subscription access — added 2026-06-01
 A Kolabing maintainer can grant a business **12 months of subscription access** from the admin panel (`/admin/users/{profile}/subscription/grant`). This produces a `business_subscriptions` row with `status = active` and **`source = maintainer`**. The grant bypasses Stripe/Apple IAP but is identical to a paid subscription as far as the paywall and re-gating logic are concerned — the business gets full subscribed-business capabilities until the period ends or a maintainer revokes it.
 
 A revoke (`/subscription/revoke`) flips the row to `status = inactive` with `cancel_at_period_end = true`. After revoke, the standard subscription-lapse re-gate (§2.8) kicks in.
 
 **Maintainer grants are auditable** via the `source = maintainer` value. There is no other way for an active subscription row to appear without payment.
 
-### 2.10 Test users — back-channel
+### 2.11 Test users — back-channel
 A profile with `profiles.is_test_user = true` is treated as having an active subscription regardless of whether a `business_subscriptions` row exists. This is reserved for Kolabing internal QA accounts. Never set this flag on real customer profiles.
 
 ---
@@ -162,8 +169,11 @@ Nothing. There is no paywall and no gated action on the community side. If code 
 - **Applications.** Either role applies to the other's post. The applying side picks dates only from the dates the posting side marked available.
 - **Chat.** Unlocked once an application is accepted. The other party's name is shown in chat.
 - **Collaboration.** Created when an application is accepted. Either side can edit the date or time. Either side can mark it finished; it also closes when the date passes. Both sides confirm.
-- **Two-way reviews.** After a collaboration, the business reviews the community and the community reviews the business. Ratings are visible on profiles and affect positioning.
-- **Feedback.** A mini feedback modal on completion. Business feedback captures star rating, stories posted, posts/reels, revenue, expectation match, and "would you recommend this community." Community feedback captures star rating, benefits received, posts/reels, expectation match, and "would you recommend this business."
+- **Two-way reviews (public).** After a collaboration, the business reviews the community and the community reviews the business via `POST /collaborations/{id}/review`. Ratings are visible on profiles via `PublicProfileReviewResource` and affect positioning.
+- **Rich feedback (private + gates completion).** A non-dismissible feedback step on completion via `POST /collaborations/{id}/feedback`. Required fields: rating (1–5), expectation match, would recommend. Optional shared: posts/reels. Business-only: stories posted, revenue. Community-only: benefits. **A collaboration only transitions to `completed` once both parties have a feedback row** (server-enforced via `config('collaborations.complete_requires_feedback')`, default true). XP fires per party on feedback submission, not on `/complete`. Editing your row via `PUT /feedback` is allowed until the partner submits — after that, both lock.
+  - Visibility (Q10 in the 2026-06-01 plan): rating + expectation_match + would_recommend are cross-visible to participants once both feedbacks land; revenue / stories_posted / posts_reels / benefits stay private to the submitter (and to maintainers).
+  - Re-gate exemption: a lapsed business can still submit `/feedback` on a past collab — feedback is post-mortem and unblocked even when `/collaborations` index is re-gated.
+  - **Backend mirror (rollout aid):** while the legacy app still POSTs to `/review`, the server transparently writes a stub `/feedback` row (mirror) so the gate succeeds. Mirrored rows carry `mirrored_from_review = true` and are excluded from the rich admin-stats aggregates.
 
 ---
 

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles → Backend → Database Map (Ground-Truth)
 
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-01 (feedback gate + admin force-complete + auto-timeout shipped same day)
 **Status:** Authoritative companion to [`ROLES-AND-PERMISSIONS.md`](./ROLES-AND-PERMISSIONS.md). Read that first (the *what*), then this (the *where*).
 **Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical, and **bump the Last updated date in both** when role behaviour or backend wiring changes.
 
@@ -70,6 +70,8 @@ Spec: paywall is **Business-only**, on **exactly two actions** (create a collabo
 | Client: create entry (intent) | `intent_selection_screen.dart` shows the paywall for unsubscribed business; communities only see the FREE CommunitySeeking option | Business only | ✅ correct |
 
 All four backend gates now follow the same pattern: `if ($profile->isBusiness() && ! $profile->hasActiveSubscription())`. **Never copy this gate into community or attendee paths.**
+
+**Feedback gate on `/complete` (added 2026-06-01, not a paywall):** `CollaborationService::complete()` now calls `enforceFeedbackGate()` which throws `awaiting_own_feedback` (422) or `awaiting_partner_feedback` (422) until both participants have a `collaboration_feedback` row. Subject to `config('collaborations.complete_requires_feedback', true)` so the gate can be soft-rolled. This is a UX gate, **not role-discriminatory** — both business and community must submit. The `awaiting_partner_feedback` error context carries `pending_feedback_from: ['business'|'community']` so the client knows who to nudge.
 
 ---
 
@@ -206,6 +208,7 @@ The admin panel is a **server-rendered Blade surface inside this Laravel backend
 | Grant subscription | `POST /admin/users/{profile}/subscription/grant` → `::grantSubscription` | `ManagedProfileService::grantSubscription($profile, $months = 12)` | `updateOrCreate` `business_subscriptions` with `status = active`, `source = maintainer`, `current_period_start = now()`, `current_period_end = now()+12mo`. Aborts 422 if profile is not `business`. |
 | Revoke subscription | `POST /admin/users/{profile}/subscription/revoke` → `::revokeSubscription` | `ManagedProfileService::revokeSubscription` | Sets `status = inactive`, `cancel_at_period_end = true`. Standard re-gate (`ROLES-AND-PERMISSIONS.md §2.8`) then applies. |
 | Force-cancel collaboration | `POST /admin/kolabs/{kolab}/collaboration/cancel` → `Admin\KolabController::cancelCollaboration` | `CollaborationService::cancel($collab, $reason, $cancelledBy = null)` | Requires a reason (min 3 chars). Persists `cancellation_reason`, `cancelled_at`, leaves `cancelled_by_profile_id` null — **`null` = cancelled by maintainer**. |
+| Force-complete collaboration | `POST /admin/kolabs/{kolab}/collaboration/complete` → `Admin\KolabController::completeCollaboration` | `CollaborationService::adminForceComplete($collab, $reason)` | Bypasses the feedback gate. Requires a reason. Persists `completion_reason`, stamps `completed_at`, leaves `completed_by_profile_id` null. No XP awarded. |
 
 **Key invariant for the role logic:** an admin-granted subscription is indistinguishable from a paid sub at the gate level. `Profile::hasActiveSubscription()` checks `status == active`; it does not branch on `source`. The `source` column is purely for audit and analytics. **Do not** add `source == stripe` checks anywhere — that would silently lock out maintainer-granted users.
 
@@ -225,8 +228,18 @@ Added by the 2026-05-31 admin stats sprint. These columns are **observability-on
 | `collaborations.cancellation_reason` | varchar 500 nullable | `CollaborationService::cancel()` |
 | `collaborations.cancelled_by_profile_id` | foreignUuid nullable | `CollaborationService::cancel()` — **null = maintainer-cancelled** |
 | `profiles.last_active_at` | timestamp nullable (indexed) | `TouchProfileActivity` middleware on the API `auth:sanctum` group; throttled to once per 5 minutes per profile |
+| `collaborations.completion_reason` | varchar 500 nullable | `CollaborationService::adminForceComplete()` |
+| `collaborations.completed_by_profile_id` | foreignUuid nullable | reserved for participant-completion paths; admin force-complete leaves it null (= maintainer) |
+| `collaborations.auto_completed_at` | timestamp nullable | `CollaborationService::autoComplete()` (called by `app:auto-complete-stale-collaborations`) |
+| `collaboration_feedback.mirrored_from_review` | boolean default false | `CollaborationFeedbackService::mirrorFromReview()` (stub rows created when a legacy client POSTs `/review`) |
+| `collaboration_feedback.expectation_match` / `would_recommend` | bool **nullable** (was NOT NULL) | relaxed in the same migration so mirrored stubs sit alongside rich rows |
 
 Backfill for legacy rows: `php artisan app:backfill-lifecycle-timestamps [--dry-run]` copies `updated_at` into the matching transition column. Run once per environment after deploy.
+
+**Auto-completion scheduler:** `app:auto-complete-stale-collaborations` runs `dailyAt('03:00')` per `routes/console.php`. Configurable thresholds in `config/collaborations.php`:
+- `auto_complete_threshold_days` (default 7): days past `scheduled_date` before a stale collab is eligible.
+- `auto_complete_requires_feedback_rows` (default true): also require at least one `collaboration_feedback` row before auto-completing (avoids declaring "done" on collabs nobody acknowledged).
+- `complete_requires_feedback` (default true): the `/complete` feedback gate. Soft-rollout knob if a mobile cutover regresses.
 
 ---
 

--- a/resources/views/admin/kolabs/_lifecycle.blade.php
+++ b/resources/views/admin/kolabs/_lifecycle.blade.php
@@ -153,6 +153,23 @@
                         </div>
                     </div>
                 </form>
+
+                <form method="POST" action="{{ route('admin.kolabs.collaboration.complete', $kolab) }}" class="mt-2"
+                      onsubmit="return confirm('Force-complete this collaboration? Bypasses the feedback gate; participants can still submit feedback after.');">
+                    @csrf
+                    <div class="form-row align-items-end">
+                        <div class="form-group col-md-9 mb-0">
+                            <label for="complete-reason" class="small text-muted mb-1">Completion reason (required)</label>
+                            <input type="text" name="reason" id="complete-reason" class="form-control" minlength="3" maxlength="500" required placeholder="Why is this being force-completed?">
+                        </div>
+                        <div class="form-group col-md-3 mb-0">
+                            <button type="submit" class="btn btn-outline-success btn-block">
+                                <i class="fas fa-check mr-1"></i>
+                                Force-complete
+                            </button>
+                        </div>
+                    </div>
+                </form>
             @endif
         @endif
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -616,6 +616,12 @@ Route::prefix('v1')->group(function (): void {
         Route::post('collaborations/{collaboration}/review', [CollaborationController::class, 'review'])
             ->name('api.v1.collaborations.review');
 
+        // Rich, role-specific completion feedback (gates the /complete endpoint).
+        Route::post('collaborations/{collaboration}/feedback', [CollaborationController::class, 'feedback'])
+            ->name('api.v1.collaborations.feedback.store');
+        Route::put('collaborations/{collaboration}/feedback', [CollaborationController::class, 'updateFeedback'])
+            ->name('api.v1.collaborations.feedback.update');
+
         // Sync selected challenges for a collaboration
         Route::put('collaborations/{collaboration}/challenges', [CollaborationChallengeController::class, 'sync'])
             ->name('api.v1.collaborations.challenges.sync');

--- a/routes/console.php
+++ b/routes/console.php
@@ -17,3 +17,7 @@ Schedule::command('notifications:send-reminders')
 // follow-up ("Did it happen?") in one pass; dedup is done via
 // the notifications table so re-runs are safe.
 Schedule::command('app:send-collab-reminders')->dailyAt('08:00');
+
+// Auto-complete collaborations stuck waiting on the second party's feedback
+// past the configured threshold. See config/collaborations.php.
+Schedule::command('app:auto-complete-stale-collaborations')->dailyAt('03:00');

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::put('/kolabs/{kolab}', [AdminKolabController::class, 'update'])->name('kolabs.update');
     Route::delete('/kolabs/{kolab}', [AdminKolabController::class, 'destroy'])->name('kolabs.destroy');
     Route::post('/kolabs/{kolab}/collaboration/cancel', [AdminKolabController::class, 'cancelCollaboration'])->name('kolabs.collaboration.cancel');
+    Route::post('/kolabs/{kolab}/collaboration/complete', [AdminKolabController::class, 'completeCollaboration'])->name('kolabs.collaboration.complete');
 
     Route::get('/stats', [AdminStatsController::class, 'index'])->name('stats.index');
 });

--- a/tests/Feature/Admin/CollaborationCompletionTest.php
+++ b/tests/Feature/Admin/CollaborationCompletionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
+use App\Enums\UserType;
+use App\Models\Application;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
+use App\Models\CollaborationFeedback;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class CollaborationCompletionTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    private function kolabWithActiveCollaboration(): array
+    {
+        $business = Profile::factory()->business()->create();
+        $community = Profile::factory()->community()->create();
+
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id]);
+        $opportunity = CollabOpportunity::factory()->create([
+            'id' => $kolab->id,
+            'creator_profile_id' => $business->id,
+        ]);
+
+        $application = Application::factory()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+            'status' => ApplicationStatus::Accepted,
+        ]);
+
+        $collab = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+            'business_profile_id' => $business->businessProfile?->id,
+            'community_profile_id' => $community->communityProfile?->id,
+            'scheduled_date' => now()->subDays(30),
+        ]);
+
+        return ['kolab' => $kolab, 'collab' => $collab, 'business' => $business, 'community' => $community];
+    }
+
+    public function test_admin_can_force_complete_a_collaboration_with_reason(): void
+    {
+        ['kolab' => $kolab, 'collab' => $collab] = $this->kolabWithActiveCollaboration();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.complete', $kolab), [
+                'reason' => 'Ghosted by both parties.',
+            ])
+            ->assertRedirect(route('admin.kolabs.edit', $kolab));
+
+        $fresh = $collab->fresh();
+        $this->assertSame(CollaborationStatus::Completed, $fresh->status);
+        $this->assertSame('Ghosted by both parties.', $fresh->completion_reason);
+        $this->assertNull($fresh->completed_by_profile_id);
+        $this->assertNotNull($fresh->completed_at);
+    }
+
+    public function test_admin_force_complete_requires_reason(): void
+    {
+        ['kolab' => $kolab] = $this->kolabWithActiveCollaboration();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.complete', $kolab), [])
+            ->assertSessionHasErrors('reason');
+    }
+
+    public function test_admin_force_complete_404s_when_no_collaboration_exists(): void
+    {
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.kolabs.collaboration.complete', $kolab), ['reason' => 'noop'])
+            ->assertNotFound();
+    }
+
+    public function test_auto_complete_command_promotes_stale_collab_with_feedback(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->kolabWithActiveCollaboration();
+
+        CollaborationFeedback::factory()->create([
+            'collaboration_id' => $collab->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewer_type' => 'business',
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+            'mirrored_from_review' => false,
+        ]);
+
+        Artisan::call('app:auto-complete-stale-collaborations');
+
+        $fresh = $collab->fresh();
+        $this->assertSame(CollaborationStatus::Completed, $fresh->status);
+        $this->assertNotNull($fresh->auto_completed_at);
+    }
+
+    public function test_auto_complete_command_skips_when_no_feedback_rows(): void
+    {
+        ['collab' => $collab] = $this->kolabWithActiveCollaboration();
+
+        Artisan::call('app:auto-complete-stale-collaborations');
+
+        $this->assertSame(CollaborationStatus::Active, $collab->fresh()->status);
+    }
+
+    public function test_auto_complete_command_dry_run_does_not_write(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->kolabWithActiveCollaboration();
+
+        CollaborationFeedback::factory()->create([
+            'collaboration_id' => $collab->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewer_type' => 'business',
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+            'mirrored_from_review' => false,
+        ]);
+
+        Artisan::call('app:auto-complete-stale-collaborations', ['--dry-run' => true]);
+
+        $this->assertSame(CollaborationStatus::Active, $collab->fresh()->status);
+    }
+}

--- a/tests/Feature/Api/V1/CollaborationFeedbackTest.php
+++ b/tests/Feature/Api/V1/CollaborationFeedbackTest.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
+use App\Enums\SubscriptionSource;
+use App\Enums\SubscriptionStatus;
+use App\Enums\UserType;
+use App\Models\Application;
+use App\Models\BusinessSubscription;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
+use App\Models\CollaborationFeedback;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class CollaborationFeedbackTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Build a business creator + community applicant + ACTIVE collaboration
+     * with both participant slots populated, returning all four key actors.
+     *
+     * @return array{collab: Collaboration, business: Profile, community: Profile, opportunity: CollabOpportunity}
+     */
+    private function makeActiveCollab(): array
+    {
+        $business = Profile::factory()->business()->create();
+        BusinessSubscription::query()->updateOrCreate(
+            ['profile_id' => $business->id],
+            ['source' => SubscriptionSource::Maintainer, 'status' => SubscriptionStatus::Active],
+        );
+
+        $community = Profile::factory()->community()->create();
+
+        $opportunity = CollabOpportunity::factory()->published()->create([
+            'creator_profile_id' => $business->id,
+            'creator_profile_type' => UserType::Business,
+        ]);
+
+        $application = Application::factory()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+            'status' => ApplicationStatus::Accepted,
+        ]);
+
+        $collab = Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'application_id' => $application->id,
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+            'business_profile_id' => $business->businessProfile?->id,
+            'community_profile_id' => $community->communityProfile?->id,
+        ]);
+
+        return ['collab' => $collab, 'business' => $business, 'community' => $community, 'opportunity' => $opportunity];
+    }
+
+    public function test_business_submits_full_feedback_and_xp_is_awarded(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $response = $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 5,
+                'expectation_match' => true,
+                'would_recommend' => true,
+                'posts_reels' => 3,
+                'stories_posted' => 12,
+                'revenue' => '450.50',
+            ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('collaboration_feedback', [
+            'collaboration_id' => $collab->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewer_type' => 'business',
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+            'mirrored_from_review' => false,
+        ]);
+        // CollaborationComplete XP fires on feedback submission (Q7).
+        $this->assertDatabaseHas('point_ledger', [
+            'profile_id' => $business->id,
+            'event_type' => 'collaboration_complete',
+            'reference_id' => $collab->id,
+        ]);
+    }
+
+    public function test_community_submits_feedback_with_benefits_only(): void
+    {
+        ['collab' => $collab, 'community' => $community] = $this->makeActiveCollab();
+
+        $this->actingAs($community)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 4,
+                'expectation_match' => false,
+                'would_recommend' => true,
+                'benefits' => 'Free coffee for the whole group',
+            ])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('collaboration_feedback', [
+            'collaboration_id' => $collab->id,
+            'reviewer_profile_id' => $community->id,
+            'reviewer_type' => 'community',
+            'reviewer_role' => 'applicant',
+            'benefits' => 'Free coffee for the whole group',
+        ]);
+    }
+
+    public function test_community_sending_business_only_fields_is_rejected(): void
+    {
+        ['collab' => $collab, 'community' => $community] = $this->makeActiveCollab();
+
+        $this->actingAs($community)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 4,
+                'expectation_match' => true,
+                'would_recommend' => true,
+                'revenue' => '500',
+                'stories_posted' => 10,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['revenue', 'stories_posted']);
+    }
+
+    public function test_business_sending_benefits_is_rejected(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 4,
+                'expectation_match' => true,
+                'would_recommend' => true,
+                'benefits' => 'should be rejected',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['benefits']);
+    }
+
+    public function test_duplicate_submission_returns_409(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $payload = ['rating' => 5, 'expectation_match' => true, 'would_recommend' => true];
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), $payload)
+            ->assertCreated();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), $payload)
+            ->assertStatus(409)
+            ->assertJsonPath('error_code', 'feedback_already_submitted');
+    }
+
+    public function test_put_edits_own_row_while_partner_has_not_submitted(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 3, 'expectation_match' => true, 'would_recommend' => true, 'revenue' => '100',
+            ])->assertCreated();
+
+        $this->actingAs($business)
+            ->putJson(route('api.v1.collaborations.feedback.update', $collab), [
+                'rating' => 5,
+                'revenue' => '999.99',
+            ])
+            ->assertOk();
+
+        $this->assertDatabaseHas('collaboration_feedback', [
+            'collaboration_id' => $collab->id,
+            'reviewer_profile_id' => $business->id,
+            'rating' => 5,
+            'revenue' => '999.99',
+        ]);
+    }
+
+    public function test_put_after_partner_submits_returns_423_locked(): void
+    {
+        ['collab' => $collab, 'business' => $business, 'community' => $community] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 4, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
+
+        $this->actingAs($community)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
+
+        $this->actingAs($business)
+            ->putJson(route('api.v1.collaborations.feedback.update', $collab), [
+                'rating' => 1,
+            ])
+            ->assertStatus(423)
+            ->assertJsonPath('error_code', 'feedback_locked');
+    }
+
+    public function test_complete_returns_422_awaiting_own_feedback_when_caller_has_not_submitted(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.complete', $collab))
+            ->assertStatus(422)
+            ->assertJsonPath('error_code', 'awaiting_own_feedback');
+
+        $this->assertSame(CollaborationStatus::Active, $collab->fresh()->status);
+    }
+
+    public function test_complete_returns_422_awaiting_partner_feedback(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.complete', $collab))
+            ->assertStatus(422)
+            ->assertJsonPath('error_code', 'awaiting_partner_feedback')
+            ->assertJsonPath('errors.pending_feedback_from', ['community']);
+    }
+
+    public function test_complete_succeeds_when_both_feedbacks_exist(): void
+    {
+        ['collab' => $collab, 'business' => $business, 'community' => $community] = $this->makeActiveCollab();
+
+        foreach ([$business, $community] as $actor) {
+            $this->actingAs($actor)
+                ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                    'rating' => 4, 'expectation_match' => true, 'would_recommend' => true,
+                ])->assertCreated();
+        }
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.complete', $collab))
+            ->assertOk();
+
+        $fresh = $collab->fresh();
+        $this->assertSame(CollaborationStatus::Completed, $fresh->status);
+        $this->assertNotNull($fresh->completed_at);
+    }
+
+    public function test_review_mirrors_to_feedback_so_complete_succeeds(): void
+    {
+        ['collab' => $collab, 'business' => $business, 'community' => $community] = $this->makeActiveCollab();
+
+        // Both parties on the legacy app path: post /review only.
+        foreach ([$business, $community] as $actor) {
+            $this->actingAs($actor)
+                ->postJson(route('api.v1.collaborations.review', $collab), [
+                    'rating' => 4,
+                ])->assertCreated();
+        }
+
+        $this->assertSame(2, CollaborationFeedback::query()
+            ->where('collaboration_id', $collab->id)
+            ->where('mirrored_from_review', true)
+            ->count());
+
+        // /complete now succeeds because both stub feedback rows exist.
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.complete', $collab))
+            ->assertOk();
+    }
+
+    public function test_feedback_submit_upgrades_existing_mirrored_stub(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        // Legacy /review call writes the mirrored stub first.
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.review', $collab), ['rating' => 3])
+            ->assertCreated();
+
+        $stubBefore = CollaborationFeedback::query()
+            ->where('collaboration_id', $collab->id)
+            ->where('reviewer_profile_id', $business->id)
+            ->firstOrFail();
+        $this->assertTrue($stubBefore->mirrored_from_review);
+        $this->assertNull($stubBefore->expectation_match);
+
+        // Now the user upgrades to the rich endpoint.
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 5,
+                'expectation_match' => true,
+                'would_recommend' => true,
+                'revenue' => '300',
+            ])
+            ->assertCreated();
+
+        $upgraded = $stubBefore->fresh();
+        $this->assertFalse($upgraded->mirrored_from_review);
+        $this->assertTrue($upgraded->expectation_match);
+        $this->assertSame(5, $upgraded->rating);
+        $this->assertSame('300.00', $upgraded->revenue);
+    }
+
+    public function test_lapsed_business_can_still_submit_feedback(): void
+    {
+        ['collab' => $collab, 'business' => $business] = $this->makeActiveCollab();
+
+        // Lapse the subscription.
+        BusinessSubscription::query()
+            ->where('profile_id', $business->id)
+            ->update(['status' => SubscriptionStatus::Inactive]);
+
+        $business->refresh();
+        $this->assertFalse($business->hasActiveSubscription());
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 4, 'expectation_match' => true, 'would_recommend' => true,
+            ])
+            ->assertCreated();
+    }
+
+    public function test_resource_exposes_pending_and_own_feedback(): void
+    {
+        ['collab' => $collab, 'business' => $business, 'community' => $community] = $this->makeActiveCollab();
+
+        $this->actingAs($business)
+            ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
+
+        $response = $this->actingAs($business)
+            ->getJson(route('api.v1.collaborations.show', $collab));
+
+        $response->assertOk()
+            ->assertJsonPath('data.pending_feedback_from', ['community'])
+            ->assertJsonPath('data.viewer_must_submit_feedback', false)
+            ->assertJsonPath('data.own_feedback.rating', 5)
+            ->assertJsonPath('data.partner_feedback', null);
+
+        $communityView = $this->actingAs($community)
+            ->getJson(route('api.v1.collaborations.show', $collab));
+        $communityView->assertOk()
+            ->assertJsonPath('data.viewer_must_submit_feedback', true);
+    }
+
+    public function test_partner_feedback_appears_only_when_both_real_rows_exist(): void
+    {
+        ['collab' => $collab, 'business' => $business, 'community' => $community] = $this->makeActiveCollab();
+
+        foreach ([$business, $community] as $actor) {
+            $this->actingAs($actor)
+                ->postJson(route('api.v1.collaborations.feedback.store', $collab), [
+                    'rating' => 4, 'expectation_match' => true, 'would_recommend' => false,
+                ])->assertCreated();
+        }
+
+        $response = $this->actingAs($business)
+            ->getJson(route('api.v1.collaborations.show', $collab));
+
+        $response->assertOk()
+            ->assertJsonPath('data.partner_feedback.rating', 4)
+            ->assertJsonPath('data.partner_feedback.would_recommend', false)
+            ->assertJsonMissingPath('data.partner_feedback.revenue')
+            ->assertJsonMissingPath('data.partner_feedback.benefits');
+    }
+}

--- a/tests/Feature/Api/V1/GamificationCollaborationIntegrationTest.php
+++ b/tests/Feature/Api/V1/GamificationCollaborationIntegrationTest.php
@@ -31,8 +31,10 @@ class GamificationCollaborationIntegrationTest extends TestCase
         return $profile;
     }
 
-    public function test_completing_collaboration_awards_points_to_both_parties(): void
+    public function test_submitting_feedback_awards_points_to_each_party(): void
     {
+        // Post-2026-06-01: XP is awarded when each party POSTs /feedback, not
+        // on /complete. See docs/plans 2026-06-01 feedback gate (Q7).
         $creator = $this->createBusinessProfile();
         $applicant = $this->createCommunityProfile();
 
@@ -42,40 +44,43 @@ class GamificationCollaborationIntegrationTest extends TestCase
             ->active()
             ->create();
 
-        $response = $this->actingAs($creator)
-            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete");
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/feedback", [
+                'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
 
-        $response->assertOk()
-            ->assertJsonPath('success', true);
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/feedback", [
+                'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+            ])->assertCreated();
 
-        // Both parties receive 10 XP plus the 50 XP first-kolab bonus.
-        $this->assertDatabaseHas('wallets', [
-            'profile_id' => $creator->id,
-            'points' => 60,
-        ]);
+        // Both parties earn 10 XP for participation + 50 XP first-kolab bonus.
+        $this->assertDatabaseHas('wallets', ['profile_id' => $creator->id, 'points' => 60]);
+        $this->assertDatabaseHas('wallets', ['profile_id' => $applicant->id, 'points' => 60]);
 
-        $this->assertDatabaseHas('wallets', [
-            'profile_id' => $applicant->id,
-            'points' => 60,
-        ]);
-
-        // Ledger entries for both parties
         $this->assertDatabaseHas('point_ledger', [
             'profile_id' => $creator->id,
             'points' => 10,
             'event_type' => 'collaboration_complete',
             'reference_id' => $collaboration->id,
         ]);
-
         $this->assertDatabaseHas('point_ledger', [
             'profile_id' => $applicant->id,
             'points' => 10,
             'event_type' => 'collaboration_complete',
             'reference_id' => $collaboration->id,
         ]);
+
+        // /complete itself awards no XP — pure metadata flip.
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete")
+            ->assertOk();
+
+        $this->assertDatabaseHas('wallets', ['profile_id' => $creator->id, 'points' => 60]);
+        $this->assertDatabaseHas('wallets', ['profile_id' => $applicant->id, 'points' => 60]);
     }
 
-    public function test_scheduled_collaboration_can_be_completed_once_and_then_returns_422(): void
+    public function test_completing_twice_returns_422_terminal_state(): void
     {
         $creator = $this->createBusinessProfile();
         $applicant = $this->createCommunityProfile();
@@ -85,6 +90,14 @@ class GamificationCollaborationIntegrationTest extends TestCase
             ->forApplicant($applicant)
             ->scheduled()
             ->create();
+
+        // Submit feedback from both sides so the gate is satisfied.
+        foreach ([$creator, $applicant] as $actor) {
+            $this->actingAs($actor)
+                ->postJson("/api/v1/collaborations/{$collaboration->id}/feedback", [
+                    'rating' => 4, 'expectation_match' => true, 'would_recommend' => true,
+                ])->assertCreated();
+        }
 
         $firstResponse = $this->actingAs($creator)
             ->postJson("/api/v1/collaborations/{$collaboration->id}/complete");
@@ -102,8 +115,10 @@ class GamificationCollaborationIntegrationTest extends TestCase
             ->assertJsonPath('errors.status', 'completed');
     }
 
-    public function test_completing_collaboration_evaluates_badges(): void
+    public function test_submitting_feedback_evaluates_badges(): void
     {
+        // Post-2026-06-01: badge evaluation runs inside awardPoints, which now
+        // fires on /feedback rather than /complete. See plan doc Q7.
         $creator = $this->createBusinessProfile();
         $applicant = $this->createCommunityProfile();
 
@@ -113,15 +128,17 @@ class GamificationCollaborationIntegrationTest extends TestCase
             ->active()
             ->create();
 
-        $this->actingAs($creator)
-            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete");
+        foreach ([$creator, $applicant] as $actor) {
+            $this->actingAs($actor)
+                ->postJson("/api/v1/collaborations/{$collaboration->id}/feedback", [
+                    'rating' => 5, 'expectation_match' => true, 'would_recommend' => true,
+                ])->assertCreated();
+        }
 
-        // Both should earn first_kolab badge
         $this->assertDatabaseHas('earned_badges', [
             'profile_id' => $creator->id,
             'badge_slug' => 'first_kolab',
         ]);
-
         $this->assertDatabaseHas('earned_badges', [
             'profile_id' => $applicant->id,
             'badge_slug' => 'first_kolab',


### PR DESCRIPTION
## Summary
Resurrects the rich completion-feedback flow that was added 2026-05-22 (commit `b16487d`) and explicitly rolled back 2026-05-26 (`dcb620b`). Implements the 11 design decisions iterated with Daniel on 2026-06-01.

### What the gate does
`POST /collaborations/{id}/complete` now refuses to transition to `completed` until **both** participants have a `collaboration_feedback` row. Returns:
- `422 awaiting_own_feedback` when caller hasn't submitted yet.
- `422 awaiting_partner_feedback` with `errors.pending_feedback_from: ['business'|'community']` when partner hasn't.

Soft-rollout knob: `config('collaborations.complete_requires_feedback', true)` (env `COLLABORATIONS_COMPLETE_REQUIRES_FEEDBACK`).

### XP timing (Q7 of the plan)
Each party's `CollaborationComplete` XP fires when they POST `/feedback`, not on `/complete`. `/complete` is now a pure metadata flip.

### Visibility (Q10)
- **Cross-visible** to participants once both feedbacks land: `rating`, `expectation_match`, `would_recommend`.
- **Private** to submitter + maintainers: `revenue`, `stories_posted`, `posts_reels`, `benefits`.

### Lapsed-business path (Q5)
A lapsed business can still POST `/feedback` (post-mortem) and call `/complete` once both rows exist. The `/collaborations` index re-gate is unchanged.

### Edit window (Q8)
`PUT /feedback` is allowed until the partner submits their own row. After that, both lock (`423 Locked`).

### Mirror (Q from the "yes by default" exchange)
Legacy clients still POSTing to `/review` automatically get a stub `/feedback` row (`mirrored_from_review = true`) so the gate succeeds. Pre-completion `/review` calls are now allowed on `active` collabs so the legacy `/complete-then-/review` order can recover. Mirror rows are filtered out of rich admin-stats aggregates (planned for the stats PR).

### Admin force-complete + auto-timeout (Q4 + Q11)
- `POST /admin/kolabs/{kolab}/collaboration/complete` — maintainer escape hatch, mirror of the existing force-cancel route. Persists `completion_reason`, leaves `completed_by_profile_id = null`.
- Lifecycle panel in `admin/kolabs/edit` gets a Force-complete form.
- `app:auto-complete-stale-collaborations` scheduled `dailyAt('03:00')`. Completes collabs 7+ days past `scheduled_date` with ≥1 feedback row. Stamps `auto_completed_at`.

### Migrations (strictly additive)
- `collaborations`: `completion_reason`, `completed_by_profile_id`, `auto_completed_at`.
- `collaboration_feedback`: `mirrored_from_review` (default false); `expectation_match` / `would_recommend` relaxed to nullable so mirrored stubs coexist with rich rows. Driver-portable (sqlite shadow-column + `change()` elsewhere).

### CollaborationResource additions
```jsonc
{
  "pending_feedback_from": ["community"],
  "viewer_must_submit_feedback": true,
  "own_feedback": { "rating": 5, ... } | null,
  "partner_feedback": null | { "rating": 4, "expectation_match": true, "would_recommend": true },
  "completion_reason": null,
  "completed_by_profile_id": null,
  "auto_completed_at": null
}
```

### Docs
Updated per the PR #8 update rule: `ROLES-AND-PERMISSIONS.md` §2.9 (Maintainer admin actions) + §4 (rich feedback) + new entries in `ROLES-BACKEND-DB-MAP.md` §9 (admin) and §10 (lifecycle columns). `Last updated` dates bumped to 2026-06-01.

## Test plan
- [x] **703 tests / 3555 assertions** — full suite green.
- [x] 14 new feature tests in `tests/Feature/Api/V1/CollaborationFeedbackTest.php`.
- [x] 6 new feature tests in `tests/Feature/Admin/CollaborationCompletionTest.php`.
- [x] Existing `GamificationCollaborationIntegrationTest` updated to the new Q7 contract (XP fires on `/feedback`).
- [x] `vendor/bin/pint --dirty` clean.
- [ ] Manual: walk through the completion sheet against a staging build; verify `pending_feedback_from` drives UX correctly.

## Deploy
1. Merge → CI/CD → `php artisan migrate --force` (additive).
2. Optionally flip `COLLABORATIONS_COMPLETE_REQUIRES_FEEDBACK=false` initially if you want the soft-rollout knob.
3. Schedule cron `php artisan schedule:run` already covers the new `app:auto-complete-stale-collaborations` daily job.
4. Hand the app team the prompt I prepared earlier so they post `/feedback` before `/complete` in the next mobile build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)