### PR TITLE
feat(chat): message-notification fan-out for community/event threads (pref-gated)

### DIFF
--- a/app/Jobs/FanOutThreadMessageNotifications.php
+++ b/app/Jobs/FanOutThreadMessageNotifications.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\NotificationType;
+use App\Models\ChatMessage;
+use App\Models\ChatThread;
+use App\Services\ChatService;
+use App\Services\NotificationService;
+use App\Services\PushNotificationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Notify the other members of a community/event chat thread about a new message:
+ * one bulk in-app insert + one multi-recipient push, gated by each recipient's
+ * `message_notifications` preference (default ON). Queued so a large audience
+ * never blocks the message-send request. Collaboration threads are NOT handled
+ * here (they notify via NotificationService::notifyNewMessage).
+ */
+class FanOutThreadMessageNotifications implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $backoff = 10;
+
+    public function __construct(
+        public readonly string $messageId,
+        public readonly string $threadId,
+        public readonly string $senderProfileId,
+    ) {}
+
+    public function handle(
+        ChatService $chat,
+        NotificationService $notifications,
+        PushNotificationService $push,
+    ): void {
+        $thread = ChatThread::query()->find($this->threadId);
+        $message = ChatMessage::query()
+            ->with('senderProfile.businessProfile', 'senderProfile.communityProfile')
+            ->find($this->messageId);
+
+        if ($thread === null || $message === null) {
+            return;
+        }
+
+        $recipientIds = $chat->threadRecipientIds($thread, $this->senderProfileId);
+        $recipientIds = $notifications->recipientsAllowingMessages($recipientIds);
+
+        if ($recipientIds === []) {
+            return;
+        }
+
+        $title = $thread->name ?? __('New message');
+        $senderName = $message->senderProfile?->businessProfile?->name
+            ?? $message->senderProfile?->communityProfile?->name;
+        $body = ($senderName !== null ? $senderName.': ' : '').Str::limit($message->content, 120);
+
+        // In-app feed: one chunked bulk insert regardless of audience size.
+        $notifications->recordNotifications(
+            recipientIds: $recipientIds,
+            type: NotificationType::NewMessage,
+            title: $title,
+            body: $body,
+            actorProfileId: $this->senderProfileId,
+            targetId: $thread->id,
+            targetType: 'chat_thread',
+        );
+
+        // Push: one multi-recipient call. Best-effort — never fail the fan-out.
+        try {
+            $push->sendToUsers($recipientIds, $title, $body, NotificationType::NewMessage, $thread->id);
+        } catch (Throwable $e) {
+            Log::warning('Thread message push fan-out failed', [
+                'thread_id' => $thread->id,
+                'recipients' => count($recipientIds),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Models/NotificationPreference.php
+++ b/app/Models/NotificationPreference.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property bool $whatsapp_notifications
  * @property bool $new_application_alerts
  * @property bool $collaboration_updates
+ * @property bool $message_notifications
  * @property bool $marketing_tips
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -37,6 +38,7 @@ class NotificationPreference extends Model
         'whatsapp_notifications',
         'new_application_alerts',
         'collaboration_updates',
+        'message_notifications',
         'marketing_tips',
     ];
 
@@ -52,6 +54,7 @@ class NotificationPreference extends Model
             'whatsapp_notifications' => 'boolean',
             'new_application_alerts' => 'boolean',
             'collaboration_updates' => 'boolean',
+            'message_notifications' => 'boolean',
             'marketing_tips' => 'boolean',
         ];
     }

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -8,6 +8,7 @@ use App\Enums\ChatThreadType;
 use App\Enums\CommunityMemberStatus;
 use App\Enums\EventSignupStatus;
 use App\Events\NewChatMessage;
+use App\Jobs\FanOutThreadMessageNotifications;
 use App\Models\Application;
 use App\Models\ChatMessage;
 use App\Models\ChatThread;
@@ -342,6 +343,10 @@ class ChatService
 
         broadcast(new NewChatMessage($message))->toOthers();
 
+        // Fan out push + in-app notifications to the thread's other members
+        // (community/event). Queued so a large audience never blocks the send.
+        FanOutThreadMessageNotifications::dispatch($message->id, $thread->id, $sender->id);
+
         return $message;
     }
 
@@ -533,6 +538,100 @@ class ChatService
             ->pluck('community_id');
 
         return $owned->merge($managed)->unique()->values();
+    }
+
+    /**
+     * Profile ids that should be notified of a new message in a thread, minus the
+     * sender. Mirrors `canAccessThread` as a SET. Collaboration threads return []
+     * (those notify via NotificationService::notifyNewMessage).
+     *
+     * @return array<int, string>
+     */
+    public function threadRecipientIds(ChatThread $thread, string $senderProfileId): array
+    {
+        $ids = match ($thread->type) {
+            ChatThreadType::CommunityMain => $this->communityAudienceIds($thread->community_id),
+            ChatThreadType::CommunityCustom => $this->customChatAudienceIds($thread),
+            ChatThreadType::Event => $this->eventChatAudienceIds($thread),
+            default => collect(),
+        };
+
+        return $ids
+            ->filter(fn ($id): bool => $id !== null && $id !== $senderProfileId)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function communityAudienceIds(?string $communityId): Collection
+    {
+        if ($communityId === null) {
+            return collect();
+        }
+
+        $members = CommunityMember::query()
+            ->where('community_id', $communityId)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->pluck('profile_id');
+
+        $owner = Community::query()->whereKey($communityId)->value('owner_profile_id');
+
+        return $members->push($owner);
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function customChatAudienceIds(ChatThread $thread): Collection
+    {
+        if ($thread->community_id === null) {
+            return collect();
+        }
+
+        $owner = Community::query()->whereKey($thread->community_id)->value('owner_profile_id');
+
+        $ids = CommunityMember::query()
+            ->with('tier')
+            ->where('community_id', $thread->community_id)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->get()
+            ->filter(fn (CommunityMember $m): bool => $m->can_manage
+                || in_array($thread->slug, $this->tierChatChannels($m->tier), true))
+            ->pluck('profile_id');
+
+        return $ids->push($owner);
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function eventChatAudienceIds(ChatThread $thread): Collection
+    {
+        if ($thread->event_id === null) {
+            return collect();
+        }
+
+        $going = EventSignup::query()
+            ->where('event_id', $thread->event_id)
+            ->where('status', EventSignupStatus::Going->value)
+            ->pluck('profile_id');
+
+        if ($thread->community_id === null) {
+            return $going;
+        }
+
+        $managers = CommunityMember::query()
+            ->where('community_id', $thread->community_id)
+            ->where('can_manage', true)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->pluck('profile_id');
+
+        $owner = Community::query()->whereKey($thread->community_id)->value('owner_profile_id');
+
+        return $going->merge($managers)->push($owner);
     }
 
     private function isCommunityMemberOrOwner(Profile $profile, string $communityId): bool

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -93,6 +93,68 @@ class NotificationService
     }
 
     /**
+     * Bulk-record a notification for many recipients in one (chunked) insert —
+     * scale-friendly fan-out (the push is sent separately, in one multi-recipient
+     * call by the caller). Does NOT dispatch per-recipient push jobs.
+     *
+     * @param  array<int, string>  $recipientIds
+     */
+    public function recordNotifications(
+        array $recipientIds,
+        NotificationType $type,
+        string $title,
+        string $body,
+        ?string $actorProfileId = null,
+        ?string $targetId = null,
+        ?string $targetType = null,
+    ): void {
+        if ($recipientIds === []) {
+            return;
+        }
+
+        $now = now();
+        $rows = array_map(static fn (string $profileId): array => [
+            'id' => (string) Str::uuid(),
+            'profile_id' => $profileId,
+            'type' => $type->value,
+            'title' => $title,
+            'body' => $body,
+            'actor_profile_id' => $actorProfileId,
+            'target_id' => $targetId,
+            'target_type' => $targetType,
+            'read_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ], array_values($recipientIds));
+
+        foreach (array_chunk($rows, 500) as $chunk) {
+            Notification::query()->insert($chunk);
+        }
+    }
+
+    /**
+     * Of the given profile ids, those who allow chat-message notifications.
+     * Missing preference row = default ON.
+     *
+     * @param  array<int, string>  $profileIds
+     * @return array<int, string>
+     */
+    public function recipientsAllowingMessages(array $profileIds): array
+    {
+        if ($profileIds === []) {
+            return [];
+        }
+
+        $optedOut = \App\Models\NotificationPreference::query()
+            ->whereIn('profile_id', $profileIds)
+            ->where('message_notifications', false)
+            ->pluck('profile_id')
+            ->all();
+
+        return array_values(array_diff($profileIds, $optedOut));
+    }
+
+    /**
      * Create a notification for a new chat message.
      * Notifies the other party in the application conversation.
      */
@@ -113,6 +175,11 @@ class NotificationService
         $senderProfile = $senderProfileId === $application->applicant_profile_id
             ? $application->applicantProfile
             : $application->collabOpportunity->creatorProfile;
+
+        // Respect the recipient's message-notification preference (default ON).
+        if ($this->recipientsAllowingMessages([$recipient->id]) === []) {
+            return;
+        }
 
         $body = Str::limit($message->content, 100, '...');
 

--- a/database/migrations/2026_06_05_000003_add_message_notifications_to_notification_preferences.php
+++ b/database/migrations/2026_06_05_000003_add_message_notifications_to_notification_preferences.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-user toggle for chat-message notifications (push + in-app feed).
+ * Default ON — members are notified of new community/event/collaboration
+ * messages unless they opt out.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('notification_preferences', function (Blueprint $table): void {
+            $table->boolean('message_notifications')->default(true)->after('collaboration_updates');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('notification_preferences', function (Blueprint $table): void {
+            $table->dropColumn('message_notifications');
+        });
+    }
+};

--- a/tests/Feature/Api/V1/ChatMessageNotificationTest.php
+++ b/tests/Feature/Api/V1/ChatMessageNotificationTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\ChatThreadType;
+use App\Models\ChatThread;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\Event;
+use App\Models\NotificationPreference;
+use App\Models\Profile;
+use App\Services\CommunityService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class ChatMessageNotificationTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(Profile $leader): Community
+    {
+        return app(CommunityService::class)->create($leader, [
+            'name' => 'Barcelona Run Club',
+            'type' => 'greek',
+        ]);
+    }
+
+    private function member(Community $community): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $profile->id,
+            'tier_id' => $community->defaultTier->id,
+            'status' => 'active',
+        ]);
+
+        return $profile;
+    }
+
+    private function mainThreadId(Community $community): string
+    {
+        return ChatThread::query()
+            ->where('community_id', $community->id)
+            ->where('type', ChatThreadType::CommunityMain->value)
+            ->value('id');
+    }
+
+    public function test_community_message_notifies_other_members_not_the_sender(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $a = $this->member($community);
+        $b = $this->member($community);
+        $threadId = $this->mainThreadId($community);
+
+        $this->actingAs($a)
+            ->postJson("/api/v1/chats/{$threadId}/messages", ['content' => 'Morning run Saturday?'])
+            ->assertStatus(201);
+
+        // Other members + leader get an in-app notification; the sender does not.
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $b->id, 'type' => 'new_message',
+            'target_id' => $threadId, 'target_type' => 'chat_thread',
+        ]);
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $leader->id, 'type' => 'new_message', 'target_id' => $threadId,
+        ]);
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $a->id, 'target_id' => $threadId,
+        ]);
+    }
+
+    public function test_member_who_opted_out_of_message_notifications_is_not_notified(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $a = $this->member($community);
+        $b = $this->member($community);
+        $threadId = $this->mainThreadId($community);
+
+        NotificationPreference::query()->create([
+            'profile_id' => $b->id,
+            'message_notifications' => false,
+        ]);
+
+        $this->actingAs($a)
+            ->postJson("/api/v1/chats/{$threadId}/messages", ['content' => 'ping'])
+            ->assertStatus(201);
+
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $b->id, 'target_id' => $threadId,
+        ]);
+        // Leader (default ON) is still notified.
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $leader->id, 'target_id' => $threadId,
+        ]);
+    }
+
+    public function test_event_message_notifies_going_members(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = Event::factory()->create([
+            'profile_id' => $leader->id,
+            'community_id' => $community->id,
+            'starts_at' => now()->addDays(2),
+            'ends_at' => now()->addDays(2)->addHours(3),
+        ]);
+
+        $m1 = $this->member($community);
+        $m2 = $this->member($community);
+        $this->actingAs($m1)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $this->actingAs($m2)->postJson("/api/v1/events/{$event->id}/signup")->assertStatus(200);
+        $threadId = $this->actingAs($leader)->postJson("/api/v1/events/{$event->id}/chat")->json('data.id');
+
+        $this->actingAs($m1)
+            ->postJson("/api/v1/chats/{$threadId}/messages", ['content' => 'On my way'])
+            ->assertStatus(201);
+
+        // The other going member + leader are notified; the sender is not.
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $m2->id, 'type' => 'new_message', 'target_id' => $threadId,
+        ]);
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $leader->id, 'target_id' => $threadId,
+        ]);
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $m1->id, 'target_id' => $threadId,
+        ]);
+    }
+}


### PR DESCRIPTION
Closes the Phase-2/3 gap: community & event chat messages only **broadcast** (Reverb) — members got nothing when the app was closed. This adds push + in-app notifications to the thread's other members, gated by a new preference.

## What's in
- **New preference `message_notifications`** on `notification_preferences`, **default ON**. Respected by the fan-out and by the existing collaboration `notifyNewMessage`.
- **`ChatService::threadRecipientIds`** — a thread's audience as a set (community members + owner; custom = tier-granted/can_manage; event = `going` sign-ups + managers), minus the sender. Mirrors `canAccessThread`.
- **Queued `FanOutThreadMessageNotifications`** (dispatched from `sendThreadMessage`): filter by preference → **one chunked bulk insert** (`recordNotifications`) + **one multi-recipient push** (`sendToUsers`). Push is best-effort (errors swallowed/logged); queued so a 1000-member audience never blocks the send.

## Scale notes
One bulk insert + one push per message regardless of audience size; fan-out runs off-request. (Aligns with NF-15.)

## Tests
`ChatMessageNotificationTest` (3): community fan-out excludes sender, opt-out respected, event notifies going members. **845 total green, 0 regressions.**

## Not in scope
@mentions (spec fast-follow); per-message vs digest batching for very chatty threads (future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)