### PR TITLE
feat(admin/kolabs): rename Matched -> Pending match + composite Has match / Done filters

### DIFF
--- a/app/Http/Controllers/Admin/KolabController.php
+++ b/app/Http/Controllers/Admin/KolabController.php
@@ -65,7 +65,7 @@ class KolabController extends Controller
             'kolabs' => $kolabs,
             'lifecycles' => $lifecycles,
             'statuses' => KolabStatus::cases(),
-            'lifecycleOptions' => KolabLifecycleService::all(),
+            'lifecycleOptions' => KolabLifecycleService::filterOptions(),
             'filters' => [
                 'status' => (string) $request->string('status'),
                 'q' => (string) $request->string('q'),

--- a/app/Services/Admin/KolabLifecycleService.php
+++ b/app/Services/Admin/KolabLifecycleService.php
@@ -35,7 +35,15 @@ class KolabLifecycleService
     public const CLOSED = 'closed';
 
     /**
-     * All lifecycle keys in display order.
+     * Composite filters — returned by no kolab's derive() but accepted by
+     * applyFilter() to broaden the dropdown. See docs/plans 2026-06-01.
+     */
+    public const HAS_MATCH = 'has_match';
+
+    public const DONE = 'done';
+
+    /**
+     * Lifecycle keys that derive() can return. One label per kolab.
      *
      * @return array<int, string>
      */
@@ -47,18 +55,37 @@ class KolabLifecycleService
         ];
     }
 
+    /**
+     * Filterable options for the /admin/kolabs dropdown — all primary
+     * lifecycles plus the two composite shortcuts.
+     *
+     * @return array<int, string>
+     */
+    public static function filterOptions(): array
+    {
+        return [
+            self::DRAFT, self::OPEN, self::RECEIVING, self::MATCHED,
+            self::HAS_MATCH,
+            self::SCHEDULED, self::ACTIVE, self::COMPLETED,
+            self::CANCELLED, self::CLOSED,
+            self::DONE,
+        ];
+    }
+
     public static function label(string $lifecycle): string
     {
         return match ($lifecycle) {
             self::DRAFT => 'Draft',
             self::OPEN => 'Open',
             self::RECEIVING => 'Receiving applicants',
-            self::MATCHED => 'Matched',
+            self::MATCHED => 'Pending match',
+            self::HAS_MATCH => 'Has match (any stage)',
             self::SCHEDULED => 'Scheduled',
             self::ACTIVE => 'Active',
             self::COMPLETED => 'Completed',
             self::CANCELLED => 'Cancelled',
             self::CLOSED => 'Closed',
+            self::DONE => 'Completed or done',
             default => ucfirst(str_replace('_', ' ', $lifecycle)),
         };
     }
@@ -247,6 +274,21 @@ class KolabLifecycleService
             self::ACTIVE => $query->whereExists($hasCollabWith(CollaborationStatus::Active)),
             self::COMPLETED => $query->whereExists($hasCollabWith(CollaborationStatus::Completed)),
             self::CANCELLED => $query->whereExists($hasCollabWith(CollaborationStatus::Cancelled)),
+
+            // Composite: anywhere along the match track — accepted application
+            // exists, regardless of subsequent collab state.
+            self::HAS_MATCH => $query->whereExists($hasApplicationWith(ApplicationStatus::Accepted)),
+
+            // Composite: post-mortem bucket — done with us, one way or the other.
+            self::DONE => $query->where(function ($outer) use ($hasCollabWith, $hasAnyCollab): void {
+                $outer->whereExists($hasCollabWith(CollaborationStatus::Completed))
+                    ->orWhereExists($hasCollabWith(CollaborationStatus::Cancelled))
+                    ->orWhere(function ($q) use ($hasAnyCollab): void {
+                        $q->where('kolabs.status', KolabStatus::Closed->value)
+                            ->whereNotExists($hasAnyCollab);
+                    });
+            }),
+
             default => null,
         };
     }

--- a/tests/Feature/Admin/KolabManagementTest.php
+++ b/tests/Feature/Admin/KolabManagementTest.php
@@ -104,6 +104,107 @@ class KolabManagementTest extends TestCase
         $response->assertDontSee('No Collab Kolab');
     }
 
+    public function test_lifecycle_filter_has_match_returns_kolabs_at_any_post_acceptance_stage(): void
+    {
+        // Pending-match only (no collab row yet).
+        $pendingMatch = $this->kolabWithOpportunity(['title' => 'Pending Match Kolab']);
+        Application::factory()->accepted()->create([
+            'collab_opportunity_id' => $pendingMatch->id,
+            'applicant_profile_id' => Profile::factory()->community(),
+        ]);
+
+        // Active collab (post-acceptance, still running).
+        $activeCollab = $this->kolabWithOpportunity(['title' => 'Active Collab Kolab']);
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $activeCollab->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $activeCollab->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $activeCollab->creator_profile_id,
+        ]);
+
+        // Completed collab (post-acceptance, done).
+        $completedCollab = $this->kolabWithOpportunity(['title' => 'Completed Collab Kolab']);
+        Collaboration::factory()->completed()->create([
+            'collab_opportunity_id' => $completedCollab->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $completedCollab->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $completedCollab->creator_profile_id,
+        ]);
+
+        // No acceptance — should NOT appear under Has match.
+        Kolab::factory()->published()->create(['title' => 'No Acceptance Kolab']);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index', ['lifecycle' => 'has_match']));
+
+        $response->assertSee('Pending Match Kolab');
+        $response->assertSee('Active Collab Kolab');
+        $response->assertSee('Completed Collab Kolab');
+        $response->assertDontSee('No Acceptance Kolab');
+    }
+
+    public function test_lifecycle_filter_done_returns_completed_cancelled_or_closed(): void
+    {
+        // Completed collab.
+        $completed = $this->kolabWithOpportunity(['title' => 'Completed Done Kolab']);
+        Collaboration::factory()->completed()->create([
+            'collab_opportunity_id' => $completed->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $completed->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $completed->creator_profile_id,
+        ]);
+
+        // Cancelled collab.
+        $cancelled = $this->kolabWithOpportunity(['title' => 'Cancelled Done Kolab']);
+        Collaboration::factory()->cancelled()->create([
+            'collab_opportunity_id' => $cancelled->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $cancelled->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $cancelled->creator_profile_id,
+        ]);
+
+        // Closed by creator, no collab.
+        Kolab::factory()->closed()->create(['title' => 'Closed By Creator Kolab']);
+
+        // Still active — should NOT appear under Done.
+        $active = $this->kolabWithOpportunity(['title' => 'Still Active Kolab']);
+        Collaboration::factory()->active()->create([
+            'collab_opportunity_id' => $active->id,
+            'application_id' => Application::factory()->accepted()->create([
+                'collab_opportunity_id' => $active->id,
+                'applicant_profile_id' => Profile::factory()->community(),
+            ])->id,
+            'creator_profile_id' => $active->creator_profile_id,
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index', ['lifecycle' => 'done']));
+
+        $response->assertSee('Completed Done Kolab');
+        $response->assertSee('Cancelled Done Kolab');
+        $response->assertSee('Closed By Creator Kolab');
+        $response->assertDontSee('Still Active Kolab');
+    }
+
+    public function test_dropdown_uses_pending_match_label_instead_of_matched(): void
+    {
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.kolabs.index'));
+
+        $response->assertOk()
+            ->assertSee('Pending match', false)
+            ->assertSee('Has match (any stage)', false)
+            ->assertSee('Completed or done', false);
+    }
+
     public function test_edit_page_shows_collaboration_details_and_reviews(): void
     {
         $kolab = $this->kolabWithOpportunity();


### PR DESCRIPTION
## Summary
Closes Thread 1 of [docs/plans/2026-06-01-admin-followups.md](docs/plans/2026-06-01-admin-followups.md). You reported that "Matched" never showed kolabs you intuitively expected (e.g. ones with live collaborations). Confirmed: the existing taxonomy is correct but the label + filter granularity is misleading. This is the small relabel-and-extend fix from that plan.

### Changes
- Rename **Matched** → **Pending match** in the UI (key stays as \`matched\`).
- New composite **Has match (any stage)** filter — returns every kolab with an accepted application, regardless of subsequent collab state.
- New composite **Completed or done** filter — post-mortem bucket: completed + cancelled + closed-without-live-collab.
- Split \`KolabLifecycleService::all()\` (one-per-kolab derive() outputs) from \`filterOptions()\` (dropdown options, including composites). Controller passes the latter.

### What is *not* in this PR
- No change to \`derive()\` or \`badgeClass()\`. A kolab's lifecycle badge stays as before.
- No schema, no migration.

## Test plan
- [x] 3 new feature tests (Has match returns 3 stages, Done excludes still-active, "Pending match" label rendered).
- [x] Existing 13 admin tests still green.
- [x] **706 tests / 3567 assertions** full suite green.
- [x] \`vendor/bin/pint --dirty\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)