### PR TITLE
feat(events): create UPCOMING events via POST /events (Phase 3 create path)

### DIFF
--- a/app/Http/Controllers/Api/V1/EventController.php
+++ b/app/Http/Controllers/Api/V1/EventController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\StoreEventRequest;
 use App\Http\Requests\Api\V1\UpdateEventRequest;
 use App\Http\Resources\Api\V1\EventResource;
+use App\Models\Community;
 use App\Models\Event;
 use App\Models\Profile;
 use App\Services\EventService;
@@ -103,7 +104,18 @@ class EventController extends Controller
         /** @var Profile $profile */
         $profile = $request->user();
 
-        if ($profile->cannot('create', Event::class)) {
+        $data = $request->validated();
+
+        if ($request->isUpcoming()) {
+            // Upcoming community event: must be owner / can_manage of the community.
+            $community = Community::query()->find($data['community_id']);
+            if ($community === null || $profile->cannot('manage', $community)) {
+                return response()->json([
+                    'success' => false,
+                    'message' => __('You are not authorized to create events for this community.'),
+                ], 403);
+            }
+        } elseif ($profile->cannot('create', Event::class)) {
             return response()->json([
                 'success' => false,
                 'message' => __('You are not authorized to create events.'),
@@ -112,8 +124,8 @@ class EventController extends Controller
 
         $event = $this->eventService->create(
             $profile,
-            $request->validated(),
-            $request->file('photos')
+            $data,
+            $request->file('photos') ?? []
         );
 
         return response()->json([

--- a/app/Http/Requests/Api/V1/StoreEventRequest.php
+++ b/app/Http/Requests/Api/V1/StoreEventRequest.php
@@ -16,10 +16,36 @@ class StoreEventRequest extends FormRequest
     }
 
     /**
+     * Upcoming-event create mode is keyed on `starts_at`. Without it, the request
+     * is the legacy retroactive past-showcase create (photos + date<=today).
+     */
+    public function isUpcoming(): bool
+    {
+        return $this->filled('starts_at');
+    }
+
+    /**
      * @return array<string, array<int, mixed>>
      */
     public function rules(): array
     {
+        if ($this->isUpcoming()) {
+            return [
+                'community_id' => ['required', 'uuid', 'exists:communities,id'],
+                'name' => ['required', 'string', 'min:3', 'max:100'],
+                'starts_at' => ['required', 'date'],
+                'ends_at' => ['nullable', 'date', 'after:starts_at'],
+                'location' => ['nullable', 'string', 'max:255'],
+                'capacity' => ['nullable', 'integer', 'min:1'],
+                'tier_gate' => ['nullable', 'array'],
+                'tier_gate.*' => ['uuid'],
+                'collaboration_id' => ['nullable', 'uuid', 'exists:collaborations,id'],
+                'photos' => ['nullable', 'array', 'max:5'],
+                'photos.*' => ['image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+            ];
+        }
+
+        // Legacy retroactive past-showcase event.
         return [
             'name' => ['required', 'string', 'min:3', 'max:100'],
             'partner_name' => ['required', 'string', 'min:2', 'max:100'],

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\FileUploadType;
+use App\Enums\UserType;
+use App\Models\Community;
 use App\Models\Event;
 use App\Models\EventPhoto;
 use App\Models\Profile;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class EventService
@@ -91,19 +94,54 @@ class EventService
     public function create(Profile $profile, array $data, array $photos): Event
     {
         return DB::transaction(function () use ($profile, $data, $photos): Event {
-            $event = Event::query()->create([
-                'profile_id' => $profile->id,
-                'name' => $data['name'],
-                'partner_name' => $data['partner_name'],
-                'partner_type' => $data['partner_type'],
-                'event_date' => $data['date'],
-                'attendee_count' => $data['attendee_count'],
-            ]);
+            // Upcoming-event mode (Phase 3) is keyed on `starts_at`; otherwise this
+            // is the legacy retroactive past-showcase create.
+            $event = empty($data['starts_at'])
+                ? Event::query()->create([
+                    'profile_id' => $profile->id,
+                    'name' => $data['name'],
+                    'partner_name' => $data['partner_name'],
+                    'partner_type' => $data['partner_type'],
+                    'event_date' => $data['date'],
+                    'attendee_count' => $data['attendee_count'],
+                ])
+                : $this->buildUpcoming($profile, $data);
 
-            $this->uploadPhotos($event, $photos);
+            if ($photos !== []) {
+                $this->uploadPhotos($event, $photos);
+            }
 
             return $event->load(['photos']);
         });
+    }
+
+    /**
+     * Create an upcoming community event (sign-up/waitlist/chat apply). Defaults
+     * partner + event_date from the community/start so the legacy NOT NULL columns
+     * stay satisfied.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function buildUpcoming(Profile $profile, array $data): Event
+    {
+        $community = Community::query()->find($data['community_id']);
+        $startsAt = Carbon::parse($data['starts_at']);
+
+        return Event::query()->create([
+            'profile_id' => $profile->id,
+            'community_id' => $data['community_id'],
+            'collaboration_id' => $data['collaboration_id'] ?? null,
+            'name' => $data['name'],
+            'partner_name' => $community?->name ?? $data['name'],
+            'partner_type' => UserType::Community->value,
+            'event_date' => $startsAt->toDateString(),
+            'starts_at' => $startsAt,
+            'ends_at' => isset($data['ends_at']) ? Carbon::parse($data['ends_at']) : null,
+            'location' => $data['location'] ?? null,
+            'capacity' => $data['capacity'] ?? null,
+            'tier_gate' => $data['tier_gate'] ?? null,
+            'attendee_count' => 0,
+        ]);
     }
 
     /**

--- a/tests/Feature/Api/V1/CreateUpcomingEventTest.php
+++ b/tests/Feature/Api/V1/CreateUpcomingEventTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\CommunityTier;
+use App\Models\Event;
+use App\Models\Profile;
+use App\Services\CommunityService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class CreateUpcomingEventTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(Profile $leader): Community
+    {
+        return app(CommunityService::class)->create($leader, [
+            'name' => 'Barcelona Run Club',
+            'type' => 'greek',
+        ]);
+    }
+
+    public function test_leader_creates_upcoming_event_without_photos(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+
+        $response = $this->actingAs($leader)->postJson('/api/v1/events', [
+            'community_id' => $community->id,
+            'name' => 'Saturday Long Run',
+            'starts_at' => now()->addDays(3)->toIso8601String(),
+            'ends_at' => now()->addDays(3)->addHours(2)->toIso8601String(),
+            'location' => 'Parc de la Ciutadella',
+            'capacity' => 20,
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.is_upcoming', true)
+            ->assertJsonPath('data.community_id', $community->id)
+            ->assertJsonPath('data.capacity', 20)
+            ->assertJsonPath('data.going_count', 0);
+
+        $eventId = $response->json('data.id');
+
+        // Appears in the upcoming list for the community.
+        $this->actingAs($leader)
+            ->getJson("/api/v1/events?community_id={$community->id}&time=upcoming")
+            ->assertStatus(200)
+            ->assertJsonPath('data.events.0.id', $eventId);
+    }
+
+    public function test_upcoming_event_can_be_tier_gated(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $tier = CommunityTier::factory()->forCommunity($community)->create(['rank' => 3]);
+
+        $response = $this->actingAs($leader)->postJson('/api/v1/events', [
+            'community_id' => $community->id,
+            'name' => 'VIP Track Day',
+            'starts_at' => now()->addDays(5)->toIso8601String(),
+            'tier_gate' => [$tier->id],
+        ])->assertStatus(201)->assertJsonPath('data.tier_gate', [$tier->id]);
+
+        // A member not on the gated tier cannot sign up (existing signup logic).
+        $eventId = $response->json('data.id');
+        $outsiderTierMember = Profile::factory()->attendee()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $outsiderTierMember->id,
+            'tier_id' => $community->defaultTier->id,
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($outsiderTierMember)
+            ->postJson("/api/v1/events/{$eventId}/signup")
+            ->assertStatus(422)->assertJsonPath('error', 'tier_not_permitted');
+    }
+
+    public function test_non_manager_cannot_create_upcoming_event(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $outsider = Profile::factory()->community()->create();
+
+        $this->actingAs($outsider)->postJson('/api/v1/events', [
+            'community_id' => $community->id,
+            'name' => 'Sneaky Event',
+            'starts_at' => now()->addDays(2)->toIso8601String(),
+        ])->assertStatus(403);
+    }
+
+    // Legacy retroactive past-event create (photos + date<=today) is covered by
+    // EventTest::test_create_event_with_valid_data — kept green by this change.
+}


### PR DESCRIPTION
Implements `kolabing-app/docs/tickets/2026-06-05-backend-create-upcoming-event-endpoint.md`. Closes the Phase-3 gap: `POST /events` only created **past** showcase rows, so upcoming community events couldn't be created via the API.

## What's in
- **Upcoming mode** keyed on `starts_at`: `StoreEventRequest` requires `community_id` + `name` + `starts_at` (future allowed), with optional `ends_at`/`location`/`capacity`/`tier_gate`/`collaboration_id`; **photos optional**. Legacy past-showcase rules unchanged.
- **Auth:** upcoming → owner/`can_manage` of the community (`CommunityPolicy::manage`), else 403; legacy → existing `EventPolicy::create`.
- **`EventService::buildUpcoming`**: defaults `partner_name` from the community, `event_date` from `starts_at`, `attendee_count` 0 (satisfies legacy NOT NULL columns).
- Returns `EventResource` (with `my_signup`/`going_count`/`capacity`/`is_upcoming`/…), 201.

## Acceptance (all covered)
1. Leader creates upcoming event (future `starts_at`, no photos) → 201, `is_upcoming:true`, in `GET /events?community_id&time=upcoming`.
2. Tier-gated create persists + blocks non-permitted signup.
3. Retroactive past create still works (EventTest green).
4. Non-owner/non-can_manage → 403.

## Tests
`CreateUpcomingEventTest` (3) + legacy `EventTest`/`EventSignupTest` → 44 event tests green.

Unblocks the app's leader create-event form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)