### PR TITLE
ci: GitHub Actions test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, dom, fileinfo, bcmath, intl, gd, curl, zip, pdo, pdo_sqlite, sqlite3
+          coverage: none
+          tools: composer:v2
+
+      - name: Prepare .env
+        env:
+          ENV_TESTING: ${{ secrets.ENV_TESTING }}
+        run: |
+          if [ -n "$ENV_TESTING" ]; then
+            printf '%s' "$ENV_TESTING" > .env
+          else
+            echo "::warning::secret ENV_TESTING not set — falling back to .env.example"
+            cp .env.example .env
+          fi
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ runner.os }}-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php8.4-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Ensure application key
+        run: |
+          if ! grep -q '^APP_KEY=.\+' .env; then
+            php artisan key:generate --force
+          fi
+
+      - name: Run tests
+        run: php artisan test
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ runner.os }}-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php8.4-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Check code style (Pint)
+        run: vendor/bin/pint --test


### PR DESCRIPTION
## Summary
Adds the CI workflow (`tests` + `lint`) that runs the full suite on every PR to master. Bootstrap PR so the workflow lands on the default branch (a `pull_request` workflow only triggers once it exists on master).

## Linked tracking item
N/A — CI bootstrap.

## Type of change
- [x] 🔧 Chore / tooling

## Changes
- `.github/workflows/ci.yml` — `tests` job (`php artisan test`, PHP 8.4, sqlite :memory:) + `lint` job (`vendor/bin/pint --test`); reads `.env` from secret `ENV_TESTING`, falls back to `.env.example`.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A

## Testing
- [x] Workflow validated; first run executes on this PR once on master.

## Docs & rules updated
- [x] No docs impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)