### PR TITLE
feat(gamification): admin-editable reward economics + live cost-impact preview

### DIFF
--- a/app/Http/Controllers/Admin/RewardEconomicsController.php
+++ b/app/Http/Controllers/Admin/RewardEconomicsController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\UpdateRewardEconomicsRequest;
+use App\Services\Admin\RewardEconomicsService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class RewardEconomicsController extends Controller
+{
+    public function __construct(private readonly RewardEconomicsService $service) {}
+
+    public function edit(): View
+    {
+        $current = $this->service->current();
+
+        return view('admin.gamification.economics.edit', [
+            'economics' => $current,
+            'currentImpact' => $this->service->costImpact(
+                $current->euro_cents_per_point,
+                $current->withdrawal_threshold_cents,
+            ),
+        ]);
+    }
+
+    public function update(UpdateRewardEconomicsRequest $request): RedirectResponse
+    {
+        $this->service->update($request->validated());
+
+        return redirect()
+            ->route('admin.gamification.economics.edit')
+            ->with('status', __('Reward economics updated.'));
+    }
+}

--- a/app/Http/Controllers/Api/V1/GamificationController.php
+++ b/app/Http/Controllers/Api/V1/GamificationController.php
@@ -18,6 +18,7 @@ use App\Models\PointLedger;
 use App\Models\Profile;
 use App\Models\ReferralCode;
 use App\Models\WithdrawalRequest;
+use App\Services\Admin\RewardEconomicsService;
 use App\Services\GamificationWalletService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -26,7 +27,8 @@ use Illuminate\Support\Facades\DB;
 class GamificationController extends Controller
 {
     public function __construct(
-        private readonly GamificationWalletService $walletService
+        private readonly GamificationWalletService $walletService,
+        private readonly RewardEconomicsService $economics,
     ) {}
 
     /**
@@ -137,20 +139,23 @@ class GamificationController extends Controller
             ], 409);
         }
 
+        $economics = $this->economics->current();
+        $thresholdPoints = $economics->withdrawalThresholdPoints();
+
         $availablePoints = $wallet->getAvailablePoints();
-        if ($availablePoints < 375) {
+        if ($availablePoints < $thresholdPoints) {
             return response()->json([
                 'success' => false,
-                'message' => "Insufficient points. Need 375, have {$availablePoints}.",
+                'message' => "Insufficient points. Need {$thresholdPoints}, have {$availablePoints}.",
             ], 400);
         }
 
-        $withdrawalRequest = DB::transaction(function () use ($profile, $wallet, $validated): WithdrawalRequest {
-            $eurAmount = round(375 * 0.20, 2);
+        $withdrawalRequest = DB::transaction(function () use ($profile, $wallet, $validated, $thresholdPoints, $economics): WithdrawalRequest {
+            $eurAmount = $economics->payoutFor($thresholdPoints);
 
             $withdrawalRequest = WithdrawalRequest::create([
                 'profile_id' => $profile->id,
-                'points' => 375,
+                'points' => $thresholdPoints,
                 'eur_amount' => $eurAmount,
                 'iban' => $validated['iban'],
                 'account_holder' => $validated['account_holder'],
@@ -159,13 +164,13 @@ class GamificationController extends Controller
 
             PointLedger::create([
                 'profile_id' => $profile->id,
-                'points' => -375,
+                'points' => -$thresholdPoints,
                 'event_type' => PointEventType::Withdrawal,
                 'reference_id' => $withdrawalRequest->id,
                 'description' => "Withdrawal of \u{20AC}".number_format($eurAmount, 2),
             ]);
 
-            $wallet->increment('redeemed_points', 375);
+            $wallet->increment('redeemed_points', $thresholdPoints);
             $wallet->update(['pending_withdrawal' => true]);
 
             return $withdrawalRequest;

--- a/app/Http/Requests/Admin/UpdateRewardEconomicsRequest.php
+++ b/app/Http/Requests/Admin/UpdateRewardEconomicsRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRewardEconomicsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'referral_goal' => ['required', 'integer', 'between:1,100'],
+            'referral_cash_reward_cents' => ['required', 'integer', 'between:0,1000000'],
+            'euro_cents_per_point' => ['required', 'integer', 'between:1,500'],
+            'withdrawal_threshold_cents' => ['required', 'integer', 'between:0,1000000'],
+            'currency' => ['required', 'string', 'size:3'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'euro_cents_per_point.between' => 'Per-point rate must be between 1 cent (€0.01) and 500 cents (€5.00).',
+            'currency.size' => 'Currency must be a 3-letter ISO code (e.g. EUR).',
+        ];
+    }
+}

--- a/app/Models/RewardEconomics.php
+++ b/app/Models/RewardEconomics.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Single-row settings model for the community reward economy.
+ *
+ * @property string $id
+ * @property int $referral_goal
+ * @property int $referral_cash_reward_cents
+ * @property int $euro_cents_per_point
+ * @property int $withdrawal_threshold_cents
+ * @property string $currency
+ */
+class RewardEconomics extends Model
+{
+    /** @use HasFactory<\Database\Factories\RewardEconomicsFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    protected $table = 'reward_economics';
+
+    /** @var list<string> */
+    protected $fillable = [
+        'referral_goal',
+        'referral_cash_reward_cents',
+        'euro_cents_per_point',
+        'withdrawal_threshold_cents',
+        'currency',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'referral_goal' => 'integer',
+            'referral_cash_reward_cents' => 'integer',
+            'euro_cents_per_point' => 'integer',
+            'withdrawal_threshold_cents' => 'integer',
+        ];
+    }
+
+    /**
+     * Number of points required to reach the withdrawal threshold.
+     * Always rounded up so a marginally underpaid user can't withdraw.
+     */
+    public function withdrawalThresholdPoints(): int
+    {
+        if ($this->euro_cents_per_point <= 0) {
+            return 0;
+        }
+
+        return (int) ceil($this->withdrawal_threshold_cents / $this->euro_cents_per_point);
+    }
+
+    /**
+     * Payout for a withdrawal of N points, in euros (2dp).
+     */
+    public function payoutFor(int $points): float
+    {
+        return round(($points * $this->euro_cents_per_point) / 100, 2);
+    }
+}

--- a/app/Services/Admin/RewardEconomicsService.php
+++ b/app/Services/Admin/RewardEconomicsService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Models\RewardEconomics;
+use App\Models\Wallet;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Read + write the single reward_economics row. Reads cached so the
+ * withdrawal flow (called per user action) doesn't hit the DB each time.
+ * Cache busted on admin write.
+ */
+class RewardEconomicsService
+{
+    public const CACHE_KEY = 'reward_economics.current';
+
+    /**
+     * Return the current settings row (cached). Falls back to a zero-state
+     * defaults object if no row exists, so the withdrawal flow never crashes.
+     */
+    public function current(): RewardEconomics
+    {
+        return Cache::remember(
+            self::CACHE_KEY,
+            now()->addHour(),
+            fn (): RewardEconomics => RewardEconomics::query()->first() ?? new RewardEconomics([
+                'referral_goal' => 3,
+                'referral_cash_reward_cents' => 7500,
+                'euro_cents_per_point' => 20,
+                'withdrawal_threshold_cents' => 7500,
+                'currency' => 'EUR',
+            ]),
+        );
+    }
+
+    /**
+     * Update the single row, bust the cache, return the fresh state.
+     *
+     * @param  array<string, int|string>  $data
+     */
+    public function update(array $data): RewardEconomics
+    {
+        $row = RewardEconomics::query()->first();
+
+        if ($row === null) {
+            $row = RewardEconomics::query()->create($data);
+        } else {
+            $row->fill($data);
+            $row->save();
+        }
+
+        Cache::forget(self::CACHE_KEY);
+
+        return $row->fresh();
+    }
+
+    /**
+     * Cost-impact preview for the admin form. Reports how many community
+     * wallets would qualify for a withdrawal at the given rate + threshold,
+     * and the total euro liability if every one of them cashed out.
+     *
+     * Use this to render the live preview card on /admin/gamification/economics
+     * — pass current values for "now" and the form's current input for "after".
+     *
+     * @return array{
+     *     threshold_points: int,
+     *     eligible_wallets: int,
+     *     total_payout_euros: float,
+     *     per_point_euros: float,
+     * }
+     */
+    public function costImpact(int $euroCentsPerPoint, int $withdrawalThresholdCents): array
+    {
+        $thresholdPoints = $euroCentsPerPoint > 0
+            ? (int) ceil($withdrawalThresholdCents / $euroCentsPerPoint)
+            : 0;
+
+        // Available points = points - redeemed_points; eligible if >= threshold.
+        $eligibleWallets = Wallet::query()
+            ->whereRaw('(points - redeemed_points) >= ?', [$thresholdPoints])
+            ->count();
+
+        $totalPayoutEuros = round(
+            ($eligibleWallets * $thresholdPoints * $euroCentsPerPoint) / 100,
+            2,
+        );
+
+        return [
+            'threshold_points' => $thresholdPoints,
+            'eligible_wallets' => $eligibleWallets,
+            'total_payout_euros' => $totalPayoutEuros,
+            'per_point_euros' => round($euroCentsPerPoint / 100, 4),
+        ];
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -333,6 +333,13 @@ return [
             'icon' => 'fas fa-fw fa-chart-line',
             'active' => ['admin/stats', 'admin/stats/*'],
         ],
+        ['header' => 'GAMIFICATION'],
+        [
+            'text' => 'Reward economics',
+            'route' => 'admin.gamification.economics.edit',
+            'icon' => 'fas fa-fw fa-euro-sign',
+            'active' => ['admin/gamification/economics', 'admin/gamification/economics/*'],
+        ],
     ],
 
     /*

--- a/database/migrations/2026_06_01_093844_create_reward_economics_table.php
+++ b/database/migrations/2026_06_01_093844_create_reward_economics_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Single-row settings table that controls the community reward economy:
+     * the referral milestone + cash, the per-point cents rate, and the
+     * withdrawal threshold. Read by RewardEconomicsService; surfaced at
+     * /admin/gamification/economics. Replaces the hardcoded `375` / `0.20`
+     * literals in GamificationController::withdrawal().
+     */
+    public function up(): void
+    {
+        Schema::create('reward_economics', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->unsignedSmallInteger('referral_goal')->default(3);
+            $table->unsignedInteger('referral_cash_reward_cents')->default(7500);
+            $table->unsignedSmallInteger('euro_cents_per_point')->default(20);
+            $table->unsignedInteger('withdrawal_threshold_cents')->default(7500);
+            $table->string('currency', 3)->default('EUR');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reward_economics');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
             CommunityTypeSeeder::class,
             BadgeSeeder::class,
             SystemChallengeSeeder::class,
+            RewardEconomicsSeeder::class,
             RealisticDataSeeder::class,
         ]);
     }

--- a/database/seeders/RewardEconomicsSeeder.php
+++ b/database/seeders/RewardEconomicsSeeder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\RewardEconomics;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seed the single reward_economics row. €0.20/point matches the current
+ * GamificationController::withdrawal() literals (375 points × €0.20 = €75),
+ * so deploying this PR with the seed run does NOT change live payouts.
+ * Maintainers can edit afterwards. Idempotent: first row is upserted by id.
+ */
+class RewardEconomicsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (RewardEconomics::query()->exists()) {
+            return;
+        }
+
+        RewardEconomics::query()->create([
+            'referral_goal' => 3,
+            'referral_cash_reward_cents' => 7500,
+            'euro_cents_per_point' => 20,
+            'withdrawal_threshold_cents' => 7500,
+            'currency' => 'EUR',
+        ]);
+    }
+}

--- a/resources/views/admin/gamification/economics/edit.blade.php
+++ b/resources/views/admin/gamification/economics/edit.blade.php
@@ -1,0 +1,158 @@
+@extends('admin.layout', ['title' => 'Reward economics'])
+
+@section('page_title', 'Reward economics')
+@section('page_subtitle', 'Per-point rate, withdrawal threshold, and referral incentives. Edits here flow into the live withdrawal flow.')
+
+@section('admin_content')
+    <div class="row">
+        <div class="col-lg-7">
+            <div class="card card-primary card-outline">
+                <form method="POST" action="{{ route('admin.gamification.economics.update') }}" id="economics-form">
+                    @csrf
+                    @method('PUT')
+
+                    <div class="card-body">
+                        <h5 class="mb-3">Withdrawal</h5>
+
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <label for="euro_cents_per_point">Per-point rate (€ cents)</label>
+                                <input type="number" name="euro_cents_per_point" id="euro_cents_per_point"
+                                       min="1" max="500" required class="form-control"
+                                       value="{{ old('euro_cents_per_point', $economics->euro_cents_per_point) }}">
+                                <small class="form-text text-muted">
+                                    <span id="display-per-point">€{{ number_format($economics->euro_cents_per_point / 100, 2) }}</span> per point.
+                                </small>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <label for="withdrawal_threshold_cents">Withdrawal threshold (€ cents)</label>
+                                <input type="number" name="withdrawal_threshold_cents" id="withdrawal_threshold_cents"
+                                       min="0" max="1000000" required class="form-control"
+                                       value="{{ old('withdrawal_threshold_cents', $economics->withdrawal_threshold_cents) }}">
+                                <small class="form-text text-muted">
+                                    <span id="display-threshold-eur">€{{ number_format($economics->withdrawal_threshold_cents / 100, 2) }}</span>
+                                    = <span id="display-threshold-points">{{ $currentImpact['threshold_points'] }}</span> points required.
+                                </small>
+                            </div>
+                        </div>
+
+                        <hr>
+                        <h5 class="mb-3">Referral</h5>
+
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <label for="referral_goal">Referrals required to unlock cash reward</label>
+                                <input type="number" name="referral_goal" id="referral_goal" min="1" max="100" required
+                                       class="form-control" value="{{ old('referral_goal', $economics->referral_goal) }}">
+                            </div>
+                            <div class="form-group col-md-6">
+                                <label for="referral_cash_reward_cents">Referral cash reward (€ cents)</label>
+                                <input type="number" name="referral_cash_reward_cents" id="referral_cash_reward_cents"
+                                       min="0" max="1000000" required class="form-control"
+                                       value="{{ old('referral_cash_reward_cents', $economics->referral_cash_reward_cents) }}">
+                                <small class="form-text text-muted">
+                                    €<span id="display-referral-eur">{{ number_format($economics->referral_cash_reward_cents / 100, 2) }}</span>
+                                </small>
+                            </div>
+                        </div>
+
+                        <hr>
+                        <h5 class="mb-3">Other</h5>
+
+                        <div class="form-group">
+                            <label for="currency">Currency</label>
+                            <input type="text" name="currency" id="currency" maxlength="3" required
+                                   class="form-control" style="max-width: 100px;"
+                                   value="{{ old('currency', $economics->currency) }}">
+                        </div>
+                    </div>
+
+                    <div class="card-footer">
+                        <button type="submit" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="col-lg-5">
+            <div class="card card-warning card-outline">
+                <div class="card-header"><h3 class="card-title mb-0">Cost-impact preview</h3></div>
+                <div class="card-body">
+                    <p class="text-muted small mb-3">
+                        How many community wallets would qualify for a payout at the values currently in the form,
+                        and the total euro liability if every one of them cashed out today. Updates as you type.
+                    </p>
+                    <dl class="row mb-0">
+                        <dt class="col-sm-7">Threshold (points)</dt>
+                        <dd class="col-sm-5 text-right"><span id="impact-threshold-points">{{ $currentImpact['threshold_points'] }}</span></dd>
+
+                        <dt class="col-sm-7">Eligible wallets</dt>
+                        <dd class="col-sm-5 text-right"><span id="impact-eligible">{{ $currentImpact['eligible_wallets'] }}</span></dd>
+
+                        <dt class="col-sm-7">Per-point rate</dt>
+                        <dd class="col-sm-5 text-right">€<span id="impact-rate">{{ number_format($currentImpact['per_point_euros'], 4) }}</span></dd>
+
+                        <dt class="col-sm-7 font-weight-bold">Total potential payout</dt>
+                        <dd class="col-sm-5 text-right font-weight-bold">€<span id="impact-payout">{{ number_format($currentImpact['total_payout_euros'], 2) }}</span></dd>
+                    </dl>
+                </div>
+                <div class="card-footer small text-muted">
+                    Live preview uses the same math as the withdrawal flow.
+                    Server values shown here on page load; typing updates the
+                    points-per-threshold + euro estimate. The "eligible wallets"
+                    count is the server snapshot — refresh after large changes.
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Vanilla JS preview. CSP allows 'unsafe-inline' so this works without
+         a build step. No external libs. --}}
+    <script>
+        (function () {
+            const ratePoints  = document.getElementById('euro_cents_per_point');
+            const thresholdEl = document.getElementById('withdrawal_threshold_cents');
+            const referralEl  = document.getElementById('referral_cash_reward_cents');
+
+            const displayPerPoint     = document.getElementById('display-per-point');
+            const displayThresholdEur = document.getElementById('display-threshold-eur');
+            const displayThresholdPts = document.getElementById('display-threshold-points');
+            const displayReferralEur  = document.getElementById('display-referral-eur');
+
+            const impactThreshold = document.getElementById('impact-threshold-points');
+            const impactRate      = document.getElementById('impact-rate');
+            const impactPayout    = document.getElementById('impact-payout');
+            const impactEligible  = document.getElementById('impact-eligible');
+
+            const eligibleSnapshot = parseInt(impactEligible.textContent, 10) || 0;
+
+            function fmt(n, places) {
+                return (Math.round(n * Math.pow(10, places)) / Math.pow(10, places))
+                    .toFixed(places);
+            }
+
+            function update() {
+                const rateCents      = parseInt(ratePoints.value, 10);
+                const thresholdCents = parseInt(thresholdEl.value, 10);
+                const referralCents  = parseInt(referralEl.value, 10);
+
+                if (rateCents > 0) {
+                    const points = Math.ceil(thresholdCents / rateCents);
+                    displayPerPoint.textContent = '€' + fmt(rateCents / 100, 2);
+                    displayThresholdEur.textContent = '€' + fmt(thresholdCents / 100, 2);
+                    displayThresholdPts.textContent = points;
+
+                    impactThreshold.textContent = points;
+                    impactRate.textContent = fmt(rateCents / 100, 4);
+                    impactPayout.textContent = fmt((eligibleSnapshot * points * rateCents) / 100, 2);
+                }
+
+                displayReferralEur.textContent = fmt(referralCents / 100, 2);
+            }
+
+            [ratePoints, thresholdEl, referralEl].forEach(function (el) {
+                el.addEventListener('input', update);
+            });
+        })();
+    </script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Admin\AuthController as AdminAuthController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\KolabController as AdminKolabController;
 use App\Http\Controllers\Admin\ManagedUserController;
+use App\Http\Controllers\Admin\RewardEconomicsController as AdminRewardEconomicsController;
 use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use Illuminate\Support\Facades\Route;
 
@@ -37,6 +38,11 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::post('/kolabs/{kolab}/collaboration/complete', [AdminKolabController::class, 'completeCollaboration'])->name('kolabs.collaboration.complete');
 
     Route::get('/stats', [AdminStatsController::class, 'index'])->name('stats.index');
+
+    Route::prefix('gamification')->as('gamification.')->group(function (): void {
+        Route::get('/economics', [AdminRewardEconomicsController::class, 'edit'])->name('economics.edit');
+        Route::put('/economics', [AdminRewardEconomicsController::class, 'update'])->name('economics.update');
+    });
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/tests/Feature/Admin/RewardEconomicsAdminTest.php
+++ b/tests/Feature/Admin/RewardEconomicsAdminTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Profile;
+use App\Models\RewardEconomics;
+use App\Models\User;
+use App\Models\Wallet;
+use App\Services\Admin\RewardEconomicsService;
+use Database\Seeders\RewardEconomicsSeeder;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class RewardEconomicsAdminTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::forget(RewardEconomicsService::CACHE_KEY);
+        $this->seed(RewardEconomicsSeeder::class);
+    }
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_edit_page_renders_for_maintainer(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.gamification.economics.edit'))
+            ->assertOk()
+            ->assertSee('Reward economics')
+            ->assertSee('Per-point rate')
+            ->assertSee('Cost-impact preview');
+    }
+
+    public function test_edit_page_forbidden_for_non_maintainer(): void
+    {
+        $user = User::factory()->create(['is_maintainer' => false]);
+
+        $this->actingAs($user, 'admin')
+            ->get(route('admin.gamification.economics.edit'))
+            ->assertForbidden();
+    }
+
+    public function test_update_changes_per_point_rate(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.economics.update'), [
+                'referral_goal' => 3,
+                'referral_cash_reward_cents' => 7500,
+                'euro_cents_per_point' => 25,
+                'withdrawal_threshold_cents' => 7500,
+                'currency' => 'EUR',
+            ])
+            ->assertRedirect(route('admin.gamification.economics.edit'));
+
+        $this->assertSame(25, RewardEconomics::query()->firstOrFail()->euro_cents_per_point);
+    }
+
+    public function test_update_rejects_invalid_rate(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.economics.update'), [
+                'referral_goal' => 3,
+                'referral_cash_reward_cents' => 7500,
+                'euro_cents_per_point' => 0,
+                'withdrawal_threshold_cents' => 7500,
+                'currency' => 'EUR',
+            ])
+            ->assertSessionHasErrors('euro_cents_per_point');
+    }
+
+    public function test_withdrawal_flow_uses_economics_threshold_and_rate(): void
+    {
+        // Set rate to €0.25/point + threshold €100 → 400 points required.
+        RewardEconomics::query()->first()->update([
+            'euro_cents_per_point' => 25,
+            'withdrawal_threshold_cents' => 10000,
+        ]);
+        Cache::forget(RewardEconomicsService::CACHE_KEY);
+
+        $profile = Profile::factory()->community()->create();
+        Wallet::factory()->create([
+            'profile_id' => $profile->id,
+            'points' => 500,
+            'redeemed_points' => 0,
+            'pending_withdrawal' => false,
+        ]);
+
+        $response = $this->actingAs($profile)
+            ->postJson(route('api.v1.gamification.withdrawal'), [
+                'iban' => 'ES7921000813610123456789',
+                'account_holder' => 'Test User',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.points', 400)
+            ->assertJsonPath('data.eur_amount', 100);
+    }
+
+    public function test_withdrawal_blocked_below_threshold(): void
+    {
+        $profile = Profile::factory()->community()->create();
+        Wallet::factory()->create([
+            'profile_id' => $profile->id,
+            'points' => 374,
+            'redeemed_points' => 0,
+            'pending_withdrawal' => false,
+        ]);
+
+        $response = $this->actingAs($profile)
+            ->postJson(route('api.v1.gamification.withdrawal'), [
+                'iban' => 'ES7921000813610123456789',
+                'account_holder' => 'Test User',
+            ]);
+
+        $response->assertStatus(400)
+            ->assertJsonPath('message', 'Insufficient points. Need 375, have 374.');
+    }
+
+    public function test_admin_edit_busts_economics_cache(): void
+    {
+        $service = app(RewardEconomicsService::class);
+
+        $this->assertSame(20, $service->current()->euro_cents_per_point);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.economics.update'), [
+                'referral_goal' => 3,
+                'referral_cash_reward_cents' => 7500,
+                'euro_cents_per_point' => 30,
+                'withdrawal_threshold_cents' => 7500,
+                'currency' => 'EUR',
+            ]);
+
+        $this->assertSame(30, $service->current()->euro_cents_per_point);
+    }
+
+    public function test_cost_impact_counts_eligible_wallets(): void
+    {
+        Wallet::factory()->count(3)->create([
+            'points' => 400,
+            'redeemed_points' => 0,
+        ]);
+        Wallet::factory()->count(2)->create([
+            'points' => 100,
+            'redeemed_points' => 0,
+        ]);
+
+        $impact = app(RewardEconomicsService::class)->costImpact(20, 7500);
+
+        $this->assertSame(375, $impact['threshold_points']);
+        $this->assertSame(3, $impact['eligible_wallets']);
+        // 3 wallets × 375 points × €0.20 = €225.
+        $this->assertSame(225.0, $impact['total_payout_euros']);
+    }
+}


### PR DESCRIPTION
## Summary
PR-3 of the [admin-followups plan](docs/plans/2026-06-01-admin-followups.md). Replaces the hardcoded \`375\` points / €0.20-per-point / €75-threshold literals in \`GamificationController::withdrawal()\` with a single editable settings row, surfaced at \`/admin/gamification/economics\` with a live cost-impact preview.

### What's different
- New \`reward_economics\` table (single-row settings): \`euro_cents_per_point\`, \`withdrawal_threshold_cents\`, \`referral_goal\`, \`referral_cash_reward_cents\`, \`currency\`.
- **Seeded with €0.20/point + €75 threshold** per your Q1 answer — math resolves to the existing 375 points / €75 payout, so deploying this PR with the seed run does NOT change live payouts. Maintainers can edit afterwards from the admin panel.
- \`GamificationController::withdrawal\` now consumes the service: \`threshold_points = ceil(threshold_cents / per_point_cents)\` and \`payout = (points × per_point_cents) / 100\`.
- Soft-rollout safe: \`RewardEconomicsService::current()\` falls back to a default-shaped row if no record exists.

### Live cost-impact preview
The /admin/gamification/economics page renders a side panel showing:
- Threshold in points (derived live)
- Eligible wallets (server snapshot — actual count from \`wallets\` table)
- Per-point rate
- **Total potential payout** if every eligible wallet cashed out

Updates as the maintainer types in the form. Vanilla JS, CSP-safe (no new script-src host).

## Test plan
- [x] 8 new feature tests (render + auth, update changes rate, invalid rejected, withdrawal uses dynamic threshold + payout, below-threshold blocked, cache bust, eligible-wallet count).
- [x] Existing 18 \`GamificationWalletTest\` cases stay green (seed defaults match old literals).
- [x] **711 tests / 3575 assertions** full suite green.
- [x] \`vendor/bin/pint --dirty\` clean.

## Deploy
1. Merge → \`php artisan migrate --force\` runs the additive migration.
2. \`php artisan db:seed --class=RewardEconomicsSeeder\` (idempotent — skipped if row already exists). \`DatabaseSeeder\` now calls it on \`migrate:fresh\`.
3. Visit \`/admin/gamification/economics\` to confirm the form renders with €0.20/point and €75 threshold.
4. Smoke-test the withdrawal flow on staging — should behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)