### PR TITLE
feat: add /reset-password landing page for password reset links

### DIFF
--- a/app/Http/Controllers/PasswordResetPageController.php
+++ b/app/Http/Controllers/PasswordResetPageController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Services\AuthService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use InvalidArgumentException;
+
+class PasswordResetPageController extends Controller
+{
+    public function __construct(private readonly AuthService $authService) {}
+
+    /**
+     * Render the password reset form. The token and email arrive as query
+     * parameters from the reset link emailed to the user.
+     */
+    public function show(Request $request): View
+    {
+        return view('auth.reset-password', [
+            'token' => (string) $request->query('token', ''),
+            'email' => (string) $request->query('email', ''),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'token' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ], [
+            'password.min' => __('The password must be at least 8 characters'),
+            'password.confirmed' => __('The password confirmation does not match'),
+        ]);
+
+        try {
+            $this->authService->resetPassword([
+                'token' => $validated['token'],
+                'email' => $validated['email'],
+                'password' => $validated['password'],
+                'password_confirmation' => (string) $request->input('password_confirmation'),
+            ]);
+        } catch (InvalidArgumentException $e) {
+            return back()
+                ->withErrors(['email' => $e->getMessage()])
+                ->withInput($request->only('email', 'token'));
+        }
+
+        return redirect()
+            ->route('password.reset')
+            ->with('status', __('Password has been reset successfully.'));
+    }
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -120,10 +120,13 @@ Builds on §3.2. Add a public-facing flow:
 **Status:** Polished MVP design quality. Critical conversion infrastructure missing.
 
 **What exists:**
-- `routes/web.php`: `/`, `/for-businesses`, `/for-communities`, `/support`, `/careers`, `/privacy`, `/terms`, plus the `/sitemap.xml` + `/llms.txt` + `/.well-known/security.txt` helpers.
+- `routes/web.php`: `/`, `/for-businesses`, `/for-communities`, `/support`, `/careers`, `/privacy`, `/terms`, `/reset-password` (password reset form + handler), plus the `/sitemap.xml` + `/llms.txt` + `/.well-known/security.txt` helpers.
 - `welcome.blade.php` — 1582-line custom-CSS hero (separate from the Tailwind-CDN layout used by other pages). 7 sections: hero, manifesto, reveal, how-it-works, examples, FAQ, final CTA, footer. Real case-study imagery. Mobile responsive at 900 / 540 breakpoints.
 - `for-businesses` / `for-communities` use the Tailwind-CDN `marketing-page` layout.
 - Legal pages exist with proper copy.
+
+**Fixes:**
+- ~~`/reset-password` 404'd — the password-reset email links to `{APP_URL}/reset-password?token=&email=` (`AppServiceProvider`) but no web route/page existed. Added GET form + POST handler (`PasswordResetPageController`) on the marketing layout, posting through `AuthService::resetPassword`. (2026-06-21, tested)~~
 
 **P0 — landing-page must-fixes before any traffic push:**
 - [ ] **All primary CTAs are broken** (`href="#"`):

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,0 +1,61 @@
+@php
+    $title = 'Reset password';
+    $description = 'Set a new password for your Kolabing account.';
+    $canonical = route('password.reset');
+@endphp
+
+<x-layouts.marketing-page :title="$title" :description="$description" :canonical="$canonical">
+    <section class="mx-auto flex max-w-md flex-col px-6 py-20">
+        <h1 class="font-montserrat text-3xl font-black uppercase md:text-4xl">Reset password</h1>
+
+        @if (session('status'))
+            <div class="mt-8 rounded-3xl border border-off-black/10 bg-primary/20 p-8 shadow-sm">
+                <h2 class="text-xl font-bold">All set</h2>
+                <p class="mt-3 text-off-black/70">{{ session('status') }}</p>
+                <p class="mt-3 text-off-black/70">You can now open the Kolabing app and sign in with your new password.</p>
+            </div>
+        @else
+            <p class="mt-4 text-off-black/70">Choose a new password for
+                <span class="font-semibold text-off-black">{{ $email }}</span>.
+            </p>
+
+            @if ($errors->any())
+                <div class="mt-6 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                    <ul class="list-disc space-y-1 pl-5">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+
+            <form method="POST" action="{{ route('password.reset.update') }}" class="mt-8 space-y-5">
+                @csrf
+                <input type="hidden" name="token" value="{{ $token }}">
+                <input type="hidden" name="email" value="{{ $email }}">
+
+                <div>
+                    <label for="password" class="block text-sm font-bold text-off-black">New password</label>
+                    <input id="password" type="password" name="password" required autocomplete="new-password"
+                        minlength="8" autofocus
+                        class="mt-2 w-full rounded-2xl border-off-black/15 bg-white px-4 py-3 text-off-black shadow-sm focus:border-off-black focus:ring-off-black">
+                    <p class="mt-2 text-xs text-off-black/50">At least 8 characters.</p>
+                </div>
+
+                <div>
+                    <label for="password_confirmation" class="block text-sm font-bold text-off-black">Confirm new password</label>
+                    <input id="password_confirmation" type="password" name="password_confirmation" required
+                        autocomplete="new-password" minlength="8"
+                        class="mt-2 w-full rounded-2xl border-off-black/15 bg-white px-4 py-3 text-off-black shadow-sm focus:border-off-black focus:ring-off-black">
+                </div>
+
+                <button type="submit"
+                    class="inline-flex w-full justify-center rounded-full bg-off-black px-5 py-3 font-bold text-white transition hover:bg-off-black/90">
+                    Reset password
+                </button>
+            </form>
+        @endif
+
+        <a href="{{ route('support') }}" class="mt-8 text-sm font-medium text-off-black/60 hover:text-off-black">Need help? Contact support</a>
+    </section>
+</x-layouts.marketing-page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Admin\TaskController as AdminTaskController;
 use App\Http\Controllers\Admin\TypeController as AdminTypeController;
 use App\Http\Controllers\Admin\XpEarnRuleController as AdminXpEarnRuleController;
 use App\Http\Controllers\Admin\XpLevelController as AdminXpLevelController;
+use App\Http\Controllers\PasswordResetPageController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -147,6 +148,9 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
         Route::put('/economics', [AdminRewardEconomicsController::class, 'update'])->name('economics.update');
     });
 });
+
+Route::get('/reset-password', [PasswordResetPageController::class, 'show'])->name('password.reset');
+Route::post('/reset-password', [PasswordResetPageController::class, 'update'])->name('password.reset.update');
 
 Route::view('/for-businesses', 'pages.for-businesses')->name('for-businesses');
 Route::view('/for-communities', 'pages.for-communities')->name('for-communities');

--- a/tests/Feature/Web/ResetPasswordPageTest.php
+++ b/tests/Feature/Web/ResetPasswordPageTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Web;
+
+use App\Models\BusinessProfile;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Tests\TestCase;
+
+class ResetPasswordPageTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_reset_password_page_renders_with_token_and_email(): void
+    {
+        $response = $this->get('/reset-password?token=abc123&email='.urlencode('user@example.com'));
+
+        $response->assertOk()
+            ->assertViewIs('auth.reset-password')
+            ->assertSee('user@example.com')
+            ->assertSee('abc123');
+    }
+
+    public function test_reset_password_updates_password_with_valid_token(): void
+    {
+        $profile = Profile::factory()->business()->create([
+            'email' => 'reset-web@example.com',
+            'password' => 'old-password-123',
+        ]);
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+
+        $token = Password::broker()->createToken($profile);
+        $url = '/reset-password?token='.$token.'&email='.urlencode($profile->email);
+
+        $response = $this->from($url)->post('/reset-password', [
+            'token' => $token,
+            'email' => $profile->email,
+            'password' => 'new-password-456',
+            'password_confirmation' => 'new-password-456',
+        ]);
+
+        $response->assertRedirect(route('password.reset'));
+        $response->assertSessionHas('status');
+
+        $this->assertTrue(Hash::check('new-password-456', $profile->fresh()->password));
+    }
+
+    public function test_reset_password_fails_with_invalid_token(): void
+    {
+        $profile = Profile::factory()->business()->create([
+            'email' => 'reset-web2@example.com',
+            'password' => 'old-password-123',
+        ]);
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+
+        $url = '/reset-password?token=invalid-token&email='.urlencode($profile->email);
+
+        $response = $this->from($url)->post('/reset-password', [
+            'token' => 'invalid-token',
+            'email' => $profile->email,
+            'password' => 'new-password-456',
+            'password_confirmation' => 'new-password-456',
+        ]);
+
+        $response->assertRedirect($url);
+        $response->assertSessionHasErrors('email');
+
+        $this->assertTrue(Hash::check('old-password-123', $profile->fresh()->password));
+    }
+
+    public function test_reset_password_validates_password_confirmation(): void
+    {
+        $url = '/reset-password?token=abc&email='.urlencode('user@example.com');
+
+        $response = $this->from($url)->post('/reset-password', [
+            'token' => 'abc',
+            'email' => 'user@example.com',
+            'password' => 'new-password-456',
+            'password_confirmation' => 'different-456',
+        ]);
+
+        $response->assertRedirect($url);
+        $response->assertSessionHasErrors('password');
+    }
+}


### PR DESCRIPTION
## Summary
The password-reset email links to `{APP_URL}/reset-password?token=&email=` (built in `AppServiceProvider::boot`), but there was **no web route** for `/reset-password` — so clicking the link 404'd.

Adds the missing page on the marketing layout:
- `GET /reset-password` → styled form, token + email prefilled from the query string (hidden inputs).
- `POST /reset-password` → resets via `AuthService::resetPassword()` (same path the API uses), then shows a success state ("open the app and sign in") or inline errors for invalid/expired tokens and password validation.

## Changes
- `app/Http/Controllers/PasswordResetPageController.php` — `show` + `update`.
- `routes/web.php` — `password.reset` (GET) + `password.reset.update` (POST).
- `resources/views/auth/reset-password.blade.php` — form using the `marketing-page` layout.
- `tests/Feature/Web/ResetPasswordPageTest.php` — 4 tests.
- `docs/BACKLOG.md` — §4 updated.

## Mobile impact (kolabing-app)
**No mobile changes required.** This is the web target of the existing reset email; the API endpoints (`/api/v1/auth/forgot-password`, `/reset-password`) are unchanged. The app already triggers the email.

## Testing
- TDD: 4 tests written → watched fail (404) → pass.
- `php artisan test tests/Feature/Web tests/Feature/MarketingSeoTest.php tests/Feature/Api/V1/PasswordResetTest.php` → **23 passed (135 assertions)**.
- `vendor/bin/pint` → clean.

## Docs & rules updated
`docs/BACKLOG.md` updated (Last updated 2026-06-21). No role/permission/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)