### PR TITLE
fix(broadcast): register /broadcasting/auth + channels for Reverb real-time

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,13 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
+    // Registers POST /broadcasting/auth (Sanctum-guarded) + loads routes/channels.php
+    // so private chat channels (chat.thread.{id}, chat.application.{id}) can authorize
+    // for Reverb real-time. Mobile clients send their Bearer token to this endpoint.
+    ->withBroadcasting(
+        __DIR__.'/../routes/channels.php',
+        ['middleware' => ['auth:sanctum']],
+    )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->append(AddSecurityHeaders::class);
 


### PR DESCRIPTION
**Prerequisite for Reverb real-time.** `bootstrap/app.php` had no `withBroadcasting()`, so `POST /broadcasting/auth` was never registered and `routes/channels.php` (the `chat.thread.{id}` / `chat.application.{id}` channel-auth closures) was never loaded. Private channels could not authorize → no real-time even with the Reverb server up.

Registers broadcasting Sanctum-guarded (`auth:sanctum`) so mobile clients authorize private channels with their Bearer token. `route:list` now shows `broadcasting/auth`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)