### PR TITLE
feat(gamification): admin challenge catalogue + audience + role-based defaults matrix

### DIFF
--- a/app/Enums/ChallengeAudience.php
+++ b/app/Enums/ChallengeAudience.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Which side may add a challenge to a collaboration. Stored on
+ * `challenges.audience`. The app's Gamification Setup card filters the
+ * selectable pool by the viewer's role using this value.
+ */
+enum ChallengeAudience: string
+{
+    case Community = 'community';
+    case Business = 'business';
+    case Both = 'both';
+
+    /**
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Community => 'Community',
+            self::Business => 'Business',
+            self::Both => 'Both',
+        };
+    }
+}

--- a/app/Http/Controllers/Admin/ChallengeController.php
+++ b/app/Http/Controllers/Admin/ChallengeController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\ChallengeAudience;
+use App\Enums\ChallengeCategory;
+use App\Enums\ChallengeDifficulty;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreChallengeRequest;
+use App\Http\Requests\Admin\UpdateChallengeRequest;
+use App\Models\Challenge;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Admin CRUD for the global system-challenge catalogue
+ * (is_system = true AND event_id IS NULL). Custom event-scoped challenges
+ * are organizer-managed elsewhere and intentionally excluded from this list.
+ */
+class ChallengeController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $challenges = Challenge::query()
+            ->where('is_system', true)
+            ->whereNull('event_id')
+            ->when($request->filled('category'), fn ($q) => $q->where('category', $request->string('category')))
+            ->when($request->filled('difficulty'), fn ($q) => $q->where('difficulty', $request->string('difficulty')))
+            ->when($request->filled('audience'), fn ($q) => $q->where('audience', $request->string('audience')))
+            ->orderBy('category')
+            ->orderBy('difficulty')
+            ->orderBy('name')
+            ->paginate(50)
+            ->withQueryString();
+
+        return view('admin.gamification.challenges.index', [
+            'challenges' => $challenges,
+            'categories' => ChallengeCategory::cases(),
+            'difficulties' => ChallengeDifficulty::cases(),
+            'audiences' => ChallengeAudience::cases(),
+            'filters' => [
+                'category' => (string) $request->string('category'),
+                'difficulty' => (string) $request->string('difficulty'),
+                'audience' => (string) $request->string('audience'),
+            ],
+        ]);
+    }
+
+    public function create(): View
+    {
+        return view('admin.gamification.challenges.create', $this->formContext());
+    }
+
+    public function store(StoreChallengeRequest $request): RedirectResponse
+    {
+        Challenge::query()->create(array_merge(
+            $request->validated(),
+            ['is_system' => true],
+        ));
+
+        return redirect()
+            ->route('admin.gamification.challenges.index')
+            ->with('status', __('Challenge created.'));
+    }
+
+    public function edit(Challenge $challenge): View
+    {
+        return view('admin.gamification.challenges.edit', array_merge(
+            $this->formContext(),
+            ['challenge' => $challenge],
+        ));
+    }
+
+    public function update(UpdateChallengeRequest $request, Challenge $challenge): RedirectResponse
+    {
+        $challenge->update($request->validated());
+
+        return redirect()
+            ->route('admin.gamification.challenges.index')
+            ->with('status', __('Challenge updated.'));
+    }
+
+    public function destroy(Challenge $challenge): RedirectResponse
+    {
+        $challenge->delete();
+
+        return redirect()
+            ->route('admin.gamification.challenges.index')
+            ->with('status', __('Challenge deleted.'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formContext(): array
+    {
+        return [
+            'categories' => ChallengeCategory::cases(),
+            'difficulties' => ChallengeDifficulty::cases(),
+            'audiences' => ChallengeAudience::cases(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Admin/ChallengeDefaultsController.php
+++ b/app/Http/Controllers/Admin/ChallengeDefaultsController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\BusinessType;
+use App\Models\Challenge;
+use App\Models\CommunityType;
+use App\Services\Admin\ChallengeDefaultsService;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * The "which challenges should auto-seed for this business / community
+ * type?" matrix. One screen, one save endpoint per type row.
+ */
+class ChallengeDefaultsController extends Controller
+{
+    public function __construct(private readonly ChallengeDefaultsService $service) {}
+
+    public function index(): View
+    {
+        return view('admin.gamification.challenges.defaults.index', [
+            'businessTypes' => BusinessType::query()->orderBy('sort_order')->orderBy('name')->get(),
+            'communityTypes' => CommunityType::query()->orderBy('sort_order')->orderBy('name')->get(),
+            'systemChallenges' => Challenge::query()
+                ->where('is_system', true)
+                ->whereNull('event_id')
+                ->orderBy('category')
+                ->orderBy('name')
+                ->get(),
+            'matrix' => $this->service->matrix(),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'applies_to' => ['required', Rule::in(['business_type', 'community_type'])],
+            'type_value' => ['required', 'string', 'max:100'],
+            'challenge_ids' => ['nullable', 'array'],
+            'challenge_ids.*' => ['uuid', 'exists:challenges,id'],
+        ]);
+
+        $this->service->syncForType(
+            $data['applies_to'],
+            $data['type_value'],
+            $data['challenge_ids'] ?? [],
+        );
+
+        return redirect()
+            ->route('admin.gamification.challenges.defaults.index')
+            ->with('status', __('Defaults updated for :type.', ['type' => $data['type_value']]));
+    }
+}

--- a/app/Http/Requests/Admin/StoreChallengeRequest.php
+++ b/app/Http/Requests/Admin/StoreChallengeRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ChallengeAudience;
+use App\Enums\ChallengeCategory;
+use App\Enums\ChallengeDifficulty;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreChallengeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:150'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'difficulty' => ['required', Rule::in(ChallengeDifficulty::values())],
+            'points' => ['required', 'integer', 'between:0,10000'],
+            'category' => ['nullable', Rule::in(ChallengeCategory::values())],
+            'audience' => ['required', Rule::in(ChallengeAudience::values())],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateChallengeRequest.php
+++ b/app/Http/Requests/Admin/UpdateChallengeRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Enums\ChallengeAudience;
+use App\Enums\ChallengeCategory;
+use App\Enums\ChallengeDifficulty;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateChallengeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:150'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'difficulty' => ['required', Rule::in(ChallengeDifficulty::values())],
+            'points' => ['required', 'integer', 'between:0,10000'],
+            'category' => ['nullable', Rule::in(ChallengeCategory::values())],
+            'audience' => ['required', Rule::in(ChallengeAudience::values())],
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/ChallengeResource.php
+++ b/app/Http/Resources/Api/V1/ChallengeResource.php
@@ -26,6 +26,7 @@ class ChallengeResource extends JsonResource
             'points' => $this->points,
             'is_system' => $this->is_system,
             'category' => $this->category?->value,
+            'audience' => $this->audience?->value ?? 'both',
             'event_id' => $this->event_id,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -42,6 +42,7 @@ class Challenge extends Model
         'is_system',
         'category',
         'event_id',
+        'audience',
     ];
 
     /** @return array<string, string> */
@@ -52,6 +53,7 @@ class Challenge extends Model
             'points' => 'integer',
             'is_system' => 'boolean',
             'category' => ChallengeCategory::class,
+            'audience' => \App\Enums\ChallengeAudience::class,
         ];
     }
 

--- a/app/Models/ChallengeDefault.php
+++ b/app/Models/ChallengeDefault.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Row in the role-based defaults matrix: when a new collaboration forms
+ * between business type X and community type Y, every challenge with a
+ * matching ChallengeDefault row gets auto-selected into
+ * collaboration_challenges. See ChallengeDefaultsService.
+ *
+ * @property string $id
+ * @property string $challenge_id
+ * @property string $applies_to 'business_type' | 'community_type'
+ * @property string $type_value The matching slug, underscored.
+ * @property int $position
+ */
+class ChallengeDefault extends Model
+{
+    /** @use HasFactory<\Database\Factories\ChallengeDefaultFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    /** @var list<string> */
+    protected $fillable = [
+        'challenge_id',
+        'applies_to',
+        'type_value',
+        'position',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+        ];
+    }
+
+    /** @return BelongsTo<Challenge, $this> */
+    public function challenge(): BelongsTo
+    {
+        return $this->belongsTo(Challenge::class);
+    }
+}

--- a/app/Services/Admin/ChallengeDefaultsService.php
+++ b/app/Services/Admin/ChallengeDefaultsService.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Models\Challenge;
+use App\Models\ChallengeDefault;
+use App\Models\Collaboration;
+use App\Models\Profile;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Manages the role-based defaults matrix:
+ *  - Admin reads via matrix() / forType() for the matrix UI.
+ *  - Admin writes via syncForType() to commit a row of the matrix.
+ *  - CollaborationService::createFromApplication() calls
+ *    seedForCollaboration() on the freshly-created row so the default
+ *    challenges land in collaboration_challenges. Idempotent on collab.
+ */
+class ChallengeDefaultsService
+{
+    /**
+     * Replace the set of default challenges for a single (applies_to,
+     * type_value) row. Used by the admin matrix save.
+     *
+     * @param  array<int, string>  $challengeIds  In display order.
+     */
+    public function syncForType(string $appliesTo, string $typeValue, array $challengeIds): void
+    {
+        DB::transaction(function () use ($appliesTo, $typeValue, $challengeIds): void {
+            ChallengeDefault::query()
+                ->where('applies_to', $appliesTo)
+                ->where('type_value', $typeValue)
+                ->delete();
+
+            foreach (array_values(array_unique($challengeIds)) as $position => $challengeId) {
+                ChallengeDefault::query()->create([
+                    'challenge_id' => $challengeId,
+                    'applies_to' => $appliesTo,
+                    'type_value' => $typeValue,
+                    'position' => $position,
+                ]);
+            }
+        });
+    }
+
+    /**
+     * Read the challenge ids currently set as defaults for a single
+     * (applies_to, type_value) row.
+     *
+     * @return array<int, string>
+     */
+    public function forType(string $appliesTo, string $typeValue): array
+    {
+        return ChallengeDefault::query()
+            ->where('applies_to', $appliesTo)
+            ->where('type_value', $typeValue)
+            ->orderBy('position')
+            ->pluck('challenge_id')
+            ->all();
+    }
+
+    /**
+     * Seed a freshly-created collaboration with default challenges based on
+     * the participant business + community types. Idempotent: skips if
+     * collaboration_challenges already has any rows for this collaboration.
+     */
+    public function seedForCollaboration(Collaboration $collaboration): void
+    {
+        if ($collaboration->challenges()->exists()) {
+            return;
+        }
+
+        $businessType = $this->resolveBusinessType($collaboration);
+        $communityType = $this->resolveCommunityType($collaboration);
+
+        $challengeIds = collect();
+
+        if ($businessType !== null) {
+            $challengeIds = $challengeIds->merge(
+                $this->forType('business_type', $businessType),
+            );
+        }
+        if ($communityType !== null) {
+            $challengeIds = $challengeIds->merge(
+                $this->forType('community_type', $communityType),
+            );
+        }
+
+        $unique = $challengeIds->unique()->values();
+
+        if ($unique->isEmpty()) {
+            return;
+        }
+
+        $collaboration->challenges()->sync($unique->all());
+    }
+
+    /**
+     * Compact representation of the matrix for the admin view:
+     * keyed by "applies_to:type_value", value is the ordered list of
+     * challenge IDs.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function matrix(): array
+    {
+        return ChallengeDefault::query()
+            ->orderBy('applies_to')
+            ->orderBy('type_value')
+            ->orderBy('position')
+            ->get()
+            ->groupBy(fn (ChallengeDefault $row): string => $row->applies_to.':'.$row->type_value)
+            ->map(fn ($rows) => $rows->pluck('challenge_id')->all())
+            ->all();
+    }
+
+    private function resolveBusinessType(Collaboration $collaboration): ?string
+    {
+        $collaboration->loadMissing(['creatorProfile.businessProfile', 'applicantProfile.businessProfile']);
+
+        foreach ([$collaboration->creatorProfile, $collaboration->applicantProfile] as $profile) {
+            if ($profile instanceof Profile && $profile->isBusiness()) {
+                return $profile->businessProfile?->business_type;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveCommunityType(Collaboration $collaboration): ?string
+    {
+        $collaboration->loadMissing(['creatorProfile.communityProfile', 'applicantProfile.communityProfile']);
+
+        foreach ([$collaboration->creatorProfile, $collaboration->applicantProfile] as $profile) {
+            if ($profile instanceof Profile && $profile->isCommunity()) {
+                return $profile->communityProfile?->community_type;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Services/CollaborationService.php
+++ b/app/Services/CollaborationService.php
@@ -296,6 +296,11 @@ class CollaborationService
                 'contact_methods' => $data['contact_methods'] ?? null,
             ]);
 
+            // Seed role-based default challenges. Idempotent — skips if any
+            // challenges already attached.
+            app(\App\Services\Admin\ChallengeDefaultsService::class)
+                ->seedForCollaboration($collaboration);
+
             return $collaboration->load([
                 'collabOpportunity',
                 'creatorProfile',

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -333,6 +333,19 @@ return [
             'icon' => 'fas fa-fw fa-chart-line',
             'active' => ['admin/stats', 'admin/stats/*'],
         ],
+        ['header' => 'GAMIFICATION'],
+        [
+            'text' => 'Challenges',
+            'route' => 'admin.gamification.challenges.index',
+            'icon' => 'fas fa-fw fa-flag-checkered',
+            'active' => ['admin/gamification/challenges', 'admin/gamification/challenges/*'],
+        ],
+        [
+            'text' => 'Challenge defaults',
+            'route' => 'admin.gamification.challenges.defaults.index',
+            'icon' => 'fas fa-fw fa-th',
+            'active' => ['admin/gamification/challenges/defaults', 'admin/gamification/challenges/defaults/*'],
+        ],
     ],
 
     /*

--- a/database/migrations/2026_06_01_094549_add_audience_to_challenges_and_create_challenge_defaults.php
+++ b/database/migrations/2026_06_01_094549_add_audience_to_challenges_and_create_challenge_defaults.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. Audience tag on each challenge — which side may add it to a
+        //    collaboration. Backfilled to 'both' so legacy challenges keep
+        //    appearing for everyone until a maintainer narrows them.
+        Schema::table('challenges', function (Blueprint $table): void {
+            $table->string('audience', 20)->default('both')->after('points');
+            $table->index('audience');
+        });
+
+        // 2. The role-based defaults matrix: which challenges should
+        //    auto-seed a new collaboration based on the participants'
+        //    business / community type. See ChallengeDefaultsService.
+        Schema::create('challenge_defaults', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('challenge_id')->constrained('challenges')->cascadeOnDelete();
+            $table->string('applies_to', 20); // 'business_type' | 'community_type'
+            $table->string('type_value', 100); // underscored slug
+            $table->unsignedSmallInteger('position')->default(0);
+            $table->timestamps();
+
+            $table->unique(['challenge_id', 'applies_to', 'type_value'], 'challenge_defaults_unique_idx');
+            $table->index(['applies_to', 'type_value']);
+        });
+
+        // 3. Slug-format cleanup: community_types was seeded with hyphenated
+        //    slugs (run-club) while community_profiles.community_type stores
+        //    underscored values (run_club). Reconcile to underscored so the
+        //    defaults matrix actually matches live data.
+        $hyphenToUnderscore = [
+            'run-club' => 'run_club',
+            'fitness-community' => 'fitness_community',
+            'wellness-community' => 'wellness_community',
+            'art-creative-community' => 'art_creative_community',
+            'photography-community' => 'photography_community',
+            'music-community' => 'music_community',
+            'dance-community' => 'dance_community',
+            'tech-startup-community' => 'tech_startup_community',
+            'book-club' => 'book_club',
+            'sustainability-community' => 'sustainability_community',
+            'food-community' => 'food_community',
+            'travel-community' => 'travel_community',
+            'student-community' => 'student_community',
+            'professional-networking-community' => 'professional_networking_community',
+            'business-coworking' => 'business_coworking',
+            'hobby-community' => 'hobby_community',
+        ];
+
+        foreach ($hyphenToUnderscore as $from => $to) {
+            DB::table('community_types')
+                ->where('slug', $from)
+                ->update(['slug' => $to]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('challenge_defaults');
+
+        Schema::table('challenges', function (Blueprint $table): void {
+            $table->dropIndex(['audience']);
+            $table->dropColumn('audience');
+        });
+
+        // Note: slug-format change is NOT reversed automatically. If you must
+        // roll back the slugs to hyphens, do it manually.
+    }
+};

--- a/resources/views/admin/gamification/challenges/_form.blade.php
+++ b/resources/views/admin/gamification/challenges/_form.blade.php
@@ -1,0 +1,53 @@
+{{-- Shared form partial for create + edit --}}
+<div class="form-row">
+    <div class="form-group col-md-8">
+        <label for="name">Name</label>
+        <input type="text" name="name" id="name" maxlength="150" required class="form-control"
+               value="{{ old('name', $challenge->name ?? '') }}">
+    </div>
+    <div class="form-group col-md-4">
+        <label for="points">Points</label>
+        <input type="number" name="points" id="points" min="0" max="10000" required class="form-control"
+               value="{{ old('points', $challenge->points ?? 10) }}">
+    </div>
+</div>
+
+<div class="form-group">
+    <label for="description">Description</label>
+    <textarea name="description" id="description" rows="3" maxlength="1000" class="form-control">{{ old('description', $challenge->description ?? '') }}</textarea>
+</div>
+
+<div class="form-row">
+    <div class="form-group col-md-4">
+        <label for="category">Category</label>
+        <select name="category" id="category" class="form-control">
+            <option value="">—</option>
+            @foreach ($categories as $cat)
+                <option value="{{ $cat->value }}" {{ old('category', $challenge->category?->value ?? '') === $cat->value ? 'selected' : '' }}>
+                    {{ ucfirst(str_replace('_', ' ', $cat->value)) }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    <div class="form-group col-md-4">
+        <label for="difficulty">Difficulty</label>
+        <select name="difficulty" id="difficulty" required class="form-control">
+            @foreach ($difficulties as $d)
+                <option value="{{ $d->value }}" {{ old('difficulty', $challenge->difficulty?->value ?? '') === $d->value ? 'selected' : '' }}>
+                    {{ ucfirst($d->value) }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+    <div class="form-group col-md-4">
+        <label for="audience">Audience</label>
+        <select name="audience" id="audience" required class="form-control">
+            @foreach ($audiences as $a)
+                <option value="{{ $a->value }}" {{ old('audience', $challenge->audience?->value ?? 'both') === $a->value ? 'selected' : '' }}>
+                    {{ $a->label() }}
+                </option>
+            @endforeach
+        </select>
+        <small class="form-text text-muted">Controls which side may add this challenge to a collaboration.</small>
+    </div>
+</div>

--- a/resources/views/admin/gamification/challenges/create.blade.php
+++ b/resources/views/admin/gamification/challenges/create.blade.php
@@ -1,0 +1,24 @@
+@extends('admin.layout', ['title' => 'New challenge'])
+
+@section('page_title', 'New challenge')
+@section('page_actions')
+    <a href="{{ route('admin.gamification.challenges.index') }}" class="btn btn-outline-secondary">
+        <i class="fas fa-arrow-left mr-1"></i>
+        Back
+    </a>
+@endsection
+
+@section('admin_content')
+    <div class="card card-primary card-outline">
+        <form method="POST" action="{{ route('admin.gamification.challenges.store') }}">
+            @csrf
+            <div class="card-body">
+                @include('admin.gamification.challenges._form')
+            </div>
+            <div class="card-footer">
+                <button type="submit" class="btn btn-primary">Create</button>
+                <a href="{{ route('admin.gamification.challenges.index') }}" class="btn btn-default">Cancel</a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/gamification/challenges/defaults/index.blade.php
+++ b/resources/views/admin/gamification/challenges/defaults/index.blade.php
@@ -1,0 +1,95 @@
+@extends('admin.layout', ['title' => 'Challenge defaults'])
+
+@section('page_title', 'Challenge defaults')
+@section('page_subtitle', 'Pick the challenges that auto-seed a new collaboration based on participant business / community type.')
+
+@section('admin_content')
+    @php
+        $renderTypeRow = function (string $appliesTo, string $typeValue, string $typeLabel) use ($systemChallenges, $matrix) {
+            $key = $appliesTo.':'.$typeValue;
+            $selected = $matrix[$key] ?? [];
+
+            return compact('appliesTo', 'typeValue', 'typeLabel', 'selected', 'systemChallenges');
+        };
+    @endphp
+
+    <div class="card mb-3">
+        <div class="card-header"><h3 class="card-title mb-0">Business types</h3></div>
+        <div class="card-body p-0">
+            @foreach ($businessTypes as $businessType)
+                @php $context = $renderTypeRow('business_type', $businessType->slug, $businessType->name); @endphp
+                <div class="border-bottom p-3">
+                    <form method="POST" action="{{ route('admin.gamification.challenges.defaults.update') }}">
+                        @csrf
+                        @method('PUT')
+                        <input type="hidden" name="applies_to" value="business_type">
+                        <input type="hidden" name="type_value" value="{{ $context['typeValue'] }}">
+
+                        <div class="form-row align-items-start">
+                            <div class="col-md-3">
+                                <h5 class="mb-0">{{ $context['typeLabel'] }}</h5>
+                                <code class="small text-muted">{{ $context['typeValue'] }}</code>
+                            </div>
+                            <div class="col-md-7">
+                                <div class="d-flex flex-wrap" style="gap: 4px;">
+                                    @forelse ($context['systemChallenges'] as $challenge)
+                                        <label class="badge badge-light p-2 mb-0" style="font-weight: normal; cursor: pointer;">
+                                            <input type="checkbox" name="challenge_ids[]" value="{{ $challenge->id }}"
+                                                   {{ in_array($challenge->id, $context['selected'], true) ? 'checked' : '' }}>
+                                            {{ $challenge->name }}
+                                        </label>
+                                    @empty
+                                        <span class="text-muted small">No system challenges to choose from.</span>
+                                    @endforelse
+                                </div>
+                            </div>
+                            <div class="col-md-2 text-right">
+                                <button type="submit" class="btn btn-sm btn-primary">Save row</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            @endforeach
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header"><h3 class="card-title mb-0">Community types</h3></div>
+        <div class="card-body p-0">
+            @foreach ($communityTypes as $communityType)
+                @php $context = $renderTypeRow('community_type', $communityType->slug, $communityType->name); @endphp
+                <div class="border-bottom p-3">
+                    <form method="POST" action="{{ route('admin.gamification.challenges.defaults.update') }}">
+                        @csrf
+                        @method('PUT')
+                        <input type="hidden" name="applies_to" value="community_type">
+                        <input type="hidden" name="type_value" value="{{ $context['typeValue'] }}">
+
+                        <div class="form-row align-items-start">
+                            <div class="col-md-3">
+                                <h5 class="mb-0">{{ $context['typeLabel'] }}</h5>
+                                <code class="small text-muted">{{ $context['typeValue'] }}</code>
+                            </div>
+                            <div class="col-md-7">
+                                <div class="d-flex flex-wrap" style="gap: 4px;">
+                                    @forelse ($context['systemChallenges'] as $challenge)
+                                        <label class="badge badge-light p-2 mb-0" style="font-weight: normal; cursor: pointer;">
+                                            <input type="checkbox" name="challenge_ids[]" value="{{ $challenge->id }}"
+                                                   {{ in_array($challenge->id, $context['selected'], true) ? 'checked' : '' }}>
+                                            {{ $challenge->name }}
+                                        </label>
+                                    @empty
+                                        <span class="text-muted small">No system challenges to choose from.</span>
+                                    @endforelse
+                                </div>
+                            </div>
+                            <div class="col-md-2 text-right">
+                                <button type="submit" class="btn btn-sm btn-primary">Save row</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/gamification/challenges/edit.blade.php
+++ b/resources/views/admin/gamification/challenges/edit.blade.php
@@ -1,0 +1,27 @@
+@extends('admin.layout', ['title' => 'Edit challenge'])
+
+@section('page_title', 'Edit challenge')
+@section('page_subtitle', $challenge->name)
+
+@section('page_actions')
+    <a href="{{ route('admin.gamification.challenges.index') }}" class="btn btn-outline-secondary">
+        <i class="fas fa-arrow-left mr-1"></i>
+        Back
+    </a>
+@endsection
+
+@section('admin_content')
+    <div class="card card-primary card-outline">
+        <form method="POST" action="{{ route('admin.gamification.challenges.update', $challenge) }}">
+            @csrf
+            @method('PUT')
+            <div class="card-body">
+                @include('admin.gamification.challenges._form')
+            </div>
+            <div class="card-footer">
+                <button type="submit" class="btn btn-primary">Save</button>
+                <a href="{{ route('admin.gamification.challenges.index') }}" class="btn btn-default">Cancel</a>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/gamification/challenges/index.blade.php
+++ b/resources/views/admin/gamification/challenges/index.blade.php
@@ -1,0 +1,110 @@
+@extends('admin.layout', ['title' => 'Challenges'])
+
+@section('page_title', 'Challenges')
+@section('page_subtitle', 'Global system challenges. Custom event-scoped challenges are organizer-managed.')
+
+@section('page_actions')
+    <a href="{{ route('admin.gamification.challenges.create') }}" class="btn btn-primary">
+        <i class="fas fa-plus mr-1"></i>
+        New
+    </a>
+@endsection
+
+@section('admin_content')
+    <div class="card mb-3">
+        <div class="card-body">
+            <form method="GET" action="{{ route('admin.gamification.challenges.index') }}" class="form-row align-items-end">
+                <div class="form-group col-md-4">
+                    <label for="category" class="small text-muted mb-1">Category</label>
+                    <select name="category" id="category" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($categories as $c)
+                            <option value="{{ $c->value }}" {{ $filters['category'] === $c->value ? 'selected' : '' }}>
+                                {{ ucfirst(str_replace('_', ' ', $c->value)) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="difficulty" class="small text-muted mb-1">Difficulty</label>
+                    <select name="difficulty" id="difficulty" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($difficulties as $d)
+                            <option value="{{ $d->value }}" {{ $filters['difficulty'] === $d->value ? 'selected' : '' }}>
+                                {{ ucfirst($d->value) }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="audience" class="small text-muted mb-1">Audience</label>
+                    <select name="audience" id="audience" class="form-control">
+                        <option value="">All</option>
+                        @foreach ($audiences as $a)
+                            <option value="{{ $a->value }}" {{ $filters['audience'] === $a->value ? 'selected' : '' }}>
+                                {{ $a->label() }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="form-group col-md-2">
+                    <button type="submit" class="btn btn-primary btn-block">Filter</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Category</th>
+                            <th>Difficulty</th>
+                            <th>Audience</th>
+                            <th class="text-center">Pts</th>
+                            <th class="text-right pr-4">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($challenges as $c)
+                            <tr>
+                                <td>
+                                    <div class="font-weight-bold">{{ $c->name }}</div>
+                                    @if ($c->description)
+                                        <small class="text-muted">{{ \Illuminate\Support\Str::limit($c->description, 80) }}</small>
+                                    @endif
+                                </td>
+                                <td><code>{{ $c->category?->value ?? '—' }}</code></td>
+                                <td>{{ ucfirst($c->difficulty->value) }}</td>
+                                <td>
+                                    <span class="badge badge-light text-uppercase">{{ $c->audience?->label() ?? 'Both' }}</span>
+                                </td>
+                                <td class="text-center font-weight-bold">{{ $c->points }}</td>
+                                <td class="text-right pr-4">
+                                    <a href="{{ route('admin.gamification.challenges.edit', $c) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+                                    <form method="POST" action="{{ route('admin.gamification.challenges.destroy', $c) }}" class="d-inline" onsubmit="return confirm('Delete this challenge?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">No challenges match the current filters.</td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        @if ($challenges->hasPages())
+            <div class="card-footer clearfix">
+                {{ $challenges->links('pagination::bootstrap-4') }}
+            </div>
+        @endif
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Admin\AuthController as AdminAuthController;
+use App\Http\Controllers\Admin\ChallengeController as AdminChallengeController;
+use App\Http\Controllers\Admin\ChallengeDefaultsController as AdminChallengeDefaultsController;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\KolabController as AdminKolabController;
 use App\Http\Controllers\Admin\ManagedUserController;
@@ -37,6 +39,18 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::post('/kolabs/{kolab}/collaboration/complete', [AdminKolabController::class, 'completeCollaboration'])->name('kolabs.collaboration.complete');
 
     Route::get('/stats', [AdminStatsController::class, 'index'])->name('stats.index');
+
+    Route::prefix('gamification')->as('gamification.')->group(function (): void {
+        Route::get('/challenges/defaults', [AdminChallengeDefaultsController::class, 'index'])->name('challenges.defaults.index');
+        Route::put('/challenges/defaults', [AdminChallengeDefaultsController::class, 'update'])->name('challenges.defaults.update');
+
+        Route::get('/challenges', [AdminChallengeController::class, 'index'])->name('challenges.index');
+        Route::get('/challenges/create', [AdminChallengeController::class, 'create'])->name('challenges.create');
+        Route::post('/challenges', [AdminChallengeController::class, 'store'])->name('challenges.store');
+        Route::get('/challenges/{challenge}/edit', [AdminChallengeController::class, 'edit'])->name('challenges.edit');
+        Route::put('/challenges/{challenge}', [AdminChallengeController::class, 'update'])->name('challenges.update');
+        Route::delete('/challenges/{challenge}', [AdminChallengeController::class, 'destroy'])->name('challenges.destroy');
+    });
 });
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');

--- a/tests/Feature/Admin/ChallengesAdminTest.php
+++ b/tests/Feature/Admin/ChallengesAdminTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ChallengeAudience;
+use App\Enums\ChallengeCategory;
+use App\Enums\ChallengeDifficulty;
+use App\Models\BusinessProfile;
+use App\Models\BusinessType;
+use App\Models\Challenge;
+use App\Models\ChallengeDefault;
+use App\Models\CollabOpportunity;
+use App\Models\Collaboration;
+use App\Models\CommunityProfile;
+use App\Models\CommunityType;
+use App\Models\Profile;
+use App\Models\User;
+use App\Services\Admin\ChallengeDefaultsService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class ChallengesAdminTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_challenges_index_renders_for_maintainer(): void
+    {
+        Challenge::factory()->create([
+            'name' => 'Test challenge alpha',
+            'is_system' => true,
+            'event_id' => null,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.gamification.challenges.index'))
+            ->assertOk()
+            ->assertSee('Test challenge alpha');
+    }
+
+    public function test_challenges_index_filters_by_audience(): void
+    {
+        Challenge::factory()->create([
+            'name' => 'Business only challenge',
+            'audience' => ChallengeAudience::Business,
+            'is_system' => true,
+            'event_id' => null,
+        ]);
+        Challenge::factory()->create([
+            'name' => 'Community only challenge',
+            'audience' => ChallengeAudience::Community,
+            'is_system' => true,
+            'event_id' => null,
+        ]);
+
+        $response = $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.gamification.challenges.index', ['audience' => 'business']));
+
+        $response->assertSee('Business only challenge');
+        $response->assertDontSee('Community only challenge');
+    }
+
+    public function test_challenges_index_forbidden_for_non_maintainer(): void
+    {
+        $this->actingAs(User::factory()->create(['is_maintainer' => false]), 'admin')
+            ->get(route('admin.gamification.challenges.index'))
+            ->assertForbidden();
+    }
+
+    public function test_create_persists_a_new_challenge_with_audience(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.gamification.challenges.store'), [
+                'name' => 'New thing',
+                'description' => 'desc',
+                'difficulty' => ChallengeDifficulty::Easy->value,
+                'points' => 15,
+                'category' => ChallengeCategory::IceBreaker->value,
+                'audience' => ChallengeAudience::Community->value,
+            ])
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+
+        $this->assertDatabaseHas('challenges', [
+            'name' => 'New thing',
+            'audience' => 'community',
+            'is_system' => true,
+        ]);
+    }
+
+    public function test_update_changes_audience(): void
+    {
+        $challenge = Challenge::factory()->create([
+            'audience' => ChallengeAudience::Both,
+            'is_system' => true,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.challenges.update', $challenge), [
+                'name' => $challenge->name,
+                'description' => $challenge->description,
+                'difficulty' => $challenge->difficulty->value,
+                'points' => $challenge->points,
+                'category' => $challenge->category?->value,
+                'audience' => ChallengeAudience::Business->value,
+            ])
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+
+        $this->assertSame('business', $challenge->fresh()->audience->value);
+    }
+
+    public function test_defaults_matrix_renders(): void
+    {
+        BusinessType::query()->create(['slug' => 'cafe', 'name' => 'Café']);
+        CommunityType::query()->create(['slug' => 'run_club', 'name' => 'Run Club']);
+        Challenge::factory()->create(['name' => 'Take a group photo', 'is_system' => true]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.gamification.challenges.defaults.index'))
+            ->assertOk()
+            ->assertSee('Café')
+            ->assertSee('Run Club')
+            ->assertSee('Take a group photo');
+    }
+
+    public function test_defaults_matrix_save_writes_rows(): void
+    {
+        BusinessType::query()->create(['slug' => 'coworking', 'name' => 'Coworking']);
+        $challenge = Challenge::factory()->create(['is_system' => true]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.challenges.defaults.update'), [
+                'applies_to' => 'business_type',
+                'type_value' => 'coworking',
+                'challenge_ids' => [$challenge->id],
+            ])
+            ->assertRedirect(route('admin.gamification.challenges.defaults.index'));
+
+        $this->assertDatabaseHas('challenge_defaults', [
+            'challenge_id' => $challenge->id,
+            'applies_to' => 'business_type',
+            'type_value' => 'coworking',
+        ]);
+    }
+
+    public function test_seed_for_collaboration_pulls_defaults_for_business_and_community_type(): void
+    {
+        $businessProfile = BusinessProfile::factory()->create(['business_type' => 'cafe']);
+        $communityProfile = CommunityProfile::factory()->create(['community_type' => 'run_club']);
+
+        $business = $businessProfile->profile;
+        $community = $communityProfile->profile;
+
+        $challengeForCafe = Challenge::factory()->create(['name' => 'Cafe default']);
+        $challengeForRunClub = Challenge::factory()->create(['name' => 'Run-club default']);
+
+        ChallengeDefault::query()->create([
+            'challenge_id' => $challengeForCafe->id,
+            'applies_to' => 'business_type',
+            'type_value' => 'cafe',
+            'position' => 0,
+        ]);
+        ChallengeDefault::query()->create([
+            'challenge_id' => $challengeForRunClub->id,
+            'applies_to' => 'community_type',
+            'type_value' => 'run_club',
+            'position' => 0,
+        ]);
+
+        $opportunity = CollabOpportunity::factory()->published()->create([
+            'creator_profile_id' => $business->id,
+        ]);
+
+        $collab = Collaboration::factory()->scheduled()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+            'business_profile_id' => $businessProfile->id,
+            'community_profile_id' => $communityProfile->id,
+        ]);
+
+        app(ChallengeDefaultsService::class)->seedForCollaboration($collab);
+
+        $this->assertSame(2, $collab->challenges()->count());
+    }
+
+    public function test_seed_for_collaboration_is_idempotent(): void
+    {
+        $businessProfile = BusinessProfile::factory()->create(['business_type' => 'cafe']);
+        $business = $businessProfile->profile;
+        $community = Profile::factory()->community()->create();
+
+        $challenge = Challenge::factory()->create();
+        ChallengeDefault::query()->create([
+            'challenge_id' => $challenge->id,
+            'applies_to' => 'business_type',
+            'type_value' => 'cafe',
+            'position' => 0,
+        ]);
+
+        $opportunity = CollabOpportunity::factory()->published()->create([
+            'creator_profile_id' => $business->id,
+        ]);
+        $collab = Collaboration::factory()->scheduled()->create([
+            'collab_opportunity_id' => $opportunity->id,
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+            'business_profile_id' => $businessProfile->id,
+        ]);
+
+        $service = app(ChallengeDefaultsService::class);
+        $service->seedForCollaboration($collab);
+        $service->seedForCollaboration($collab);
+
+        $this->assertSame(1, $collab->challenges()->count());
+    }
+}


### PR DESCRIPTION
## Summary
PR-4 of the [admin-followups plan](docs/plans/2026-06-01-admin-followups.md). Three things in one PR because they're all tied:

1. **Audience on challenges** — new \`audience\` column (community / business / both) + ChallengeAudience enum. Surfaced on \`ChallengeResource.audience\` so the app's Gamification Setup card can filter the pool by viewer role. Existing 49 system challenges backfilled to \`both\`.
2. **Role-based defaults matrix** — new \`challenge_defaults\` table + \`ChallengeDefaultsService\`. CollaborationService::createFromApplication seeds defaults automatically when a collab forms. Idempotent — skips if challenges already attached.
3. **Slug-format cleanup (Q5)** — migration reseeds \`community_types.slug\` from hyphenated (\`run-club\`) to underscored (\`run_club\`) so it matches \`community_profiles.community_type\`. Without this, the defaults matrix wouldn't actually match live data.

### Admin surfaces
Under the existing **GAMIFICATION** sidebar header:
- \`/admin/gamification/challenges\` — list with category / difficulty / audience filters + create / edit / delete (system catalogue only — \`is_system=true AND event_id IS NULL\`).
- \`/admin/gamification/challenges/defaults\` — matrix view, one form per business / community type, checkboxes for each system challenge.

## Test plan
- [x] 9 new feature tests (renders, audience filter, gating, create + update, matrix render + save, seeding pulls defaults for both sides, idempotent re-seed).
- [x] **712 tests / 3575 assertions** full suite green.
- [x] \`vendor/bin/pint --dirty\` clean.

## Deploy
1. Merge → \`php artisan migrate --force\` runs the additive migration + the slug update.
2. No new seeders required (existing 49 challenges keep audience=both until edited).
3. Verify \`/admin/gamification/challenges\` and \`/admin/gamification/challenges/defaults\` render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)