### PR TITLE
feat(events): event photos endpoints + message_notifications prefs API (NF-16 backend)

### DIFF
--- a/app/Http/Controllers/Api/V1/EventPhotoController.php
+++ b/app/Http/Controllers/Api/V1/EventPhotoController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreEventPhotosRequest;
+use App\Http\Resources\Api\V1\EventResource;
+use App\Models\Community;
+use App\Models\Event;
+use App\Models\EventPhoto;
+use App\Models\Profile;
+use App\Services\EventService;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class EventPhotoController extends Controller
+{
+    public function __construct(
+        private readonly EventService $eventService
+    ) {}
+
+    /**
+     * POST /api/v1/events/{event}/photos — add photos (creator / community can_manage).
+     */
+    public function store(StoreEventPhotosRequest $request, Event $event): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if (! $this->canManageEvent($profile, $event)) {
+            return $this->forbidden();
+        }
+
+        try {
+            $event = $this->eventService->addPhotos($event, $request->file('photos'));
+        } catch (DomainException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => $e->getMessage(),
+                'message' => __('An event can have at most 5 photos.'),
+            ], 422);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => new EventResource($event),
+        ], 201);
+    }
+
+    /**
+     * DELETE /api/v1/events/{event}/photos/{photo} — remove a photo (creator / can_manage).
+     */
+    public function destroy(Request $request, Event $event, EventPhoto $photo): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if (! $this->canManageEvent($profile, $event)) {
+            return $this->forbidden();
+        }
+
+        if ($photo->event_id !== $event->id) {
+            return response()->json([
+                'success' => false,
+                'message' => __('Photo not found for this event.'),
+            ], 404);
+        }
+
+        $this->eventService->deletePhoto($photo);
+
+        return response()->json([
+            'success' => true,
+            'data' => null,
+        ]);
+    }
+
+    /**
+     * The event creator, or an owner/can_manage of the event's community.
+     */
+    private function canManageEvent(Profile $profile, Event $event): bool
+    {
+        if ($profile->id === $event->profile_id) {
+            return true;
+        }
+
+        if ($event->community_id !== null) {
+            $community = Community::query()->find($event->community_id);
+
+            return $community !== null && $profile->can('manage', $community);
+        }
+
+        return false;
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => __('You are not authorized to manage this event\'s photos.'),
+        ], 403);
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreEventPhotosRequest.php
+++ b/app/Http/Requests/Api/V1/StoreEventPhotosRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreEventPhotosRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'photos' => ['required', 'array', 'min:1', 'max:5'],
+            'photos.*' => ['required', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/UpdateEventRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateEventRequest.php
@@ -26,6 +26,13 @@ class UpdateEventRequest extends FormRequest
             'partner_type' => ['sometimes', 'string', Rule::in([UserType::Business->value, UserType::Community->value])],
             'date' => ['sometimes', 'date', 'before_or_equal:today'],
             'attendee_count' => ['sometimes', 'integer', 'min:1'],
+            // Upcoming-event fields (NF-16 edit). future allowed.
+            'starts_at' => ['sometimes', 'date'],
+            'ends_at' => ['sometimes', 'nullable', 'date', 'after:starts_at'],
+            'location' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'capacity' => ['sometimes', 'nullable', 'integer', 'min:1'],
+            'tier_gate' => ['sometimes', 'nullable', 'array'],
+            'tier_gate.*' => ['uuid'],
         ];
     }
 

--- a/app/Http/Requests/Api/V1/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateNotificationPreferencesRequest.php
@@ -28,6 +28,7 @@ class UpdateNotificationPreferencesRequest extends FormRequest
             'whatsapp_notifications' => ['sometimes', 'boolean'],
             'new_application_alerts' => ['sometimes', 'boolean'],
             'collaboration_updates' => ['sometimes', 'boolean'],
+            'message_notifications' => ['sometimes', 'boolean'],
             'marketing_tips' => ['sometimes', 'boolean'],
         ];
     }
@@ -44,6 +45,7 @@ class UpdateNotificationPreferencesRequest extends FormRequest
             'whatsapp_notifications',
             'new_application_alerts',
             'collaboration_updates',
+            'message_notifications',
             'marketing_tips',
         ]);
     }

--- a/app/Http/Resources/Api/V1/NotificationPreferenceResource.php
+++ b/app/Http/Resources/Api/V1/NotificationPreferenceResource.php
@@ -26,6 +26,7 @@ class NotificationPreferenceResource extends JsonResource
             'whatsapp_notifications' => $this->whatsapp_notifications,
             'new_application_alerts' => $this->new_application_alerts,
             'collaboration_updates' => $this->collaboration_updates,
+            'message_notifications' => $this->message_notifications,
             'marketing_tips' => $this->marketing_tips,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -169,6 +169,21 @@ class EventService
             $updateData['attendee_count'] = $data['attendee_count'];
         }
 
+        // Upcoming-event fields (NF-16 edit). starts_at also syncs event_date.
+        if (isset($data['starts_at'])) {
+            $startsAt = Carbon::parse($data['starts_at']);
+            $updateData['starts_at'] = $startsAt;
+            $updateData['event_date'] = $startsAt->toDateString();
+        }
+        if (array_key_exists('ends_at', $data)) {
+            $updateData['ends_at'] = $data['ends_at'] !== null ? Carbon::parse($data['ends_at']) : null;
+        }
+        foreach (['location', 'capacity', 'tier_gate'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $updateData[$field] = $data[$field];
+            }
+        }
+
         if (! empty($updateData)) {
             $event->update($updateData);
         }

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -177,6 +177,51 @@ class EventService
     }
 
     /**
+     * Add photos to an existing event (gallery grows). Total capped at 5.
+     *
+     * @param  array<int, UploadedFile>  $photos
+     *
+     * @throws \DomainException 'photo_limit_reached'
+     */
+    public function addPhotos(Event $event, array $photos): Event
+    {
+        $existing = $event->photos()->count();
+
+        if ($existing + count($photos) > 5) {
+            throw new \DomainException('photo_limit_reached');
+        }
+
+        return DB::transaction(function () use ($event, $photos, $existing): Event {
+            foreach (array_values($photos) as $i => $photo) {
+                $url = $this->fileUploadService->uploadFromFile(
+                    $photo,
+                    FileUploadType::EventPhoto,
+                    $event->id
+                );
+
+                EventPhoto::query()->create([
+                    'event_id' => $event->id,
+                    'url' => $url,
+                    'sort_order' => $existing + $i,
+                ]);
+            }
+
+            return $event->load(['photos']);
+        });
+    }
+
+    /**
+     * Remove a single photo from an event (file + row).
+     */
+    public function deletePhoto(EventPhoto $photo): void
+    {
+        DB::transaction(function () use ($photo): void {
+            $this->fileUploadService->delete($photo->url);
+            $photo->delete();
+        });
+    }
+
+    /**
      * Delete an event and its photos from storage.
      */
     public function delete(Event $event): void

--- a/app/Services/ProfileService.php
+++ b/app/Services/ProfileService.php
@@ -284,6 +284,7 @@ class ProfileService
                 'whatsapp_notifications' => true,
                 'new_application_alerts' => true,
                 'collaboration_updates' => true,
+                'message_notifications' => true,
                 'marketing_tips' => false,
             ]
         );

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\Api\V1\DashboardController;
 use App\Http\Controllers\Api\V1\DeviceTokenController;
 use App\Http\Controllers\Api\V1\DiscoveryOpportunityController;
 use App\Http\Controllers\Api\V1\EventController;
+use App\Http\Controllers\Api\V1\EventPhotoController;
 use App\Http\Controllers\Api\V1\EventSignupController;
 use App\Http\Controllers\Api\V1\EventDiscoveryController;
 use App\Http\Controllers\Api\V1\EventRewardController;
@@ -263,6 +264,12 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.events.signups.index');
         Route::post('events/{event}/chat', [ChatController::class, 'storeEventChat'])
             ->name('api.v1.events.chat.store');
+
+        // NF-16 — add/remove photos on an existing event (creator / can_manage)
+        Route::post('events/{event}/photos', [EventPhotoController::class, 'store'])
+            ->name('api.v1.events.photos.store');
+        Route::delete('events/{event}/photos/{photo}', [EventPhotoController::class, 'destroy'])
+            ->name('api.v1.events.photos.destroy');
 
         /*
         |--------------------------------------------------------------------------

--- a/tests/Feature/Api/V1/CreateUpcomingEventTest.php
+++ b/tests/Feature/Api/V1/CreateUpcomingEventTest.php
@@ -81,6 +81,31 @@ class CreateUpcomingEventTest extends TestCase
             ->assertStatus(422)->assertJsonPath('error', 'tier_not_permitted');
     }
 
+    public function test_creator_can_edit_upcoming_event_fields(): void
+    {
+        $leader = Profile::factory()->community()->create();
+        $community = $this->community($leader);
+        $event = Event::factory()->create([
+            'profile_id' => $leader->id,
+            'community_id' => $community->id,
+            'starts_at' => now()->addDays(2),
+            'capacity' => 10,
+        ]);
+
+        $newStart = now()->addDays(4)->startOfMinute();
+
+        $this->actingAs($leader)->putJson("/api/v1/events/{$event->id}", [
+            'capacity' => 30,
+            'location' => 'New venue',
+            'starts_at' => $newStart->toIso8601String(),
+        ])->assertStatus(200)
+            ->assertJsonPath('data.capacity', 30)
+            ->assertJsonPath('data.location', 'New venue')
+            ->assertJsonPath('data.is_upcoming', true);
+
+        $this->assertSame(30, $event->fresh()->capacity);
+    }
+
     public function test_non_manager_cannot_create_upcoming_event(): void
     {
         $leader = Profile::factory()->community()->create();

--- a/tests/Feature/Api/V1/EventPhotoTest.php
+++ b/tests/Feature/Api/V1/EventPhotoTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Event;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class EventPhotoTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['filesystems.uploads_disk' => 'public']);
+        Storage::fake('public');
+    }
+
+    private function image(): UploadedFile
+    {
+        return UploadedFile::fake()->image('photo.jpg', 600, 400);
+    }
+
+    public function test_creator_can_add_photos_to_an_event(): void
+    {
+        $owner = Profile::factory()->community()->create();
+        $event = Event::factory()->create(['profile_id' => $owner->id]);
+
+        $this->actingAs($owner)
+            ->postJson("/api/v1/events/{$event->id}/photos", ['photos' => [$this->image(), $this->image()]])
+            ->assertStatus(201)
+            ->assertJsonCount(2, 'data.photos');
+
+        $this->assertSame(2, $event->photos()->count());
+    }
+
+    public function test_photo_cap_of_five_is_enforced_across_requests(): void
+    {
+        $owner = Profile::factory()->community()->create();
+        $event = Event::factory()->create(['profile_id' => $owner->id]);
+
+        $this->actingAs($owner)->postJson("/api/v1/events/{$event->id}/photos", [
+            'photos' => [$this->image(), $this->image(), $this->image()],
+        ])->assertStatus(201)->assertJsonCount(3, 'data.photos');
+
+        // 3 existing + 3 more = 6 > 5 → rejected.
+        $this->actingAs($owner)->postJson("/api/v1/events/{$event->id}/photos", [
+            'photos' => [$this->image(), $this->image(), $this->image()],
+        ])->assertStatus(422)->assertJsonPath('error', 'photo_limit_reached');
+
+        $this->assertSame(3, $event->photos()->count());
+    }
+
+    public function test_creator_can_delete_a_photo(): void
+    {
+        $owner = Profile::factory()->community()->create();
+        $event = Event::factory()->create(['profile_id' => $owner->id]);
+
+        $photoId = $this->actingAs($owner)
+            ->postJson("/api/v1/events/{$event->id}/photos", ['photos' => [$this->image()]])
+            ->json('data.photos.0.id');
+
+        $this->actingAs($owner)
+            ->deleteJson("/api/v1/events/{$event->id}/photos/{$photoId}")
+            ->assertStatus(200);
+
+        $this->assertDatabaseMissing('event_photos', ['id' => $photoId]);
+    }
+
+    public function test_cannot_delete_a_photo_from_another_event(): void
+    {
+        $owner = Profile::factory()->community()->create();
+        $eventA = Event::factory()->create(['profile_id' => $owner->id]);
+        $eventB = Event::factory()->create(['profile_id' => $owner->id]);
+
+        $photoId = $this->actingAs($owner)
+            ->postJson("/api/v1/events/{$eventA->id}/photos", ['photos' => [$this->image()]])
+            ->json('data.photos.0.id');
+
+        $this->actingAs($owner)
+            ->deleteJson("/api/v1/events/{$eventB->id}/photos/{$photoId}")
+            ->assertStatus(404);
+    }
+
+    public function test_non_manager_cannot_add_photos(): void
+    {
+        $owner = Profile::factory()->community()->create();
+        $event = Event::factory()->create(['profile_id' => $owner->id]);
+        $outsider = Profile::factory()->community()->create();
+
+        $this->actingAs($outsider)
+            ->postJson("/api/v1/events/{$event->id}/photos", ['photos' => [$this->image()]])
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/NotificationPreferenceControllerTest.php
+++ b/tests/Feature/Api/V1/NotificationPreferenceControllerTest.php
@@ -255,4 +255,24 @@ class NotificationPreferenceControllerTest extends TestCase
             ->assertJsonPath('data.email_notifications', false)
             ->assertJsonMissing(['data.unknown_field']);
     }
+
+    public function test_message_notifications_defaults_on_and_can_be_toggled(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+        BusinessSubscription::factory()->create(['profile_id' => $profile->id]);
+
+        // Auto-created defaults: message_notifications ON.
+        $this->actingAs($profile)->getJson('/api/v1/me/notification-preferences')
+            ->assertStatus(200)
+            ->assertJsonPath('data.message_notifications', true);
+
+        // Opt out → persisted and returned.
+        $this->actingAs($profile)->putJson('/api/v1/me/notification-preferences', [
+            'message_notifications' => false,
+        ])->assertStatus(200)->assertJsonPath('data.message_notifications', false);
+
+        $this->actingAs($profile)->getJson('/api/v1/me/notification-preferences')
+            ->assertJsonPath('data.message_notifications', false);
+    }
 }


### PR DESCRIPTION
Backend half of NF-16 (`docs/tickets/2026-06-05-backend-event-photos-and-message-pref.md`). App half is being built in parallel.

## What's in
- **`POST /events/{event}/photos`** (multipart, creator or community owner/can_manage) — adds photos to an existing event, **total cap 5** → `422 chat... photo_limit_reached`. Reuses `FileUploadService` + `EventPhoto`. Returns `EventResource`.
- **`DELETE /events/{event}/photos/{photo}`** — same auth; foreign photo → 404; deletes file + row.
- **`message_notifications` wired into the prefs API** — added to `UpdateNotificationPreferencesRequest` (rules + `getPreferencesData`), `NotificationPreferenceResource`, and `getOrCreateNotificationPreferences` defaults (so a freshly-created row reports it ON). The fan-out shipped the column; this exposes it so the app's Messages toggle can read/write.

## Tests
`EventPhotoTest` (5: add, cap, delete, foreign 404, non-manager 403) + a prefs toggle test. **854 total green, 0 regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)