### PR TITLE
fix: trust Apple's verified originalTransactionId instead of client value

### DIFF
--- a/app/Http/Controllers/Api/V1/AppleIAPController.php
+++ b/app/Http/Controllers/Api/V1/AppleIAPController.php
@@ -57,7 +57,6 @@ class AppleIAPController extends Controller
             $transactionData = $this->appleIAPService->verifyTransaction($transactionId);
             $this->appleIAPService->assertTransactionMatchesRequest(
                 $transactionData,
-                $originalTransactionId,
                 $productId,
             );
         } catch (\RuntimeException $e) {
@@ -138,7 +137,6 @@ class AppleIAPController extends Controller
                 $transactionData = $this->appleIAPService->verifyTransaction($transaction['transaction_id']);
                 $this->appleIAPService->assertTransactionMatchesRequest(
                     $transactionData,
-                    $transaction['original_transaction_id'],
                     $transaction['product_id'],
                 );
 

--- a/app/Services/AppleIAPService.php
+++ b/app/Services/AppleIAPService.php
@@ -120,13 +120,8 @@ class AppleIAPService
      */
     public function assertTransactionMatchesRequest(
         array $transactionData,
-        string $expectedOriginalTransactionId,
         string $expectedProductId,
     ): void {
-        if (($transactionData['originalTransactionId'] ?? null) !== $expectedOriginalTransactionId) {
-            throw new \RuntimeException('Apple original transaction ID mismatch');
-        }
-
         if (($transactionData['productId'] ?? null) !== $expectedProductId) {
             throw new \RuntimeException('Apple product ID mismatch');
         }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -81,6 +81,7 @@ Each item lists what exists now, what's missing, and any open decisions. See ref
 - Status transitions for `SUBSCRIBED`, `DID_RENEW`, `DID_FAIL_TO_RENEW`, `EXPIRED`, `REVOKE` correctly mapped.
 
 **Fixes:**
+- ~~"Invalid transaction / Could not verify with Apple" on real sandbox purchases — `assertTransactionMatchesRequest` rejected when the client's `original_transaction_id` differed from Apple's verified value. In StoreKit2 every renewal keeps the same `originalTransactionId` (sandbox renews monthly subs in minutes), so the client's value is unreliable. Now only the `productId` is asserted; Apple's authoritative `originalTransactionId` is stored, which also fixes the `DID_CHANGE_RENEWAL_STATUS` "subscription not found" webhook warning. (2026-06-21, tested)~~
 - ~~Sentry `file_get_contents(.../storage/app/apple/AuthKey.p8): Failed to open stream` — `AppleIAPService` read the `.p8` key with a raw `file_get_contents`, emitting a PHP warning when the on-disk key was absent on the container. Now resolves the key inline via `APPLE_PRIVATE_KEY` (preferred) with a guarded file fallback; no warning leaks to Sentry. (2026-06-21, tested)~~
 
 **P2 follow-ups:**

--- a/tests/Feature/Api/V1/AppleIAPControllerTest.php
+++ b/tests/Feature/Api/V1/AppleIAPControllerTest.php
@@ -318,7 +318,7 @@ class AppleIAPControllerTest extends TestCase
 
         $mock = $this->partialAppleIAPService();
         $mock->shouldReceive('verifyTransaction')->once()->andReturn($this->fakeTransactionData([
-            'originalTransactionId' => '2000000000009999',
+            'productId' => 'com.kolabing.kolabingApp.subscription.three_months',
         ]));
 
         $response = $this->actingAs($profile)->postJson('/api/v1/me/subscription/apple-verify', [
@@ -330,6 +330,38 @@ class AppleIAPControllerTest extends TestCase
         $response->assertStatus(400)
             ->assertJsonPath('success', false)
             ->assertJsonPath('error', 'apple_verification_failed');
+    }
+
+    /**
+     * Regression: in StoreKit2 every renewal has a new transactionId but the SAME
+     * originalTransactionId. In sandbox a monthly sub renews in minutes, so the
+     * client may send a stale/wrong original_transaction_id. Apple's verified
+     * response is authoritative — verification must succeed and the subscription
+     * must be stored under Apple's originalTransactionId so webhooks match.
+     */
+    public function test_verify_succeeds_when_client_original_transaction_id_differs_from_apple_renewal_chain(): void
+    {
+        $profile = $this->createBusinessProfile();
+
+        $mock = $this->partialAppleIAPService();
+        $mock->shouldReceive('verifyTransaction')->once()->andReturn($this->fakeTransactionData([
+            'transactionId' => '2000001191883535',
+            'originalTransactionId' => '2000001189129494',
+        ]));
+
+        $response = $this->actingAs($profile)->postJson('/api/v1/me/subscription/apple-verify', [
+            'transaction_id' => '2000001191883535',
+            'original_transaction_id' => '2000001191883535',
+            'product_id' => $this->monthlyAppleProductId(),
+        ]);
+
+        $response->assertOk()->assertJsonPath('success', true);
+
+        $this->assertDatabaseHas('business_subscriptions', [
+            'profile_id' => $profile->id,
+            'apple_original_transaction_id' => '2000001189129494',
+            'apple_transaction_id' => '2000001191883535',
+        ]);
     }
 
     public function test_restore_returns_subscription_when_found(): void


### PR DESCRIPTION
## Summary
Real sandbox purchases failed with **"Invalid transaction. Could not verify with Apple"**. Logs (added in #42) pinpointed it: `error: Apple original transaction ID mismatch`.

`assertTransactionMatchesRequest()` required the client-supplied `original_transaction_id` to equal Apple's verified value. But in StoreKit2 **every renewal keeps the same `originalTransactionId` while getting a new `transactionId`** — and sandbox renews a monthly sub every few minutes — so the client's value is unreliable. Apple's verified response is the source of truth.

The check is now limited to `productId` (a meaningful integrity check). The subscription is stored under **Apple's** `originalTransactionId`, which also fixes the `DID_CHANGE_RENEWAL_STATUS` → "subscription not found" webhook lookup (webhooks key on the true original `2000001189129494`).

## Changes
- `AppleIAPService::assertTransactionMatchesRequest()` — drop the `originalTransactionId` equality check + param; keep `productId`.
- `AppleIAPController` — update verify + restore call sites.
- Tests — repurpose the payload-mismatch test to assert on `productId`; add a renewal-chain regression test (client original ≠ Apple original → 200, stored under Apple's value).
- `docs/BACKLOG.md` — logged under §3.1.

## Mobile impact (kolabing-app)
**Contract relaxed, not broken.** `original_transaction_id` is still accepted in the request (no breaking change) but is no longer required to match Apple's value. **Recommended mobile follow-up:** send StoreKit2 `Transaction.originalID` for `original_transaction_id` rather than the current transaction id, for cleaner data — but verification no longer depends on it.

## Testing
- TDD: renewal-chain test written → watched fail (400) → pass (200).
- `php artisan test --filter='Apple|Subscription'` → **58 passed (328 assertions)**.
- `vendor/bin/pint` → clean.

## Docs & rules updated
`docs/BACKLOG.md` updated (Last updated 2026-06-21). No role/permission/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)