### PR TITLE
docs: add cross-repo launch backlog (audit findings)

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,214 @@
+# Kolabing — Pre-launch Backlog
+
+**Last updated:** 2026-06-01
+**Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
+
+A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
+
+Each item lists what exists now, what's missing, and any open decisions. See referenced docs / commits for detail.
+
+---
+
+## 1. Email infrastructure (Postmark)
+
+**Status:** Not wired. Only password reset uses Laravel's Password broker default.
+
+**What exists:**
+- `config/services.php:17-19` declares Postmark with `POSTMARK_API_KEY` env.
+- `config/mail.php:17` default mailer is `'log'` (not Postmark).
+- `AuthService:566` sends password reset via `Password::broker()->sendResetLink()`.
+
+**What's missing:**
+- No `app/Mail/` Mailables at all. No `app/Notifications/` mail-channel classes. No `resources/views/mail/` templates.
+- No `POSTMARK_API_KEY` in `.env.example`.
+- Default mailer never flipped to `postmark`.
+- No `MustVerifyEmail` on the `Profile` model — email confirmation on signup is not enforced. (Google OAuth manually sets `email_verified_at = now()` per `AuthService:168` so OAuth users skip verification anyway.)
+
+**P0 — must ship before launch:**
+- [ ] `Mail/EmailVerification` Mailable + send on registration (email/password path). Owner: **backend**.
+- [ ] `Mail/PasswordReset` Mailable to replace Laravel's default reset email (custom branding). Owner: **backend**.
+- [ ] `Mail/WelcomeBusiness`, `Mail/WelcomeCommunity` post-onboarding. Owner: **backend**.
+- [ ] Wire Postmark: `POSTMARK_API_KEY` to `.env.example`, `MAIL_MAILER=postmark` in production env. Owner: **infra**.
+- [ ] Email-style branding template (`emails/layouts/master.blade.php`) so all subsequent Mailables share a header/footer. Owner: **backend**.
+
+**P1 — customer success flows:**
+- [ ] "Create your first kolab" nudge — business with no published kolab after N days. Trigger: scheduled command. Owner: **backend**.
+- [ ] "Your first application is in" — business gets an email when they receive their first community application. Owner: **backend**.
+- [ ] Collab-day + follow-up reminders also as email fallback (push exists already). Owner: **backend**.
+- [ ] Subscription receipts on activation / cancellation / past_due (gated on §3 Stripe ship). Owner: **backend**.
+
+**P2 — lifecycle marketing:**
+- [ ] Re-engagement after N days inactive — email path complementing push. Owner: **backend**.
+- [ ] Monthly "your Kolabing impact" summary for businesses (revenue from feedback, attendance, reviews). Owner: **backend**.
+
+**Open decisions:**
+- Single Postmark stream or one stream per type (transactional vs broadcast)?
+- Do we mirror every push as an email, or push for time-sensitive + email for value-add?
+
+---
+
+## 2. Push notifications (OneSignal)
+
+**Status:** OneSignal is the live provider since the 2026-05-22 migration (`47decb5`). Core transactional pushes work.
+
+**What exists** (`NotificationService` + `PushNotificationService` + `OneSignalService`):
+- `NewMessage`, `ApplicationReceived`, `ApplicationAccepted`, `ApplicationDeclined`, `ChallengeVerified`, `RewardWon`, `CollabDayReminder`, `CollabFollowUpReminder`, `KolabCreateIncomplete`, `ApplicationPending`, `UnreadMessage` — all dispatch correctly.
+- Reminders cadence: 2h, 24h, 72h via `NotificationReminder` model + `notifications:send-reminders` command.
+- `routes/console.php` schedules `app:send-collab-reminders` daily 08:00 and the new `app:auto-complete-stale-collaborations` daily 03:00.
+- iOS/Android deep linking, thread IDs, interruption levels, badge counts all configured.
+
+**P1 — gaps that block real-world use:**
+- [ ] **`NotificationPreference` isn't respected.** `Profile` has the relation, the table exists, but no runtime filter inside `NotificationService` — all pushes go regardless of opt-out. Owner: **backend**.
+- [ ] **Schedule the reminders cron.** Audit found `notifications:send-reminders` exists but isn't registered in `routes/console.php` (collab reminders are; this one isn't). Owner: **backend**.
+- [ ] Trigger the four enum types currently defined but never dispatched: `BadgeAwarded`, `GamificationBadgeEarned`, `PointsEarned`, `WithdrawalProcessed`. Owner: **backend** (wire from `GamificationWalletService` + `WithdrawalService`).
+- [ ] Subscription state pushes — renewal succeeded, payment failed, sub cancelled (depends on §3 Stripe ship; Apple IAP webhook should trigger these too). Owner: **backend**.
+
+**P2:**
+- [ ] Dormancy re-engagement — push at day 7 / 14 / 30 of inactivity, gated by `profiles.last_active_at`. Owner: **backend**.
+- [ ] Drop `kreait/laravel-firebase` once we confirm Apple JWT validation has migrated to a non-Firebase path (Firebase SDK is only used for JWT parsing inside `AppleIAPService` today). Owner: **backend**.
+
+---
+
+## 3. Subscription payments (Stripe + Apple IAP)
+
+**Status:** Apple IAP is **fully shipped** (StoreKit2). Stripe is **stub-only**. Web checkout doesn't exist.
+
+### 3.1 Apple IAP — `P0` confirmed shipped, P2 follow-ups only
+**What exists:**
+- `app/Services/AppleIAPService.php` — full StoreKit2 implementation: transaction verification, JWS/JWT signature validation, subscription state sync, grace period handling.
+- `app/Http/Controllers/Api/V1/AppleIAPController.php` — `POST /me/subscription/apple-verify` + `apple-restore`.
+- `app/Http/Controllers/Api/V1/AppleWebhookController.php` — `POST /webhooks/apple`.
+- Status transitions for `SUBSCRIBED`, `DID_RENEW`, `DID_FAIL_TO_RENEW`, `EXPIRED`, `REVOKE` correctly mapped.
+
+**P2 follow-ups:**
+- [ ] Fire push + email on subscription state changes (renewal, failure, refund) from `AppleIAPService::handleNotification()`. Owner: **backend**.
+- [ ] Drop the `kreait/laravel-firebase` dependency once Apple JWT validation uses a smaller library or a hand-rolled verifier. Owner: **backend**.
+
+### 3.2 Stripe — `P0` build for web checkout
+**What exists:**
+- `composer.json` has `stripe/stripe-php`.
+- `.env.example:77-81` declares `STRIPE_PUBLISHABLE_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_MONTHLY_PRICE_ID`.
+- `business_subscriptions` has `stripe_customer_id`, `stripe_subscription_id`, `current_period_*`, `cancel_at_period_end`.
+- `SubscriptionSource::Stripe` enum value.
+
+**What's missing — full Stripe build required for web payment:**
+- [ ] `StripeService` — create/retrieve customer, create checkout session, sync subscription state from webhook events. Owner: **backend**.
+- [ ] `StripeCheckoutController` — `POST /api/v1/me/subscription/create-checkout-session` returning session URL. Owner: **backend**.
+- [ ] `StripeWebhookController` — `POST /api/v1/webhooks/stripe`, signature validation, handle `checkout.session.completed`, `customer.subscription.updated`, `invoice.payment_failed`, `customer.subscription.deleted`. Owner: **backend**.
+- [ ] `Stripe` block in `config/services.php`. Owner: **backend**.
+
+### 3.3 Web subscription checkout — `P0` for launch (§4 covers the landing-page UI)
+Builds on §3.2. Add a public-facing flow:
+- [ ] `/pricing` route + Blade page showing the monthly (€29) and 4-month (€96) plans. Owner: **backend**.
+- [ ] "Subscribe" CTA on `/for-businesses` + footer + post-OAuth confirmation page that redirects to Stripe Checkout. Owner: **backend**.
+- [ ] Success / cancel return URLs with appropriate user feedback. Owner: **backend**.
+- [ ] Email receipt on subscription activation (joins §1.P1). Owner: **backend**.
+
+**Open decisions:**
+- Pricing display: monthly only, or both monthly + 4-month plan with comparison?
+- Trial period? (None today.)
+- VAT handling at checkout for EU customers?
+
+---
+
+## 4. Public marketing site (landing + supporting pages)
+
+**Status:** Polished MVP design quality. Critical conversion infrastructure missing.
+
+**What exists:**
+- `routes/web.php`: `/`, `/for-businesses`, `/for-communities`, `/support`, `/careers`, `/privacy`, `/terms`, plus the `/sitemap.xml` + `/llms.txt` + `/.well-known/security.txt` helpers.
+- `welcome.blade.php` — 1582-line custom-CSS hero (separate from the Tailwind-CDN layout used by other pages). 7 sections: hero, manifesto, reveal, how-it-works, examples, FAQ, final CTA, footer. Real case-study imagery. Mobile responsive at 900 / 540 breakpoints.
+- `for-businesses` / `for-communities` use the Tailwind-CDN `marketing-page` layout.
+- Legal pages exist with proper copy.
+
+**P0 — landing-page must-fixes before any traffic push:**
+- [ ] **All primary CTAs are broken** (`href="#"`):
+  - App Store + Google Play download buttons (hero).
+  - "Join as a business" + "Join as a community" (final CTA).
+  Owner: **backend** (wire to actual store URLs + the new `/pricing` flow from §3.3).
+- [ ] **GDPR cookie banner.** Target market is EU (Barcelona). Operating without consent management is a hard legal risk. Owner: **backend**.
+- [ ] **`/pricing` page** (covered in §3.3).
+- [ ] Analytics instrumentation — at minimum GA4 or Plausible page-view tracking; conversion events on Subscribe + sign-up. Owner: **backend**.
+
+**P1 — site polish:**
+- [ ] Decide on the `welcome.blade.php` vs Tailwind-CDN duality. Either migrate the hand-CSS landing to Tailwind, or move all marketing pages to a single Vite-built Tailwind bundle. Today they coexist in two different tech stacks. Owner: **backend**.
+- [ ] Waitlist email-capture form (Klaviyo / ConvertKit / a simple `waitlist_signups` table — the migration was scoped earlier on the `fixes-and-improvements` branch but was dropped with the stash). Useful for collecting interest pre-Stripe. Owner: **backend**.
+- [ ] Real-user testimonials (currently using case studies only). Owner: **content**.
+- [ ] FAQ extension to cover pricing + payment + cancellation (currently silent on these). Owner: **backend** (copy) once §3.3 ships.
+
+**P2:**
+- [ ] Localised landing pages (Spanish first, given Barcelona launch). Owner: **backend**.
+- [ ] Open Graph / Twitter Card metadata for share previews. Owner: **backend**.
+- [ ] `Organization` JSON-LD with `priceRange` once pricing is public. Owner: **backend**.
+
+---
+
+## 5. Database region — move to EU
+
+**Status:** Currently US-east-1 by env default; production hosting location not auditable from the repo.
+
+**What we know:**
+- `.env.example` sets `AWS_DEFAULT_REGION=us-east-1`.
+- Real production DB region depends on the hosting environment (Forge / Vapor / managed RDS / Supabase). Not in repo.
+- Target market is EU (Barcelona) — latency and GDPR data-residency both push toward `eu-west-1` (Ireland) or `eu-west-3` (Paris).
+
+**P1 (becomes P0 once we start collecting any real EU PII):**
+- [ ] Confirm current production DB region with whoever manages the hosting account (Daniel). Owner: **infra**.
+- [ ] If US, plan migration: snapshot → restore in EU region → swap DNS / connection string with brief read-only window. Estimate ~30 min downtime for a small DB. Owner: **infra**.
+- [ ] Update `AWS_DEFAULT_REGION` in production env post-migration. Owner: **infra**.
+- [ ] Verify backups remain in EU after the move. Owner: **infra**.
+- [ ] Bake an EU-region constraint into the deployment runbook so future spin-ups don't drift back to US. Owner: **infra**.
+
+**Code impact:** ~zero. This is an infrastructure change.
+
+---
+
+## 6. Profile picture zoom / scale
+
+**Status:** No-op on backend. App-side feature.
+
+**What exists:**
+- Backend: `ProfileController:64` uploads via `FileUploadService` → stores `business_profiles.profile_photo` / `community_profiles.profile_photo`. `PublicProfileResource::absoluteUrl()` serves the URL.
+- App: `lib/features/profile/screens/public_profile_screen.dart` + `profile_reviews_screen.dart` show profile photos via `CachedNetworkImage` / `CircleAvatar` + `NetworkImage`. No `InteractiveViewer` / `PhotoView` wrapping.
+
+**P1:**
+- [ ] Wrap the profile-photo display widgets with a tap-to-open full-screen `PhotoView` (or `InteractiveViewer`) showing the high-res image with pinch-zoom + pan. Owner: **app**.
+- [ ] Apply the same pattern to `public_profile_screen.dart`, `profile_reviews_screen.dart`, and `past_collaboration_card.dart`. Owner: **app**.
+
+**P2 (backend follow-up if needed for performance):**
+- [ ] Multi-size serving — when the photo's pixel dimensions are large, serve a thumb + a full version. Likely not needed in v1 since `FileUploadService` already caps sizes; verify. Owner: **backend**.
+
+**Open decisions:**
+- Use the existing `cached_network_image` instance for the zoomed view too, or load a separate full-res variant?
+- Show a download / share affordance on the zoom modal?
+
+---
+
+## 7. Admin dashboard gaps
+
+Cross-references to PRs and plans already on file — listed here so they don't get lost.
+
+- [ ] **Gamification admin section** (entire `/admin/gamification/*` subtree) — see [docs/plans/2026-06-01-admin-followups.md](plans/2026-06-01-admin-followups.md). Five PRs planned (XP rules + config endpoint, economics, challenges, bonus rewards, badges) with several open decisions still to land. Owner: **backend**.
+- [ ] **Lifecycle filter UX fix** on `/admin/kolabs` — rename "Matched" → "Pending match", add composite "Has match" + "Completed or done" filters. Same plan doc. Owner: **backend**.
+- [ ] **Admin stats — feedback metrics** — `PlatformStatsService::quality()` currently reads `collaboration_reviews`. Extend to surface the new `collaboration_feedback` columns (revenue, expectation_match %, would_recommend %) with the `mirrored_from_review` filter for clean rich aggregates. Tied to PR #9. Owner: **backend**.
+- [ ] **`Admin\ManagedUserController::destroy()`** should run the full `ProfileService::deleteProfile()` cleanup transaction, not a bare soft-delete. Currently bypasses email-free + collab-cancel side effects. Owner: **backend**.
+
+---
+
+## 8. Pre-existing role surface debt
+
+From [docs/ROLES-BACKEND-DB-MAP.md](ROLES-BACKEND-DB-MAP.md) §8 — still-open items. Repeated here so they're visible from the launch backlog too.
+
+- [ ] **Implement the Explore blur** for free businesses (golden rules 4 + 5). Server should emit an `identity_locked` flag; client renders an actual blur, not a hard block. Owner: **cross**.
+- [ ] **Add `coliving` to `BusinessOnboardingRequest::BUSINESS_TYPES`** — it's in the spec but rejected at validation today. Owner: **backend**.
+- [ ] **Attendee role scope decision** — code is shipped (gamification, wallet, badges, checkin) but `ROLES-AND-PERMISSIONS.md §7` still marks it as `[VERIFY]`. Decide: in or out of launch; pricing; whether the attendee wallet redeems to cash. Owner: **product (Daniel)**, then **backend** / **app**.
+
+---
+
+## How to use this file
+
+- One canonical list across both repos. Mirror any edit in both — keep the files byte-identical (`diff -q` should be empty).
+- When something ships, move the item to a `## Shipped` section at the bottom rather than deleting it, so the launch history stays visible.
+- When picking up an item, open a PR with a description that links here so the backlog is self-documenting.
+
+*Owner labels: `backend` = `kolabing-v2`, `app` = `kolabing-app`, `cross` = both, `infra` = hosting account, `product` = Daniel.*

--- a/docs/plans/2026-06-01-admin-followups.md
+++ b/docs/plans/2026-06-01-admin-followups.md
@@ -1,0 +1,140 @@
+# Admin follow-ups — Lifecycle filter audit + Gamification gap
+
+**Date:** 2026-06-01
+**Status:** Plan (no code yet). Two distinct threads bundled because both surfaced together on a single review of `/admin`.
+
+---
+
+## Thread 1 — Lifecycle filter audit on `/admin/kolabs`
+
+### What you observed
+- Filter dropdown options like "Matched" don't surface kolabs you'd expect to see there. Specifically, a kolab that is already "Active" (live collaboration) does not appear under "Matched".
+- "More errors" — i.e. the buckets don't feel right against the real data.
+
+### What the code actually does (recap)
+`App\Services\Admin\KolabLifecycleService::derive()` assigns **exactly one** lifecycle per kolab, in this priority order:
+
+| Order | Lifecycle | Condition |
+|---|---|---|
+| 1 | Draft | `kolabs.status = draft` |
+| 2 | Scheduled / Active / Completed / Cancelled | a `collaborations` row exists for this kolab.id → mirror its `status` |
+| 3 | Matched | ≥1 accepted application AND **no** collaboration row yet |
+| 4 | Closed | `kolabs.status = closed` AND no collaboration exists |
+| 5 | Receiving applicants | published, ≥1 pending application, no accepted yet |
+| 6 | Open | published, nothing yet |
+
+`applyFilter()` mirrors this — each filter option matches **only** the kolabs whose `derive()` would return exactly that lifecycle.
+
+### Root cause of the surprise
+The taxonomy is correct, but the **labels and the filter granularity are misleading**.
+
+- **"Matched" today means a transient edge state** — accepted application exists, but the collaboration row hasn't been created yet. In practice this is near-empty (acceptance creates the collaboration immediately), so the filter looks broken.
+- What you actually want when you filter "Matched" is "a match was confirmed at some point" — which includes Scheduled, Active, Completed, and Cancelled. None of those show under the current "Matched" filter.
+- There's no composite filter for "any kolab that has progressed past Receiving" — you have to click each lifecycle in turn.
+
+### Proposed fix
+A small, low-risk refactor of `applyFilter()` plus a label change. **No migration, no data change.**
+
+1. Rename `Matched` → **`Pending match`** in the dropdown labels (the underlying constant stays `matched` so cross-references and tests don't break). This makes it clear it's the transient edge state.
+2. Add a new composite filter option **`Has match`** that returns the union of Matched + Scheduled + Active + Completed (everything where an accepted application has produced a real match). Implemented as `whereExists(applications WHERE status = accepted)` — single subselect.
+3. Add a second composite option **`Completed or done`** that returns Completed + Cancelled + Closed (post-mortem bucket).
+4. Reorder the dropdown for legibility:
+   ```
+   All
+   ──────────
+   Draft
+   Open
+   Receiving applicants
+   Pending match            ← was "Matched"
+   ──────────
+   Has match (any stage)   ← new composite
+   Scheduled
+   Active
+   Completed
+   ──────────
+   Closed
+   Cancelled
+   Completed or done       ← new composite
+   ```
+5. **Verification step:** add a small admin diagnostic command `php artisan app:audit-kolab-lifecycles` that prints, for each lifecycle bucket, the count vs. what the live data implies. Run on prod once to confirm derive() matches your mental model before further changes. *(Optional but valuable; ~30 min.)*
+
+### Secondary findings while auditing
+- **System A opportunities are invisible on `/admin/kolabs`.** The admin Kolabs page lists only the `kolabs` table. Legacy opportunities created via the System A path (`OpportunityController` → `collab_opportunities` directly) don't appear, even if they have live applications. This is by design today, but if you see "missing kolabs" in the admin compared to what the mobile app shows, this is why. Resolving requires either listing both tables (messy) or completing the `LegacyOpportunityBridgeService` cleanup so System A is dead. **Not part of this PR.**
+- **The bridge invariant (`kolab.id == collab_opportunity.id`) is required** for the filter to work. If you see a kolab in the admin list that should have a collab but doesn't, query `collab_opportunities` directly with that UUID to confirm the bridge ran. The bridge runs from `ApplicationController::store()` — application submission triggers it. A kolab that has somehow accumulated `applications` without ever going through `ApplicationController` (which shouldn't be possible via the public API) would have an inconsistent state. *Worth confirming on prod data.*
+
+### Scope of the lifecycle fix
+- `app/Services/Admin/KolabLifecycleService.php` — extend `applyFilter()` with two new lifecycle keys (`has_match`, `done`).
+- `resources/views/admin/kolabs/index.blade.php` — relabel `Matched` and add the two composite options at sensible positions in the dropdown.
+- `tests/Feature/Admin/KolabManagementTest.php` — add three tests (composite Has match, composite Done, Pending-match label).
+- *(Optional)* `app/Console/Commands/AuditKolabLifecycles.php`.
+- ROLES docs — none affected.
+
+**Estimated effort:** ~1 hour with tests.
+
+---
+
+## Thread 2 — Gamification admin section is still missing
+
+### Current state
+- The admin sidebar has **CONTENT** (Kolabs) and **INSIGHTS** (Statistics) headers. There is no **GAMIFICATION** section.
+- The gamification system is entirely driven by code-level constants + the seeded `challenges`, `badges`, and `earned_badges` tables. None of these are admin-editable.
+- The mobile app hardcodes XP ladders, per-action XP amounts, badge requirements, referral milestone, and withdrawal economics. The backend awards points without exposing the rates → silent drift risk.
+
+### Two prompts already exist for this work
+We reviewed and flagged both during the iteration earlier today:
+
+1. **Admin challenge catalogue + role-based defaults + per-collaboration bonuses** — manages the `challenges` table (per-challenge `audience`, `points`, the matrix that maps business/community types to default challenges, business-defined real-world bonuses per collaboration).
+2. **Admin XP / rewards economy + `/gamification/config` read endpoint** — manages XP levels, per-action XP awards (the single source of truth that both writes `point_ledger` and powers the app's labels), badge requirements, and the referral + withdrawal economics. Read endpoint replaces the app's hardcoded constants.
+
+Both prompts have **non-trivial open questions** flagged during the review. Before building, those need answers (one chat round).
+
+### Open decisions blocking the gamification build
+
+**From the challenges prompt:**
+1. **Bonus storage** — option A (pivot, preserved-sync) or option B (separate `collaboration_challenge_bonuses` table)? I recommended B.
+2. **Defaults slug format** — underscored (matches `*_profiles` columns) or hyphenated (matches lookup-table seeders)? I recommended underscore + a same-PR fix of the lookup seeders.
+3. **Defaults source on business side** — `business_type` only, or include `categories[]`?
+4. **Audience enforcement** — 422 or silent filter on a violation?
+5. **Empty-selection allowed via sync?** (Today `min:1`.)
+
+**From the XP economy prompt:**
+6. **Badge system disambiguation** — option A (new `badge_definitions` table keyed by `GamificationBadgeSlug`, attendee `badges` table untouched), option B (unify both systems), or option C (admin-manage `GamificationBadgeSlug` only and punt attendee). I recommended A.
+7. **Withdrawal rate canonical value** — the spec says **€0.25/point**, the backend code currently uses **€0.20/point** (with a hardcoded `375 points = €75` threshold). Confirm which is correct; the prompt's defaults would silently bump payouts by 25 % if not addressed.
+
+### Suggested sequencing (4 PRs, each merge-independent)
+
+I'd ship gamification in this order, smallest blast-radius first:
+
+| PR | Scope | Why this order | Effort |
+|---|---|---|---|
+| **PR-1: Lifecycle filter fix** | Thread 1 above. | Quick win, surfaces no decisions. | ~1 h |
+| **PR-2: XP earn rules + levels + `/gamification/config`** | XP economy prompt §1, §2, §5. Single read endpoint kills the app↔server drift. Drops `awardPoints`'s `$points` parameter in favour of a rule-table lookup. Includes `PointEventType::defaultPoints()` fallback. | Highest-impact, lowest-question-count. Drift is silent and current. | ~1 day |
+| **PR-3: Reward economics + withdrawal wiring** | XP economy prompt §4. Resolves the €0.20 vs €0.25 disagreement; removes the hardcoded `375` / `0.20` literals in `GamificationController::withdrawal()`. Includes the `currency` / `withdrawal_threshold_cents` / `referral_cash_reward_cents` settings. | Needs Q7 answered (rate). | ~½ day |
+| **PR-4: Admin challenge catalogue + audience + defaults seeding** | Challenges prompt §1–§3. Per-challenge `audience` column. Default matrix per business/community type. Hooks into `CollaborationService::createFromApplication` for idempotent seeding. Includes the slug-format reconciliation. | Needs Q1–Q5 answered. | ~1 day |
+| **PR-5: Business bonus rewards on a challenge** | Challenges prompt §4. Option B (separate `collaboration_challenge_bonuses` table). Business-only policy. Includes the attendee-facing claim/redeem follow-ups *only if* attendee scope is confirmed (still `[VERIFY]` per the ROLES doc §7). | Cleanest as a follow-up. | ~½ day |
+| **PR-6: Badge admin** | XP economy prompt §3. Per option A (`badge_definitions` table keyed by `GamificationBadgeSlug`). | Last because of Q6. | ~½ day |
+
+**Total:** ~3.5–4 days of focused work spread across 6 PRs.
+
+A new sidebar header **GAMIFICATION** is added in PR-2 (it's the first one that touches `/admin/*`); subsequent PRs slot into it.
+
+---
+
+## What I'd like from you before starting
+
+A single round of answers, ideally short:
+
+- **Lifecycle filter:** OK with the relabel + composite-filter approach? (or push back on the label changes)
+- **Withdrawal rate (Q7):** €0.20/point (current code) or €0.25/point (spec doc § 3.5)?
+- **Badge dual-system (Q6):** A (new table for `GamificationBadgeSlug`) — or you want option B / C?
+- **Bonus storage (Q1):** A (pivot) or B (separate table)?
+- **Slug format (Q2):** underscored everywhere?
+- **The other small ones (Q3 / Q4 / Q5):** I can default to my recommendations if you don't have strong opinions.
+
+Once those are in, I start in the order above. PR-1 (lifecycle fix) is independent and can go in parallel.
+
+---
+
+*Sister doc to:*
+- *2026-05-31-admin-stats-dashboard.md* — stats infra this builds on
+- *2026-06-01 feedback-gate plan (in PR #9 description)*


### PR DESCRIPTION
## Summary
A single launch-tracking backlog consolidating four parallel code audits and two lighter checks I just ran. Mirrored byte-identical into [`kolabing-app`](https://github.com/kolabing/kolabing-app/pull/new/docs/launch-backlog-2026-06-01).

### What's covered
1. **Email / Postmark** — not wired. No Mailables. Only password reset uses Laravel's broker default.
2. **Push / OneSignal** — live and working for core transactional events. `NotificationPreference` opt-out **not respected**. Four notification types declared in enum but never dispatched.
3. **Apple IAP** — fully shipped (StoreKit2, webhook, state sync, grace period).
4. **Stripe** — stub-only. Env vars exist, zero implementation.
5. **Web subscription checkout** — doesn't exist. All landing-page CTAs (`Join as a business`, app store buttons) are \`href=\"#\"\`.
6. **Landing page** — polished MVP design, but no `/pricing`, no GDPR cookie banner (hard EU risk), no analytics.
7. **DB region** — env defaults to us-east-1; production region must be confirmed with Daniel and (likely) migrated to EU.
8. **Profile-picture zoom** — app-only feature (wrap with InteractiveViewer / PhotoView).

### Why one file
Owner-tagged (`backend` / `app` / `cross` / `infra` / `product`) + priority-tagged (P0 / P1 / P2). So the same backlog serves as a launch checklist regardless of which repo you're working in.

Also pulls in the still-open role-surface items from `ROLES-BACKEND-DB-MAP.md §8` (Explore blur, coliving enum, attendee scope) and the admin gap items from [docs/plans/2026-06-01-admin-followups.md](docs/plans/2026-06-01-admin-followups.md), so the launch view is in one place.

## Test plan
- [x] `diff -q docs/BACKLOG.md ../kolabing-app/docs/BACKLOG.md` is empty.
- [ ] Daniel reads through, especially the P0 items, and confirms ownership / priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)