### PR TITLE
feat(events): Chat Phase 3 — event RSVP/sign-up, event chats, Reverb channel auth

### DIFF
--- a/app/Enums/EventSignupStatus.php
+++ b/app/Enums/EventSignupStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum EventSignupStatus: string
+{
+    case Going = 'going';
+    case Waitlisted = 'waitlisted';
+    case Cancelled = 'cancelled';
+}

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -21,6 +21,7 @@ enum NotificationType: string
     case UnreadMessage = 'unread_message';
     case CollabDayReminder = 'collab_day_reminder';
     case CollabFollowUpReminder = 'collab_followup_reminder';
+    case WaitlistPromoted = 'waitlist_promoted';
 
     /**
      * @return array<string>

--- a/app/Http/Controllers/Api/V1/ChatController.php
+++ b/app/Http/Controllers/Api/V1/ChatController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\Api\V1\ChatThreadResource;
 use App\Models\Application;
 use App\Models\ChatThread;
 use App\Models\Community;
+use App\Models\Event;
 use App\Models\Profile;
 use App\Services\ChatService;
 use DomainException;
@@ -89,6 +90,32 @@ class ChatController extends Controller
                 'message' => __('This community already has the maximum of 5 custom chats.'),
             ], 422);
         }
+
+        return response()->json([
+            'success' => true,
+            'data' => new ChatThreadResource($thread),
+        ], 201);
+    }
+
+    /**
+     * Create (or fetch) the event chat for an event (leader / can_manage).
+     *
+     * POST /api/v1/events/{event}/chat
+     */
+    public function storeEventChat(Request $request, Event $event): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($event->community_id === null
+            || ! $this->chatService->canManageCommunity($profile, $event->community_id)) {
+            return response()->json([
+                'success' => false,
+                'message' => __('You are not authorized to manage this event\'s chat.'),
+            ], 403);
+        }
+
+        $thread = $this->chatService->eventThreadFor($event, $profile);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/Api/V1/EventController.php
+++ b/app/Http/Controllers/Api/V1/EventController.php
@@ -21,26 +21,38 @@ class EventController extends Controller
     ) {}
 
     /**
-     * List events for a profile.
+     * List events, one lifecycle for every surface (NF-CHAT Phase 3 §6.1).
      *
-     * GET /api/v1/events?profile_id={uuid}
-     * Defaults to authenticated user if profile_id not provided.
+     * GET /api/v1/events?community_id=&time=upcoming|past&attendee=me&profile_id=
+     * Filters: community_id (community Details), time (upcoming tab vs past
+     * showcase), attendee=me (profile's attended/going), profile_id (a profile's
+     * created events). With no filter, defaults to the authenticated user's own.
      */
     public function index(Request $request): JsonResponse
     {
         /** @var Profile $authProfile */
         $authProfile = $request->user();
 
-        $profileId = $request->query('profile_id');
         $perPage = min((int) $request->query('limit', '10'), 50);
 
-        if ($profileId) {
-            $profile = Profile::query()->findOrFail($profileId);
-        } else {
-            $profile = $authProfile;
+        $communityId = $request->query('community_id');
+        $profileId = $request->query('profile_id');
+        $time = $request->query('time'); // upcoming | past | null
+        $attendeeId = $request->query('attendee') === 'me' ? $authProfile->id : null;
+
+        $filters = array_filter([
+            'community_id' => $communityId,
+            'profile_id' => $profileId,
+            'attendee_profile_id' => $attendeeId,
+            'time' => $time,
+        ], static fn ($value) => $value !== null);
+
+        // Back-compat: with no scoping filter, list the viewer's own events.
+        if ($communityId === null && $profileId === null && $attendeeId === null) {
+            $filters['profile_id'] = $authProfile->id;
         }
 
-        $paginator = $this->eventService->listForProfile($profile, $perPage);
+        $paginator = $this->eventService->list($filters, $perPage);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/Api/V1/EventSignupController.php
+++ b/app/Http/Controllers/Api/V1/EventSignupController.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\EventSignupStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\EventResource;
+use App\Http\Resources\Api\V1\EventSignupResource;
+use App\Models\Event;
+use App\Models\Profile;
+use App\Services\ChatService;
+use App\Services\EventSignupService;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EventSignupController extends Controller
+{
+    public function __construct(
+        private readonly EventSignupService $signups,
+        private readonly ChatService $chatService,
+    ) {}
+
+    /**
+     * POST /api/v1/events/{event}/signup — join (or land on the waitlist).
+     */
+    public function store(Request $request, Event $event): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        try {
+            $this->signups->signup($event, $profile);
+        } catch (DomainException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => $e->getMessage(),
+                'message' => $this->messageFor($e->getMessage()),
+            ], 422);
+        }
+
+        return $this->eventResponse($event);
+    }
+
+    /**
+     * DELETE /api/v1/events/{event}/signup — leave/cancel (auto-promotes waitlist).
+     */
+    public function destroy(Request $request, Event $event): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        $this->signups->cancel($event, $profile);
+
+        return $this->eventResponse($event);
+    }
+
+    /**
+     * GET /api/v1/events/{event}/signups — going + waitlist roster (leader / can_manage).
+     */
+    public function index(Request $request, Event $event): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($event->community_id === null
+            || ! $this->chatService->canManageCommunity($profile, $event->community_id)) {
+            return response()->json([
+                'success' => false,
+                'message' => __('You are not authorized to view this event\'s sign-ups.'),
+            ], 403);
+        }
+
+        $rows = $event->signups()
+            ->with('profile.businessProfile', 'profile.communityProfile')
+            ->whereIn('status', [EventSignupStatus::Going->value, EventSignupStatus::Waitlisted->value])
+            ->orderByRaw("CASE status WHEN 'going' THEN 0 ELSE 1 END")
+            ->orderBy('waitlist_position')
+            ->orderBy('created_at')
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'going' => EventSignupResource::collection(
+                    $rows->where('status', EventSignupStatus::Going)->values()
+                ),
+                'waitlist' => EventSignupResource::collection(
+                    $rows->where('status', EventSignupStatus::Waitlisted)->values()
+                ),
+            ],
+        ]);
+    }
+
+    private function eventResponse(Event $event): JsonResponse
+    {
+        $event->load('photos');
+
+        return response()->json([
+            'success' => true,
+            'data' => new EventResource($event->fresh(['photos'])),
+        ]);
+    }
+
+    private function messageFor(string $code): string
+    {
+        return match ($code) {
+            'event_not_upcoming' => __('Sign-ups are only open for upcoming events.'),
+            'event_not_signup_enabled' => __('This event is not open for sign-ups.'),
+            'not_a_member' => __('You must be a member of this community to sign up.'),
+            'tier_not_permitted' => __('Your tier is not permitted to sign up for this event.'),
+            default => __('Could not complete the sign-up.'),
+        };
+    }
+}

--- a/app/Http/Resources/Api/V1/EventResource.php
+++ b/app/Http/Resources/Api/V1/EventResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use App\Models\Event;
+use App\Services\EventSignupService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -23,14 +24,35 @@ class EventResource extends JsonResource
             'name' => $this->name,
             'partner_name' => $this->partner_name,
             'partner_type' => $this->partner_type,
+            // Legacy single-day field kept for the past-showcase view.
             'date' => $this->event_date->toDateString(),
+            'starts_at' => $this->starts_at?->toIso8601String(),
+            'ends_at' => $this->ends_at?->toIso8601String(),
+            'is_upcoming' => $this->isUpcoming(),
             'attendee_count' => $this->attendee_count,
             'location_lat' => $this->location_lat,
             'location_lng' => $this->location_lng,
             'address' => $this->address,
+            'location' => $this->location,
+            'community_id' => $this->community_id,
+            'collaboration_id' => $this->collaboration_id,
+            'capacity' => $this->capacity,
+            'tier_gate' => $this->tier_gate,
             'photos' => EventPhotoResource::collection($this->whenLoaded('photos')),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+
+        // Per-viewer sign-up state + counts (drives the "I'm going" button).
+        $signups = app(EventSignupService::class);
+        $data['going_count'] = $signups->goingCount($this->resource);
+        $data['waitlist_count'] = $signups->waitlistCount($this->resource);
+
+        $viewer = $request->user();
+        $mine = $viewer !== null ? $signups->signupFor($this->resource, $viewer) : null;
+        $data['my_signup'] = $mine === null ? null : [
+            'status' => $mine->status->value,
+            'waitlist_position' => $mine->waitlist_position,
         ];
 
         if (isset($this->resource->distance_km)) {

--- a/app/Http/Resources/Api/V1/EventSignupResource.php
+++ b/app/Http/Resources/Api/V1/EventSignupResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\EventSignup;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin EventSignup
+ */
+class EventSignupResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'profile_id' => $this->profile_id,
+            'status' => $this->status->value,
+            'waitlist_position' => $this->waitlist_position,
+            'profile' => $this->whenLoaded('profile', fn () => new ProfileSummaryResource($this->profile)),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -17,10 +17,16 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $partner_name
  * @property string $partner_type
  * @property \Illuminate\Support\Carbon $event_date
+ * @property \Illuminate\Support\Carbon|null $starts_at
+ * @property \Illuminate\Support\Carbon|null $ends_at
  * @property int $attendee_count
  * @property string|null $location_lat
  * @property string|null $location_lng
  * @property string|null $address
+ * @property string|null $location
+ * @property int|null $capacity
+ * @property array<int, mixed>|null $tier_gate
+ * @property string|null $collaboration_id
  * @property int $max_challenges_per_attendee
  * @property bool $is_active
  * @property string|null $checkin_token
@@ -45,14 +51,20 @@ class Event extends Model
     protected $fillable = [
         'profile_id',
         'community_id',
+        'collaboration_id',
         'name',
         'partner_name',
         'partner_type',
         'event_date',
+        'starts_at',
+        'ends_at',
         'attendee_count',
         'location_lat',
         'location_lng',
         'address',
+        'location',
+        'capacity',
+        'tier_gate',
         'max_challenges_per_attendee',
         'is_active',
         'checkin_token',
@@ -65,12 +77,35 @@ class Event extends Model
     {
         return [
             'event_date' => 'date',
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
             'attendee_count' => 'integer',
             'location_lat' => 'decimal:7',
             'location_lng' => 'decimal:7',
+            'capacity' => 'integer',
+            'tier_gate' => 'array',
             'max_challenges_per_attendee' => 'integer',
             'is_active' => 'boolean',
         ];
+    }
+
+    /**
+     * Effective end of the event for the upcoming/past split — prefers the new
+     * timestamps, falling back to the legacy date.
+     */
+    public function effectiveEnd(): \Illuminate\Support\Carbon
+    {
+        return $this->ends_at
+            ?? $this->starts_at
+            ?? \Illuminate\Support\Carbon::parse($this->event_date)->endOfDay();
+    }
+
+    /**
+     * Upcoming = sign-up/RSVP + event chat apply. Past = showcase only.
+     */
+    public function isUpcoming(): bool
+    {
+        return $this->effectiveEnd()->isFuture();
     }
 
     /**
@@ -121,5 +156,25 @@ class Event extends Model
     public function rewards(): HasMany
     {
         return $this->hasMany(EventReward::class);
+    }
+
+    /**
+     * The collaboration (kolab) this event is linked to, if any.
+     *
+     * @return BelongsTo<Collaboration, $this>
+     */
+    public function collaboration(): BelongsTo
+    {
+        return $this->belongsTo(Collaboration::class);
+    }
+
+    /**
+     * Sign-ups (going / waitlisted / cancelled) for an upcoming event.
+     *
+     * @return HasMany<EventSignup, $this>
+     */
+    public function signups(): HasMany
+    {
+        return $this->hasMany(EventSignup::class);
     }
 }

--- a/app/Models/EventSignup.php
+++ b/app/Models/EventSignup.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\EventSignupStatus;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $event_id
+ * @property string $profile_id
+ * @property EventSignupStatus $status
+ * @property int|null $waitlist_position
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Event $event
+ * @property-read Profile $profile
+ */
+class EventSignup extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'event_id',
+        'profile_id',
+        'status',
+        'waitlist_position',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => EventSignupStatus::class,
+            'waitlist_position' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Event, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -6,6 +6,7 @@ namespace App\Services;
 
 use App\Enums\ChatThreadType;
 use App\Enums\CommunityMemberStatus;
+use App\Enums\EventSignupStatus;
 use App\Events\NewChatMessage;
 use App\Models\Application;
 use App\Models\ChatMessage;
@@ -14,6 +15,8 @@ use App\Models\ChatThreadRead;
 use App\Models\Community;
 use App\Models\CommunityMember;
 use App\Models\CommunityTier;
+use App\Models\Event;
+use App\Models\EventSignup;
 use App\Models\Profile;
 use DomainException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -196,6 +199,7 @@ class ChatService
     {
         return $this->visibleCollaborationThreads($profile)
             ->merge($this->visibleCommunityThreads($profile))
+            ->merge($this->visibleEventThreads($profile))
             ->sortByDesc(fn (ChatThread $thread): int => $thread->last_message_at?->getTimestamp() ?? 0)
             ->values();
     }
@@ -283,6 +287,11 @@ class ChatService
             return $thread->application !== null && $this->canParticipate($profile, $thread->application);
         }
 
+        // Event chats: a `going` sign-up, or the community leader/can_manage.
+        if ($thread->type === ChatThreadType::Event) {
+            return $this->canAccessEventThread($profile, $thread);
+        }
+
         if ($thread->community_id === null) {
             return false;
         }
@@ -295,7 +304,7 @@ class ChatService
             return $this->canAccessCustomChat($profile, $thread);
         }
 
-        return false; // event chats arrive in Phase 3
+        return false;
     }
 
     /**
@@ -414,6 +423,116 @@ class ChatService
         }
 
         return $visible->values();
+    }
+
+    /**
+     * Resolve (or lazily create) the single event chat thread for an event.
+     */
+    public function eventThreadFor(Event $event, ?Profile $creator = null): ChatThread
+    {
+        return ChatThread::query()->firstOrCreate(
+            ['type' => ChatThreadType::Event->value, 'event_id' => $event->id],
+            [
+                'community_id' => $event->community_id,
+                'name' => $event->name,
+                'created_by' => $creator?->id,
+            ],
+        );
+    }
+
+    /**
+     * Event threads visible to a profile: the events they are `going` to, plus
+     * (for leaders) the event chats of communities they manage.
+     *
+     * @return Collection<int, ChatThread>
+     */
+    private function visibleEventThreads(Profile $profile): Collection
+    {
+        $goingEventIds = EventSignup::query()
+            ->where('profile_id', $profile->id)
+            ->where('status', EventSignupStatus::Going->value)
+            ->pluck('event_id');
+
+        $managedCommunityIds = $this->managedCommunityIds($profile);
+
+        if ($goingEventIds->isEmpty() && $managedCommunityIds->isEmpty()) {
+            return collect();
+        }
+
+        $threads = ChatThread::query()
+            ->where('type', ChatThreadType::Event->value)
+            ->where(function ($query) use ($goingEventIds, $managedCommunityIds): void {
+                $query->whereIn('event_id', $goingEventIds);
+                if ($managedCommunityIds->isNotEmpty()) {
+                    $query->orWhereIn('community_id', $managedCommunityIds);
+                }
+            })
+            ->get();
+
+        foreach ($threads as $thread) {
+            $thread->unread_count = $this->unreadForThread($profile, $thread);
+        }
+
+        return $threads->values();
+    }
+
+    private function canAccessEventThread(Profile $profile, ChatThread $thread): bool
+    {
+        if ($thread->event_id === null) {
+            return false;
+        }
+
+        $event = Event::query()->find($thread->event_id);
+        if ($event === null) {
+            return false;
+        }
+
+        // Community leader / can_manage always has access to manage the chat.
+        if ($event->community_id !== null && $this->canManageCommunity($profile, $event->community_id)) {
+            return true;
+        }
+
+        // Going sign-ups have access; waitlisted do not.
+        return EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('profile_id', $profile->id)
+            ->where('status', EventSignupStatus::Going->value)
+            ->exists();
+    }
+
+    /**
+     * Owner, or active member with can_manage, of a community.
+     */
+    public function canManageCommunity(Profile $profile, string $communityId): bool
+    {
+        if (Community::query()->whereKey($communityId)->where('owner_profile_id', $profile->id)->exists()) {
+            return true;
+        }
+
+        return CommunityMember::query()
+            ->where('community_id', $communityId)
+            ->where('profile_id', $profile->id)
+            ->where('can_manage', true)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->exists();
+    }
+
+    /**
+     * Community ids the profile manages (owns or can_manage).
+     *
+     * @return Collection<int, string>
+     */
+    private function managedCommunityIds(Profile $profile): Collection
+    {
+        $owned = Community::query()->where('owner_profile_id', $profile->id)->pluck('id');
+
+        $managed = CommunityMember::query()
+            ->where('profile_id', $profile->id)
+            ->where('can_manage', true)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->pluck('community_id');
+
+        return $owned->merge($managed)->unique()->values();
     }
 
     private function isCommunityMemberOrOwner(Profile $profile, string $communityId): bool

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -31,6 +31,50 @@ class EventService
     }
 
     /**
+     * Filtered event list (NF-CHAT Phase 3 §6.1) — one events lifecycle feeds the
+     * upcoming tab, community Details (past + gallery) and the profile showcase.
+     *
+     * @param  array{community_id?: ?string, profile_id?: ?string, attendee_profile_id?: ?string, time?: ?string}  $filters
+     */
+    public function list(array $filters, int $perPage = 10): LengthAwarePaginator
+    {
+        // COALESCE(ends_at, starts_at, event_date) = the event's effective time.
+        $effective = 'COALESCE(ends_at, starts_at, event_date)';
+
+        $query = Event::query()->with(['photos']);
+
+        if (! empty($filters['community_id'])) {
+            $query->where('community_id', $filters['community_id']);
+        }
+
+        if (! empty($filters['profile_id'])) {
+            $query->where('profile_id', $filters['profile_id']);
+        }
+
+        if (! empty($filters['attendee_profile_id'])) {
+            $attendeeId = $filters['attendee_profile_id'];
+            $query->where(function ($q) use ($attendeeId): void {
+                $q->whereHas('checkins', fn ($c) => $c->where('profile_id', $attendeeId))
+                    ->orWhereHas('signups', fn ($s) => $s->where('profile_id', $attendeeId)
+                        ->where('status', '!=', 'cancelled'));
+            });
+        }
+
+        $time = $filters['time'] ?? null;
+        if ($time === 'upcoming') {
+            $query->whereRaw("$effective >= ?", [now()])
+                ->orderByRaw('COALESCE(starts_at, event_date) asc');
+        } elseif ($time === 'past') {
+            $query->whereRaw("$effective < ?", [now()])
+                ->orderByRaw('COALESCE(starts_at, event_date) desc');
+        } else {
+            $query->orderByDesc('event_date');
+        }
+
+        return $query->paginate($perPage);
+    }
+
+    /**
      * Get a single event with relations loaded.
      */
     public function getWithRelations(Event $event): Event

--- a/app/Services/EventSignupService.php
+++ b/app/Services/EventSignupService.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\EventSignupStatus;
+use App\Enums\NotificationType;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\Event;
+use App\Models\EventSignup;
+use App\Models\Profile;
+use DomainException;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Upcoming-event sign-ups with capacity + waitlist (NF-CHAT Phase 3).
+ *
+ * Binary "I'm going". Over capacity → waitlisted with a position; on a
+ * leave/cancel the head of the waitlist auto-promotes to going and is notified.
+ * Access to the event chat is DERIVED from a `going` row (see ChatService).
+ */
+class EventSignupService
+{
+    public function __construct(
+        private readonly NotificationService $notificationService,
+    ) {}
+
+    /**
+     * Join an upcoming event (or land on the waitlist if full).
+     *
+     * @throws DomainException 'event_not_upcoming' | 'event_not_signup_enabled'
+     *                         | 'not_a_member' | 'tier_not_permitted'
+     */
+    public function signup(Event $event, Profile $profile): EventSignup
+    {
+        if (! $event->isUpcoming()) {
+            throw new DomainException('event_not_upcoming');
+        }
+
+        if ($event->community_id === null) {
+            throw new DomainException('event_not_signup_enabled');
+        }
+
+        $this->assertEligible($event, $profile);
+
+        return DB::transaction(function () use ($event, $profile): EventSignup {
+            // Lock this event's sign-ups so concurrent joins can't both take the
+            // last seat.
+            $existing = EventSignup::query()
+                ->where('event_id', $event->id)
+                ->where('profile_id', $profile->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existing !== null && $existing->status !== EventSignupStatus::Cancelled) {
+                return $existing; // already going or waitlisted — idempotent
+            }
+
+            $goingCount = EventSignup::query()
+                ->where('event_id', $event->id)
+                ->where('status', EventSignupStatus::Going->value)
+                ->lockForUpdate()
+                ->count();
+
+            $hasRoom = $event->capacity === null || $goingCount < $event->capacity;
+
+            $status = $hasRoom ? EventSignupStatus::Going : EventSignupStatus::Waitlisted;
+            $position = $hasRoom ? null : $this->nextWaitlistPosition($event);
+
+            $attributes = [
+                'status' => $status->value,
+                'waitlist_position' => $position,
+            ];
+
+            if ($existing !== null) {
+                $existing->update($attributes);
+
+                return $existing->refresh();
+            }
+
+            return EventSignup::query()->create([
+                'event_id' => $event->id,
+                'profile_id' => $profile->id,
+                ...$attributes,
+            ]);
+        });
+    }
+
+    /**
+     * Leave/cancel a sign-up. If a `going` seat is freed, auto-promote the head
+     * of the waitlist and notify them.
+     */
+    public function cancel(Event $event, Profile $profile): void
+    {
+        DB::transaction(function () use ($event, $profile): void {
+            $signup = EventSignup::query()
+                ->where('event_id', $event->id)
+                ->where('profile_id', $profile->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($signup === null || $signup->status === EventSignupStatus::Cancelled) {
+                return;
+            }
+
+            $wasGoing = $signup->status === EventSignupStatus::Going;
+            $signup->update([
+                'status' => EventSignupStatus::Cancelled->value,
+                'waitlist_position' => null,
+            ]);
+
+            if ($wasGoing) {
+                $this->promoteNextWaitlisted($event);
+            } else {
+                $this->resequenceWaitlist($event);
+            }
+        });
+    }
+
+    /**
+     * @return int going count
+     */
+    public function goingCount(Event $event): int
+    {
+        return EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('status', EventSignupStatus::Going->value)
+            ->count();
+    }
+
+    public function waitlistCount(Event $event): int
+    {
+        return EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('status', EventSignupStatus::Waitlisted->value)
+            ->count();
+    }
+
+    public function signupFor(Event $event, Profile $profile): ?EventSignup
+    {
+        return EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('profile_id', $profile->id)
+            ->first();
+    }
+
+    /**
+     * Whether a profile currently holds a `going` seat (drives chat access).
+     */
+    public function isGoing(Event $event, Profile $profile): bool
+    {
+        return EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('profile_id', $profile->id)
+            ->where('status', EventSignupStatus::Going->value)
+            ->exists();
+    }
+
+    private function assertEligible(Event $event, Profile $profile): void
+    {
+        // The community owner (leader) is always eligible.
+        if (Community::query()->whereKey($event->community_id)->where('owner_profile_id', $profile->id)->exists()) {
+            return;
+        }
+
+        $member = CommunityMember::query()
+            ->where('community_id', $event->community_id)
+            ->where('profile_id', $profile->id)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->first();
+
+        if ($member === null) {
+            throw new DomainException('not_a_member');
+        }
+
+        // Optional tier gate: tier_gate is a list of allowed tier ids.
+        $gate = $event->tier_gate ?? [];
+        if (is_array($gate) && $gate !== [] && ! in_array($member->tier_id, $gate, true)) {
+            throw new DomainException('tier_not_permitted');
+        }
+    }
+
+    private function nextWaitlistPosition(Event $event): int
+    {
+        $max = EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('status', EventSignupStatus::Waitlisted->value)
+            ->max('waitlist_position');
+
+        return (int) $max + 1;
+    }
+
+    private function promoteNextWaitlisted(Event $event): void
+    {
+        $next = EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('status', EventSignupStatus::Waitlisted->value)
+            ->orderBy('waitlist_position')
+            ->lockForUpdate()
+            ->first();
+
+        if ($next === null) {
+            return;
+        }
+
+        $next->update([
+            'status' => EventSignupStatus::Going->value,
+            'waitlist_position' => null,
+        ]);
+
+        $this->resequenceWaitlist($event);
+
+        $this->notificationService->createNotification(
+            recipient: $next->profile,
+            type: NotificationType::WaitlistPromoted,
+            title: __('You\'re in!'),
+            body: __('A spot opened up for ":event" — you\'re now going.', ['event' => $event->name]),
+            targetId: $event->id,
+            targetType: 'event',
+        );
+    }
+
+    /**
+     * Re-number remaining waitlist rows to 1..N (stable by current position).
+     */
+    private function resequenceWaitlist(Event $event): void
+    {
+        $waitlisted = EventSignup::query()
+            ->where('event_id', $event->id)
+            ->where('status', EventSignupStatus::Waitlisted->value)
+            ->orderBy('waitlist_position')
+            ->get();
+
+        $position = 1;
+        foreach ($waitlisted as $row) {
+            if ($row->waitlist_position !== $position) {
+                $row->update(['waitlist_position' => $position]);
+            }
+            $position++;
+        }
+    }
+}

--- a/database/migrations/2026_06_05_000001_create_event_signups_table.php
+++ b/database/migrations/2026_06_05_000001_create_event_signups_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Upcoming-event sign-ups (NF-CHAT Phase 3). Binary "I'm going" with capacity +
+ * waitlist. One row per (event, profile); a re-join flips cancelled -> going.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('event_signups', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('event_id')->constrained('events')->cascadeOnDelete();
+            $table->foreignUuid('profile_id')->constrained('profiles')->cascadeOnDelete();
+            $table->string('status', 20)->default('going'); // going | waitlisted | cancelled
+            $table->unsignedInteger('waitlist_position')->nullable();
+            $table->timestamps();
+
+            $table->unique(['event_id', 'profile_id']);
+            $table->index(['event_id', 'status']);
+            $table->index('profile_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('event_signups');
+    }
+};

--- a/database/migrations/2026_06_05_000002_add_phase3_columns_to_events_table.php
+++ b/database/migrations/2026_06_05_000002_add_phase3_columns_to_events_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Upcoming-event fields (NF-CHAT Phase 3). `event_date` stays for the existing
+ * past-showcase; `starts_at`/`ends_at` drive the upcoming/past lifecycle.
+ * `community_id` already exists (2026_06_03_000004).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            $table->timestamp('starts_at')->nullable()->after('event_date');
+            $table->timestamp('ends_at')->nullable()->after('starts_at');
+            $table->string('location')->nullable()->after('address');
+            $table->unsignedInteger('capacity')->nullable()->after('location'); // null = unlimited
+            $table->json('tier_gate')->nullable()->after('capacity'); // null = all members may sign up
+            $table->foreignUuid('collaboration_id')->nullable()->after('community_id')
+                ->constrained('collaborations')->nullOnDelete();
+
+            $table->index('starts_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('collaboration_id');
+            $table->dropIndex(['starts_at']);
+            $table->dropColumn(['starts_at', 'ends_at', 'location', 'capacity', 'tier_gate']);
+        });
+    }
+};

--- a/docs/plans/2026-06-05-chat-phase3-events-rsvp.md
+++ b/docs/plans/2026-06-05-chat-phase3-events-rsvp.md
@@ -1,0 +1,55 @@
+# Chat Phase 3 — Event RSVP + event chats + Reverb real-time (backend)
+
+**Created:** 2026-06-05 · **Branch:** `feat/chat-phase3-events-rsvp` · **Repo:** `kolabing-v2`
+**Ticket:** `kolabing-app/docs/tickets/2026-06-04-chat-phase3-events-rsvp-realtime-backend.md`
+Builds on shipped Phase 1 (inbox) + Phase 2 (community chats, generic `/chats/{thread}/messages`).
+
+## Status: backend BUILT — 842 tests green (11 new), 0 regressions
+
+### Sign-ups (RSVP) — binary "I'm going" + capacity + waitlist
+- Migration `event_signups` (`event_id`, `profile_id`, `status` going|waitlisted|cancelled,
+  `waitlist_position`, unique `(event_id, profile_id)`). Enum `EventSignupStatus`. Model `EventSignup`.
+- Migration adds to `events`: `starts_at`, `ends_at`, `location`, `capacity`, `tier_gate` (json),
+  `collaboration_id`. (`community_id` already existed.) `Event` gains casts, `signups()`/`collaboration()`
+  relations, `effectiveEnd()` + `isUpcoming()` (COALESCE(ends_at, starts_at, event_date)).
+- `EventSignupService`: `signup` (capacity → going else waitlisted; idempotent; tier-gate + membership
+  via `community_tiers`/owner), `cancel` (frees a seat → **auto-promote** head of waitlist + notify),
+  `resequenceWaitlist`, counts/`isGoing`. Row-locked (`lockForUpdate`) so the last seat can't double-book.
+- New `NotificationType::WaitlistPromoted`.
+- Endpoints: `POST/DELETE /events/{event}/signup`, `GET /events/{event}/signups` (leader/can_manage).
+  `EventResource` gains `my_signup`, `going_count`, `waitlist_count`, `capacity`, `starts_at`/`ends_at`,
+  `location`, `community_id`, `collaboration_id`, `tier_gate`, `is_upcoming`. `EventSignupResource` for the roster.
+
+### Event chat
+- `POST /events/{event}/chat` (leader/can_manage) → idempotent `event` `ChatThread` via
+  `ChatService::eventThreadFor` → `ChatThreadResource` (the app's `createEventChat` no longer 404s).
+- `ChatService::canAccessThread` Event branch: `going` sign-up OR community leader/can_manage.
+  Waitlisted/outsiders denied. Reuses the Phase-2 `/chats/{thread}/messages` + `/read` surface unchanged.
+- `ChatService::visibleThreads` now also returns event threads (events the viewer is `going` to + the
+  event chats of communities they manage), with per-thread unread.
+
+### Real-time (Reverb)
+- `routes/channels.php`: new private channel `chat.thread.{threadId}` authorized by
+  `ChatService::canAccessThread` — SAME derived access as REST (the security boundary; never authorizes
+  on community membership alone for tier/event-gated threads).
+- `NewChatMessage` already broadcasts on `chat.thread.{id}` (Phase 2) for every thread type, so event
+  messages broadcast with no further change. `laravel/reverb` + `config/reverb.php` + `BROADCAST_CONNECTION=reverb`
+  + `REVERB_*` env already present.
+- Ops to do on the server: run `php artisan reverb:start` (or supervisor) and point the app's Echo client at it.
+
+### Events ↔ Kolabs + lifecycle (§6, §6.1)
+- `events.collaboration_id` mirror of `collaborations.event_id` added.
+- `GET /events` now filtered: `community_id`, `time=upcoming|past`, `attendee=me`, `profile_id` — one
+  `events` lifecycle feeds the upcoming tab, community Details (past + gallery) and the profile showcase.
+  No filter → the viewer's own events (back-compat). Retroactive past-event creation (showcase-only) is
+  untouched; sign-up/waitlist/chat apply only to upcoming events (`isUpcoming`).
+
+## Tests
+`EventSignupTest` (7): signup, capacity→waitlist, cancel auto-promote+notify, tier-gate, non-member,
+past-event blocked, leader roster (+ non-manager 403). `EventChatTest` (4): create chat, non-manager 403,
+going/leader access vs waitlisted/outsider 403, event thread in `/chats` + send/read.
+
+## Remaining (not backend code)
+- App side: "I'm going" button + waitlist UI, event-chat surfacing, Reverb/Echo client (app contract §7).
+- Ops: run the Reverb server; confirm prod env.
+- Out of scope (separate tickets): member-to-member DMs, typing/presence, profile redesign.

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Api\V1\DashboardController;
 use App\Http\Controllers\Api\V1\DeviceTokenController;
 use App\Http\Controllers\Api\V1\DiscoveryOpportunityController;
 use App\Http\Controllers\Api\V1\EventController;
+use App\Http\Controllers\Api\V1\EventSignupController;
 use App\Http\Controllers\Api\V1\EventDiscoveryController;
 use App\Http\Controllers\Api\V1\EventRewardController;
 use App\Http\Controllers\Api\V1\GalleryController;
@@ -252,6 +253,16 @@ Route::prefix('v1')->group(function (): void {
         // Delete event
         Route::delete('events/{event}', [EventController::class, 'destroy'])
             ->name('api.v1.events.destroy');
+
+        // NF-CHAT Phase 3 — event sign-up (RSVP) + event chat
+        Route::post('events/{event}/signup', [EventSignupController::class, 'store'])
+            ->name('api.v1.events.signup.store');
+        Route::delete('events/{event}/signup', [EventSignupController::class, 'destroy'])
+            ->name('api.v1.events.signup.destroy');
+        Route::get('events/{event}/signups', [EventSignupController::class, 'index'])
+            ->name('api.v1.events.signups.index');
+        Route::post('events/{event}/chat', [ChatController::class, 'storeEventChat'])
+            ->name('api.v1.events.chat.store');
 
         /*
         |--------------------------------------------------------------------------

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Application;
+use App\Models\ChatThread;
 use App\Models\Profile;
 use App\Services\ChatService;
 use Illuminate\Support\Facades\Broadcast;
@@ -28,4 +29,21 @@ Broadcast::channel('chat.application.{applicationId}', function (Profile $profil
     $chatService = app(ChatService::class);
 
     return $chatService->canParticipate($profile, $application);
+});
+
+/*
+ * Per-thread channel for real-time chat (NF-CHAT Phase 3). NewChatMessage
+ * broadcasts on `chat.thread.{id}` for every thread type (collaboration,
+ * community, event). Authorization is the SAME derived access as the REST layer
+ * (ChatService::canAccessThread) — this is the security boundary: never authorize
+ * on community membership alone for tier-gated or event (sign-up-gated) threads.
+ */
+Broadcast::channel('chat.thread.{threadId}', function (Profile $profile, string $threadId) {
+    $thread = ChatThread::find($threadId);
+
+    if (! $thread) {
+        return false;
+    }
+
+    return app(ChatService::class)->canAccessThread($profile, $thread);
 });

--- a/tests/Feature/Api/V1/EventChatTest.php
+++ b/tests/Feature/Api/V1/EventChatTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\Event;
+use App\Models\Profile;
+use App\Services\CommunityService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class EventChatTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(Profile $leader): Community
+    {
+        return app(CommunityService::class)->create($leader, [
+            'name' => 'Barcelona Run Club',
+            'type' => 'greek',
+        ]);
+    }
+
+    private function upcomingEvent(Community $community, array $overrides = []): Event
+    {
+        return Event::factory()->create(array_merge([
+            'profile_id' => $community->owner_profile_id,
+            'community_id' => $community->id,
+            'starts_at' => now()->addDays(2),
+            'ends_at' => now()->addDays(2)->addHours(3),
+        ], $overrides));
+    }
+
+    private function member(Community $community): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $profile->id,
+            'tier_id' => $community->defaultTier->id,
+            'status' => 'active',
+        ]);
+
+        return $profile;
+    }
+
+    public function test_leader_creates_event_chat(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community);
+
+        $this->actingAs($leader)
+            ->postJson("/api/v1/events/{$event->id}/chat")
+            ->assertStatus(201)
+            ->assertJsonPath('data.type', 'event')
+            ->assertJsonPath('data.event_id', $event->id);
+    }
+
+    public function test_non_manager_cannot_create_event_chat(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community);
+        $member = $this->member($community);
+
+        $this->actingAs($member)->postJson("/api/v1/events/{$event->id}/chat")->assertStatus(403);
+    }
+
+    public function test_only_going_members_access_event_chat(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community, ['capacity' => 1]);
+
+        $going = $this->member($community);
+        $waitlisted = $this->member($community);
+        $outsider = Profile::factory()->attendee()->create();
+
+        $this->actingAs($going)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $this->actingAs($waitlisted)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+
+        $threadId = $this->actingAs($leader)
+            ->postJson("/api/v1/events/{$event->id}/chat")->json('data.id');
+
+        // Going member + leader: access. Waitlisted + outsider: denied.
+        $this->actingAs($going)->getJson("/api/v1/chats/{$threadId}/messages")->assertStatus(200);
+        $this->actingAs($leader)->getJson("/api/v1/chats/{$threadId}/messages")->assertStatus(200);
+        $this->actingAs($waitlisted)->getJson("/api/v1/chats/{$threadId}/messages")->assertStatus(403);
+        $this->actingAs($outsider)->getJson("/api/v1/chats/{$threadId}/messages")->assertStatus(403);
+    }
+
+    public function test_event_thread_appears_in_chats_for_going_member_and_send_works(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community);
+        $member = $this->member($community);
+
+        $this->actingAs($member)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $threadId = $this->actingAs($leader)->postJson("/api/v1/events/{$event->id}/chat")->json('data.id');
+
+        // Going member posts a message.
+        $this->actingAs($member)
+            ->postJson("/api/v1/chats/{$threadId}/messages", ['content' => 'See you there!'])
+            ->assertStatus(201)
+            ->assertJsonPath('data.thread_id', $threadId);
+
+        // The event thread shows up in the going member's inbox.
+        $threads = $this->actingAs($member)->getJson('/api/v1/chats')->assertStatus(200)->json('data');
+        $eventThread = collect($threads)->firstWhere('type', 'event');
+        $this->assertNotNull($eventThread);
+        $this->assertSame($event->id, $eventThread['event_id']);
+
+        // And the message is readable back.
+        $this->actingAs($member)->getJson("/api/v1/chats/{$threadId}/messages")
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.messages')
+            ->assertJsonPath('data.messages.0.content', 'See you there!');
+    }
+}

--- a/tests/Feature/Api/V1/EventSignupTest.php
+++ b/tests/Feature/Api/V1/EventSignupTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\EventSignupStatus;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\CommunityTier;
+use App\Models\Event;
+use App\Models\EventSignup;
+use App\Models\Profile;
+use App\Services\CommunityService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class EventSignupTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(Profile $leader): Community
+    {
+        return app(CommunityService::class)->create($leader, [
+            'name' => 'Barcelona Run Club',
+            'type' => 'greek',
+        ]);
+    }
+
+    private function upcomingEvent(Community $community, array $overrides = []): Event
+    {
+        return Event::factory()->create(array_merge([
+            'profile_id' => $community->owner_profile_id,
+            'community_id' => $community->id,
+            'starts_at' => now()->addDays(2),
+            'ends_at' => now()->addDays(2)->addHours(3),
+        ], $overrides));
+    }
+
+    private function member(Community $community, ?string $tierId = null): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $profile->id,
+            'tier_id' => $tierId ?? $community->defaultTier->id,
+            'status' => 'active',
+        ]);
+
+        return $profile;
+    }
+
+    public function test_member_can_sign_up_to_upcoming_event(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community);
+        $member = $this->member($community);
+
+        $this->actingAs($member)
+            ->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(200)
+            ->assertJsonPath('data.my_signup.status', 'going')
+            ->assertJsonPath('data.going_count', 1);
+    }
+
+    public function test_over_capacity_goes_to_waitlist(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community, ['capacity' => 1]);
+
+        $a = $this->member($community);
+        $b = $this->member($community);
+
+        $this->actingAs($a)->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(200)->assertJsonPath('data.my_signup.status', 'going');
+
+        $this->actingAs($b)->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(200)
+            ->assertJsonPath('data.my_signup.status', 'waitlisted')
+            ->assertJsonPath('data.my_signup.waitlist_position', 1)
+            ->assertJsonPath('data.going_count', 1)
+            ->assertJsonPath('data.waitlist_count', 1);
+    }
+
+    public function test_cancel_auto_promotes_head_of_waitlist_and_notifies(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community, ['capacity' => 1]);
+
+        $a = $this->member($community);
+        $b = $this->member($community);
+
+        $this->actingAs($a)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $this->actingAs($b)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+
+        // A leaves → B (head of waitlist) is promoted to going.
+        $this->actingAs($a)->deleteJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+
+        $this->assertTrue(
+            EventSignup::query()->where('event_id', $event->id)->where('profile_id', $b->id)
+                ->where('status', EventSignupStatus::Going->value)->exists()
+        );
+
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $b->id,
+            'type' => 'waitlist_promoted',
+        ]);
+    }
+
+    public function test_tier_gated_event_blocks_other_tiers(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $gatedTier = CommunityTier::factory()->forCommunity($community)->create(['rank' => 3]);
+        $event = $this->upcomingEvent($community, ['tier_gate' => [$gatedTier->id]]);
+
+        $wrongTier = $this->member($community, $community->defaultTier->id);
+        $this->actingAs($wrongTier)->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(422)->assertJsonPath('error', 'tier_not_permitted');
+
+        $allowed = $this->member($community, $gatedTier->id);
+        $this->actingAs($allowed)->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(200)->assertJsonPath('data.my_signup.status', 'going');
+    }
+
+    public function test_non_member_cannot_sign_up(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community);
+        $outsider = Profile::factory()->attendee()->create();
+
+        $this->actingAs($outsider)->postJson("/api/v1/events/{$event->id}/signup")
+            ->assertStatus(422)->assertJsonPath('error', 'not_a_member');
+    }
+
+    public function test_cannot_sign_up_to_past_event(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $past = Event::factory()->create([
+            'profile_id' => $leader->id,
+            'community_id' => $community->id,
+            'starts_at' => now()->subDays(2),
+            'ends_at' => now()->subDays(2)->addHours(2),
+        ]);
+        $member = $this->member($community);
+
+        $this->actingAs($member)->postJson("/api/v1/events/{$past->id}/signup")
+            ->assertStatus(422)->assertJsonPath('error', 'event_not_upcoming');
+    }
+
+    public function test_leader_lists_going_and_waitlist(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = $this->upcomingEvent($community, ['capacity' => 1]);
+
+        $a = $this->member($community);
+        $b = $this->member($community);
+        $this->actingAs($a)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $this->actingAs($b)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+
+        $this->actingAs($leader)->getJson("/api/v1/events/{$event->id}/signups")
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.going')
+            ->assertJsonCount(1, 'data.waitlist')
+            ->assertJsonPath('data.going.0.profile_id', $a->id)
+            ->assertJsonPath('data.waitlist.0.profile_id', $b->id);
+
+        // A non-manager member cannot view the roster.
+        $this->actingAs($a)->getJson("/api/v1/events/{$event->id}/signups")->assertStatus(403);
+    }
+}


### PR DESCRIPTION
Backend for NF-CHAT Phase 3 (ticket: kolabing-app/docs/tickets/2026-06-04-chat-phase3-events-rsvp-realtime-backend.md). Builds on shipped Phase 1 (inbox) + Phase 2 (community chats).

## What's in
- **Sign-ups (RSVP):** `event_signups` + `EventSignupStatus`; `events` gains `starts_at`/`ends_at`/`location`/`capacity`/`tier_gate`/`collaboration_id` + `isUpcoming()`. `EventSignupService` = binary "I'm going" → going else **waitlisted w/ position** (row-locked, idempotent), tier-gate + membership eligibility, **cancel auto-promotes** head of waitlist + notifies (`WaitlistPromoted`). `POST/DELETE /events/{event}/signup`, `GET /events/{event}/signups` (leader). `EventResource` += `my_signup`/`going_count`/`waitlist_count`/`capacity`/`starts_at`…
- **Event chat:** `POST /events/{event}/chat` (leader) → idempotent `event` thread; `canAccessThread` Event branch (going or leader; waitlisted/outsider denied); surfaced in `GET /chats`; reuses Phase-2 message endpoints.
- **Real-time (Reverb):** private `chat.thread.{id}` channel authorized by `canAccessThread` (same derived access as REST). `NewChatMessage` already broadcasts there.
- **Lifecycle/§6.1:** `events.collaboration_id` mirror; `GET /events` filters `community_id`/`time=upcoming|past`/`attendee=me`/`profile_id` — one events lifecycle feeds upcoming/past/profile. Retroactive past-event creation + check-in/showcase untouched.

## Tests
`EventSignupTest` (7) + `EventChatTest` (4). **842 total green, 0 regressions.**

## Not in scope / follow-ups
- App side (I'm going button, waitlist UI, event-chat surfacing, Echo client).
- Ops: run the Reverb server; confirm prod env + run migrations.
- Known: `EventResource` runs a few count queries per event on list endpoints — fine now, flagged for the scale-audit ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)