### PR TITLE
fix: resolve Apple IAP private key inline to stop Sentry file-missing warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,9 @@ APPLE_CLIENT_ID=com.kolabing.kolabingApp
 APPLE_BUNDLE_ID=com.kolabing.kolabingApp
 APPLE_ISSUER_ID=
 APPLE_KEY_ID=
+# Provide the .p8 key EITHER inline (preferred for containers — survives rebuilds)
+# or as a readable file path. APPLE_PRIVATE_KEY takes precedence when set.
+APPLE_PRIVATE_KEY=
 APPLE_PRIVATE_KEY_PATH=
 APPLE_IAP_ENVIRONMENT=production
 APPLE_IAP_MONTHLY_PRODUCT_ID=com.kolabing.kolabingApp.subscription.monthly

--- a/app/Services/AppleIAPService.php
+++ b/app/Services/AppleIAPService.php
@@ -281,12 +281,7 @@ class AppleIAPService
 
     private function generateApiToken(): string
     {
-        $privateKeyPath = config('services.apple.private_key_path');
-        $privateKey = file_get_contents($privateKeyPath);
-
-        if ($privateKey === false) {
-            throw new \RuntimeException("Apple private key not found at: {$privateKeyPath}");
-        }
+        $privateKey = $this->resolvePrivateKey();
 
         $payload = [
             'iss' => config('services.apple.issuer_id'),
@@ -297,6 +292,40 @@ class AppleIAPService
         ];
 
         return JWT::encode($payload, $privateKey, 'ES256', config('services.apple.key_id'));
+    }
+
+    /**
+     * Resolve the Apple App Store private key (.p8) contents.
+     *
+     * Prefers the inline APPLE_PRIVATE_KEY value so containerised deploys do not
+     * depend on a file that may be absent after a rebuild. Falls back to the
+     * configured file path, guarding the read so a missing file raises a clear
+     * exception instead of a raw file_get_contents() PHP warning.
+     */
+    private function resolvePrivateKey(): string
+    {
+        $inlineKey = config('services.apple.private_key');
+
+        if (is_string($inlineKey) && trim($inlineKey) !== '') {
+            return $inlineKey;
+        }
+
+        $privateKeyPath = config('services.apple.private_key_path');
+
+        if (! is_string($privateKeyPath) || ! is_readable($privateKeyPath)) {
+            throw new \RuntimeException(
+                'Apple private key not configured: set APPLE_PRIVATE_KEY or provide a readable '
+                ."file at APPLE_PRIVATE_KEY_PATH (resolved: {$privateKeyPath})."
+            );
+        }
+
+        $privateKey = file_get_contents($privateKeyPath);
+
+        if ($privateKey === false) {
+            throw new \RuntimeException("Apple private key could not be read at: {$privateKeyPath}");
+        }
+
+        return $privateKey;
     }
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -73,6 +73,7 @@ return [
         'bundle_id' => env('APPLE_BUNDLE_ID', 'com.kolabing.kolabingApp'),
         'issuer_id' => env('APPLE_ISSUER_ID'),
         'key_id' => env('APPLE_KEY_ID'),
+        'private_key' => env('APPLE_PRIVATE_KEY'),
         'private_key_path' => env('APPLE_PRIVATE_KEY_PATH', storage_path('app/apple/AuthKey.p8')),
         'iap_environment' => env('APPLE_IAP_ENVIRONMENT', 'sandbox'),
     ],

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-21
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -79,6 +79,9 @@ Each item lists what exists now, what's missing, and any open decisions. See ref
 - `app/Http/Controllers/Api/V1/AppleIAPController.php` — `POST /me/subscription/apple-verify` + `apple-restore`.
 - `app/Http/Controllers/Api/V1/AppleWebhookController.php` — `POST /webhooks/apple`.
 - Status transitions for `SUBSCRIBED`, `DID_RENEW`, `DID_FAIL_TO_RENEW`, `EXPIRED`, `REVOKE` correctly mapped.
+
+**Fixes:**
+- ~~Sentry `file_get_contents(.../storage/app/apple/AuthKey.p8): Failed to open stream` — `AppleIAPService` read the `.p8` key with a raw `file_get_contents`, emitting a PHP warning when the on-disk key was absent on the container. Now resolves the key inline via `APPLE_PRIVATE_KEY` (preferred) with a guarded file fallback; no warning leaks to Sentry. (2026-06-21, tested)~~
 
 **P2 follow-ups:**
 - [ ] Fire push + email on subscription state changes (renewal, failure, refund) from `AppleIAPService::handleNotification()`. Owner: **backend**.

--- a/tests/Unit/Services/AppleIAPServiceTest.php
+++ b/tests/Unit/Services/AppleIAPServiceTest.php
@@ -51,6 +51,82 @@ class AppleIAPServiceTest extends TestCase
     }
 
     /**
+     * Regression for the Sentry warning
+     * "file_get_contents(.../storage/app/apple/AuthKey.p8): Failed to open stream":
+     * the key may be supplied inline via APPLE_PRIVATE_KEY (config services.apple.private_key)
+     * so containerised deploys do not depend on an on-disk file.
+     */
+    public function test_resolve_private_key_prefers_inline_key_contents(): void
+    {
+        config([
+            'services.apple.private_key' => "-----BEGIN PRIVATE KEY-----\ninline\n-----END PRIVATE KEY-----",
+            'services.apple.private_key_path' => '/nonexistent/AuthKey.p8',
+        ]);
+
+        $key = $this->invokeResolvePrivateKey();
+
+        $this->assertStringContainsString('inline', $key);
+    }
+
+    public function test_resolve_private_key_reads_from_path_when_no_inline_key(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'p8');
+        file_put_contents($path, "-----BEGIN PRIVATE KEY-----\nfromfile\n-----END PRIVATE KEY-----");
+
+        config([
+            'services.apple.private_key' => null,
+            'services.apple.private_key_path' => $path,
+        ]);
+
+        try {
+            $key = $this->invokeResolvePrivateKey();
+        } finally {
+            @unlink($path);
+        }
+
+        $this->assertStringContainsString('fromfile', $key);
+    }
+
+    /**
+     * The crux of the Sentry fix: a missing key file must NOT trigger a raw
+     * file_get_contents() E_WARNING — it must fail with a clear RuntimeException
+     * and produce no PHP warning for Sentry to capture.
+     */
+    public function test_resolve_private_key_throws_clean_exception_without_php_warning_when_file_missing(): void
+    {
+        config([
+            'services.apple.private_key' => null,
+            'services.apple.private_key_path' => '/nonexistent/path/AuthKey.p8',
+        ]);
+
+        $warnings = [];
+        set_error_handler(function (int $errno, string $message) use (&$warnings): bool {
+            $warnings[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->invokeResolvePrivateKey();
+            $this->fail('Expected RuntimeException for missing key file.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Apple private key', $e->getMessage());
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings, 'Missing key file must not emit a PHP warning.');
+    }
+
+    private function invokeResolvePrivateKey(): string
+    {
+        $service = app(AppleIAPService::class);
+        $method = new \ReflectionMethod($service, 'resolvePrivateKey');
+
+        return $method->invoke($service);
+    }
+
+    /**
      * Generate an EC P-256 key pair and a matching self-signed X.509 leaf cert,
      * returning [private key PEM, base64 DER cert for the JWS x5c header].
      *


### PR DESCRIPTION
## Summary
Fixes the recurring Sentry warning `file_get_contents(/var/www/html/storage/app/apple/AuthKey.p8): Failed to open stream: No such file or directory`.

`AppleIAPService::generateApiToken()` read the Apple App Store `.p8` private key with a raw `file_get_contents($path)`. When the on-disk key is absent on the production container (`/var/www/html` is an ephemeral filesystem and the gitignored key never reaches it), PHP raises an `E_WARNING` **before** the existing `=== false` guard throws — and Sentry captures that warning independently.

The new `resolvePrivateKey()`:
- Prefers an inline key via the new `APPLE_PRIVATE_KEY` env var (survives container rebuilds — the recommended way to inject `.p8` in containerized deploys).
- Falls back to the file path, guarded with `is_readable()`, throwing a clear `RuntimeException` instead of leaking a PHP warning.

## Changes
- `app/Services/AppleIAPService.php` — new `resolvePrivateKey()`; `generateApiToken()` uses it.
- `config/services.php` — added `'private_key' => env('APPLE_PRIVATE_KEY')`.
- `.env.example` — documented `APPLE_PRIVATE_KEY` (inline, preferred) alongside `APPLE_PRIVATE_KEY_PATH`.
- `tests/Unit/Services/AppleIAPServiceTest.php` — 3 new tests (inline precedence, file fallback, missing-file emits no PHP warning).
- `docs/BACKLOG.md` — logged fix under §3.1, bumped date.

## Mobile impact (kolabing-app)
**No mobile changes required.** Internal key-loading change only — no API payload, endpoint, enum, auth, or error-code change. The `POST /me/subscription/apple-verify` contract is unchanged.

## Testing
- New unit tests written test-first (watched fail → pass).
- `php artisan test --filter="Apple|Subscription"` → **57 passed (324 assertions)**.
- `vendor/bin/pint` → clean.

## Docs & rules updated
- `docs/BACKLOG.md` updated (Last updated 2026-06-21). Roles/schema docs N/A — no role, permission, or schema change.

## Deployment note
Set `APPLE_PRIVATE_KEY` (full `.p8` contents) in the production environment, then `php artisan config:clear`. `APPLE_PRIVATE_KEY_PATH` still works as a fallback for persistent mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
