### PR TITLE
fix: surface joined-community events in event discover for members

### DIFF
--- a/app/Http/Controllers/Api/V1/EventDiscoveryController.php
+++ b/app/Http/Controllers/Api/V1/EventDiscoveryController.php
@@ -34,7 +34,7 @@ class EventDiscoveryController extends Controller
             'type' => $request->validated('type'),
         ];
 
-        $paginator = $this->discoveryService->discover($lat, $lng, $radius, $perPage, $filters);
+        $paginator = $this->discoveryService->discover($lat, $lng, $radius, $perPage, $filters, $request->user());
         $this->eventSignupService->hydrateSummaries($paginator->items(), $request->user());
 
         return response()->json([

--- a/app/Services/EventDiscoveryService.php
+++ b/app/Services/EventDiscoveryService.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\CommunityMemberStatus;
 use App\Enums\EventVisibility;
+use App\Models\CommunityMember;
 use App\Models\Event;
+use App\Models\Profile;
 use App\Support\CommunityTypeVocabulary;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -20,6 +23,10 @@ class EventDiscoveryService
      * Geo filtering is applied only when both $lat and $lng are provided; a
      * city_id alone (no coordinates) drives a non-geo, city-scoped query.
      *
+     * The optional $viewer makes the surface viewer-aware: a member additionally
+     * sees the (members/tier) events of the communities they ACTIVELY belong to.
+     * Non-members (and anonymous callers) still see only public events.
+     *
      * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
      * @return LengthAwarePaginator<Event>
      */
@@ -28,15 +35,16 @@ class EventDiscoveryService
         ?float $lng,
         float $radiusKm = 50.0,
         int $perPage = 10,
-        array $filters = []
+        array $filters = [],
+        ?Profile $viewer = null
     ): LengthAwarePaginator {
         $hasGeo = $lat !== null && $lng !== null;
 
         if ($hasGeo) {
-            return $this->discoverNearby($lat, $lng, $radiusKm, $perPage, $filters);
+            return $this->discoverNearby($lat, $lng, $radiusKm, $perPage, $filters, $viewer);
         }
 
-        return $this->discoverFiltered($perPage, $filters);
+        return $this->discoverFiltered($perPage, $filters, $viewer);
     }
 
     /**
@@ -53,15 +61,16 @@ class EventDiscoveryService
         float $lng,
         float $radiusKm = 50.0,
         int $perPage = 10,
-        array $filters = []
+        array $filters = [],
+        ?Profile $viewer = null
     ): LengthAwarePaginator {
         $driver = DB::getDriverName();
 
         if ($driver === 'sqlite') {
-            return $this->discoverNearbySqlite($lat, $lng, $radiusKm, $perPage, $filters);
+            return $this->discoverNearbySqlite($lat, $lng, $radiusKm, $perPage, $filters, $viewer);
         }
 
-        return $this->discoverNearbyPostgres($lat, $lng, $radiusKm, $perPage, $filters);
+        return $this->discoverNearbyPostgres($lat, $lng, $radiusKm, $perPage, $filters, $viewer);
     }
 
     /**
@@ -70,9 +79,9 @@ class EventDiscoveryService
      * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
      * @return LengthAwarePaginator<Event>
      */
-    private function discoverFiltered(int $perPage, array $filters): LengthAwarePaginator
+    private function discoverFiltered(int $perPage, array $filters, ?Profile $viewer = null): LengthAwarePaginator
     {
-        $query = $this->baseQuery($filters);
+        $query = $this->baseQuery($filters, $viewer);
 
         return $query
             ->orderByRaw('COALESCE(starts_at, event_date) ASC')
@@ -92,20 +101,57 @@ class EventDiscoveryService
      * artefact of the old geo "active now" path; the public/city upcoming surface
      * is governed entirely by visibility + date, so dropping it here is safe.
      *
+     * Viewer-aware visibility (§8.6): the surface stays PUBLIC for non-members —
+     * members/tier events never leak to a non-member or anonymous caller. But the
+     * authenticated $viewer ALSO sees events of the communities they ACTIVELY
+     * belong to, regardless of those events' visibility (a member is entitled to
+     * their own community's events). The city / date / type filters still apply.
+     *
      * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
      * @return Builder<Event>
      */
-    private function baseQuery(array $filters): Builder
+    private function baseQuery(array $filters, ?Profile $viewer = null): Builder
     {
+        $memberCommunityIds = $this->memberCommunityIds($viewer);
+
         $query = Event::query()
-            // Discover is a PUBLIC surface: only events explicitly marked public are
-            // visible to non-members. members/tier events never leak here.
-            ->where('visibility', EventVisibility::Public->value)
+            ->where(function (Builder $visible) use ($memberCommunityIds): void {
+                // Public events are visible to everyone.
+                $visible->where('visibility', EventVisibility::Public->value);
+
+                // The viewer's joined communities also surface their member/tier
+                // events — to this viewer only.
+                if ($memberCommunityIds !== []) {
+                    $visible->orWhereIn('community_id', $memberCommunityIds);
+                }
+            })
             ->with(['photos', 'profile', 'city', 'community.communityProfile.city']);
 
         $this->applyFilters($query, $filters);
 
         return $query;
+    }
+
+    /**
+     * The community ids the $viewer is an ACTIVE member of (empty for anonymous
+     * callers). Drives the viewer-aware branch of the visibility gate.
+     *
+     * @return list<string>
+     */
+    private function memberCommunityIds(?Profile $viewer): array
+    {
+        if ($viewer === null) {
+            return [];
+        }
+
+        /** @var list<string> $ids */
+        $ids = CommunityMember::query()
+            ->where('profile_id', $viewer->id)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->pluck('community_id')
+            ->all();
+
+        return $ids;
     }
 
     /**
@@ -220,7 +266,8 @@ class EventDiscoveryService
         float $lng,
         float $radiusKm,
         int $perPage,
-        array $filters = []
+        array $filters = [],
+        ?Profile $viewer = null
     ): LengthAwarePaginator {
         $haversine = '(
             6371 * acos(
@@ -230,7 +277,7 @@ class EventDiscoveryService
             )
         )';
 
-        $query = $this->baseQuery($filters)
+        $query = $this->baseQuery($filters, $viewer)
             ->whereNotNull('location_lat')
             ->whereNotNull('location_lng')
             ->select('events.*')
@@ -255,7 +302,8 @@ class EventDiscoveryService
         float $lng,
         float $radiusKm,
         int $perPage,
-        array $filters = []
+        array $filters = [],
+        ?Profile $viewer = null
     ): LengthAwarePaginator {
         $latDelta = $radiusKm / 111.0;
         $lngDelta = $radiusKm / (111.0 * cos(deg2rad($lat)));
@@ -265,7 +313,7 @@ class EventDiscoveryService
         $minLng = $lng - $lngDelta;
         $maxLng = $lng + $lngDelta;
 
-        $paginator = $this->baseQuery($filters)
+        $paginator = $this->baseQuery($filters, $viewer)
             ->whereNotNull('location_lat')
             ->whereNotNull('location_lng')
             ->whereBetween('location_lat', [$minLat, $maxLat])

--- a/docs/ROLES-AND-PERMISSIONS.md
+++ b/docs/ROLES-AND-PERMISSIONS.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles, Permissions & Features (Canonical Reference)
 
-**Last updated:** 2026-06-19 (legacy `collab_opportunities` table-level code archived; canonical create/apply moved to `/kolabs/*` with new `/kolabs/{kolab}/applications` apply routes — #30)
+**Last updated:** 2026-06-23 (event discover is now viewer-aware: a Community Member also sees the member/tier events of communities they actively belong to — §7.1, §8.6 — non-members still see only public)
 **Status:** Authoritative. This document overrides assumptions.
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical. When role behaviour changes, update both **and bump the Last updated date** in both.
 
@@ -227,6 +227,7 @@ The attendee role's backend track has shipped and the canonical position that at
 - Earn points (`point_ledger` — append-only) and badges (`BadgeService` awards on milestones like `LoyalAttendee = total_events_attended >= N`).
 - See per-event and global leaderboards.
 - Hold a reward wallet and redeem rewards.
+- Discover events (`GET /api/v1/events/discover`). The surface is **viewer-aware**: public events for everyone, PLUS the member/tier events of the communities the attendee **actively belongs to** (`community_members.status = active`). The city / date / type filters still apply to all of them, so a joined community's event surfaces only when it matches the selected city/date. See §8.6 and the backend map's §12.6.
 
 ### 7.2 What an attendee CANNOT do (confirmed at the service layer)
 - Create or publish kolabs / opportunities — neither service path accepts an attendee creator.
@@ -270,6 +271,8 @@ Tiers can auto-assign by rule: `xp_threshold` (member XP from `point_ledger`), `
 
 ### 8.6 The community ↔ events linkage
 "This community's events" is defined by a new nullable `events.community_id` FK. The `events_attended` rule counts check-ins on events with that `community_id`. The chapter-scoped leaderboard (`GET /leaderboard/global?community_id=`) is scoped by **active membership** (the global leaderboard filtered to one community's members). Organiser's events are NOT silently assumed to be the community's events.
+
+**Member visibility on discover (2026-06-23).** Community events default to `visibility = members` (`EventService`), so they never appear on the public city discover surface. To let members find their own communities' events, `GET /api/v1/events/discover` is **viewer-aware**: it returns public events to everyone, and additionally the events whose `community_id` is one of the **active** memberships of the authenticated viewer (any visibility — a member is entitled to their community's events). This is NOT a leak: a non-member or anonymous caller still sees only `visibility = public`. The city / date / type / geo filters apply uniformly to public and member events alike. Per-community listing (`GET /events?community_id=`) is unchanged and already returns all of a community's events.
 
 Backend wiring (tables, endpoints, policy, command) is in `ROLES-BACKEND-DB-MAP.md §12`.
 

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles → Backend → Database Map (Ground-Truth)
 
-**Last updated:** 2026-06-19 (legacy `collab_opportunities` table-level code archived — model/bridge/command/factory/seeder deleted, dual-write removed; new `/kolabs/{kolab}/applications` apply routes; `/opportunities` shim retained pending mobile migration — #30)
+**Last updated:** 2026-06-23 (event discover made viewer-aware — `EventDiscoveryService` now surfaces a viewer's active-membership community events alongside public ones; see §12.6)
 **Status:** Authoritative companion to [`ROLES-AND-PERMISSIONS.md`](./ROLES-AND-PERMISSIONS.md). Read that first (the *what*), then this (the *where*).
 **Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical, and **bump the Last updated date in both** when role behaviour or backend wiring changes.
 
@@ -188,6 +188,7 @@ Fixed since the last revision:
 - [x] Collaboration cancellation now persists `cancellation_reason`, `cancelled_at`, and `cancelled_by_profile_id` (§10).
 - [x] **Feedback gate on `/complete` shipped** with admin force-complete, auto-timeout scheduler, and a `/review`→`/feedback` mirror for legacy clients (§3, §9, §10). XP moved from `/complete` to `/feedback` per Q7. PR #9, 2026-06-01.
 - [x] **NF-6 community members + tiers, Phase 1 shipped** (2026-06-03): `communities` / `community_tiers` / `community_members` tables, `events.community_id`, `CommunityPolicy`, the cap gate (NOT the paywall), the auto-assignment command + on-check-in hook, and the chapter-scoped leaderboard. See §12.
+- [x] **Members' joined-community events now surface in event discover** (2026-06-23): `EventDiscoveryService` is viewer-aware — public events for everyone PLUS the member/tier events of the viewer's active communities; non-members still see public only. Fixes attendees seeing "No events" despite having joined communities. See §12.6.
 
 Still open:
 
@@ -366,3 +367,28 @@ Resources (`app/Http/Resources/Api/V1`): `CommunityResource`, `CommunityTierReso
 - Never call `Profile::hasActiveSubscription()` or throw `SubscriptionRequiredException`. The cap is the only gate and it is config-driven.
 - Never add a `user_type` enum value for "community member" — the wire value stays `attendee` (D4).
 - Never couple `can_manage` to the top tier (D1).
+
+### 12.6 Viewer-aware event discover (2026-06-23)
+
+**Problem.** Community events are created `visibility = members` (`EventService::create()` / `buildUpcoming()`, `:119,:157`). `EventDiscoveryService::baseQuery()` hard-filtered `where('visibility', public)`, so a Community Member never saw their own communities' events in the city discover feed (`GET /api/v1/events/discover`). There was no membership-scoped event surface.
+
+**Fix.** `EventDiscoveryService` is now viewer-aware. `discover()` / `discoverNearby()` / both geo impls / `discoverFiltered()` thread an optional `?Profile $viewer` (passed from `EventDiscoveryController` as `$request->user()`) into `baseQuery()`. The visibility gate became:
+
+```php
+->where(function ($visible) use ($memberCommunityIds) {
+    $visible->where('visibility', EventVisibility::Public->value);
+    if ($memberCommunityIds !== []) {
+        $visible->orWhereIn('community_id', $memberCommunityIds);
+    }
+})
+```
+
+`memberCommunityIds()` = `CommunityMember::where('profile_id', viewer)->where('status', active)->pluck('community_id')`. So:
+
+| Caller | Sees |
+|---|---|
+| Anonymous / non-member | `visibility = public` only (the §8.6 invariant holds) |
+| Active member | public events **+** every event of communities they actively belong to (any visibility) |
+| Inactive / removed member | public only (status must be `active`) |
+
+The city / date / type / geo filters in `applyFilters()` / `applyDateFilter()` are unchanged and apply to public and member events alike — a joined community's event still surfaces only when it matches the selected city/date. Per-community listing (`GET /events?community_id=` → `EventService::list()`) was already unfiltered by visibility and is untouched. Viewing a single event is governed by `EventPolicy::view()` (returns `true` for any authenticated user). Tests: `tests/Feature/Api/V1/EventDiscoveryMembershipTest.php`.

--- a/tests/Feature/Api/V1/EventDiscoveryMembershipTest.php
+++ b/tests/Feature/Api/V1/EventDiscoveryMembershipTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\EventVisibility;
+use App\Models\City;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\CommunityProfile;
+use App\Models\Event;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Viewer-aware discover: an attendee must see member-visibility events of the
+ * communities they ACTIVELY belong to, alongside public events — while a
+ * non-member still never sees those member events (the §8.6 invariant). The
+ * city / date / type filters still apply to the member events.
+ */
+class EventDiscoveryMembershipTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Build a community sitting in $city and a members-visibility event it hosts.
+     *
+     * @param  array<string, mixed>  $eventAttributes
+     * @return array{0: Community, 1: Event}
+     */
+    private function createCommunityWithMembersEvent(
+        City $city,
+        string $type = 'run_club',
+        array $eventAttributes = []
+    ): array {
+        $owner = Profile::factory()->business()->create();
+
+        $communityProfile = CommunityProfile::factory()->create([
+            'city_id' => $city->id,
+            'community_type' => $type,
+        ]);
+
+        $community = Community::factory()->create([
+            'type' => $type,
+            'community_profile_id' => $communityProfile->id,
+        ]);
+
+        $event = Event::factory()->forProfile($owner)->create(array_merge([
+            'community_id' => $community->id,
+            'city_id' => $city->id,
+            'location_lat' => 41.3900,
+            'location_lng' => 2.1700,
+            'is_active' => false,
+            'visibility' => EventVisibility::Members->value,
+            'event_date' => now()->addDays(10)->toDateString(),
+            'starts_at' => now()->addDays(10),
+            'ends_at' => now()->addDays(10)->addHours(2),
+        ], $eventAttributes));
+
+        return [$community, $event];
+    }
+
+    private function joinCommunity(
+        Profile $member,
+        Community $community,
+        CommunityMemberStatus $status = CommunityMemberStatus::Active
+    ): void {
+        CommunityMember::factory()->create([
+            'community_id' => $community->id,
+            'profile_id' => $member->id,
+            'status' => $status->value,
+        ]);
+    }
+
+    public function test_discover_includes_members_event_of_joined_community(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+        [$community, $event] = $this->createCommunityWithMembersEvent($city);
+        $this->joinCommunity($attendee, $community);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?city_id='.$city->id)
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $event->id);
+    }
+
+    public function test_discover_still_excludes_members_event_for_non_member(): void
+    {
+        $stranger = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+        $this->createCommunityWithMembersEvent($city);
+
+        $this->actingAs($stranger)
+            ->getJson('/api/v1/events/discover?city_id='.$city->id)
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
+    public function test_discover_member_events_still_respect_city_filter(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $barcelona = City::factory()->create(['name' => 'Barcelona']);
+        $madrid = City::factory()->create(['name' => 'Madrid']);
+
+        // Joined community, but its event is in Madrid.
+        [$community] = $this->createCommunityWithMembersEvent($madrid);
+        $this->joinCommunity($attendee, $community);
+
+        // Filtering Barcelona must NOT surface the Madrid member event.
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?city_id='.$barcelona->id)
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
+    public function test_discover_excludes_member_events_when_membership_not_active(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+        [$community] = $this->createCommunityWithMembersEvent($city);
+        $this->joinCommunity($attendee, $community, CommunityMemberStatus::Removed);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?city_id='.$city->id)
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
+    public function test_discover_geo_surfaces_member_event_of_joined_community(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+        [$community, $event] = $this->createCommunityWithMembersEvent($city, eventAttributes: [
+            'location_lat' => 41.3900,
+            'location_lng' => 2.1700,
+        ]);
+        $this->joinCommunity($attendee, $community);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?lat=41.3874&lng=2.1686')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $event->id);
+    }
+
+    public function test_discover_combines_public_and_joined_member_events(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        // A joined community's members-only event.
+        [$community, $memberEvent] = $this->createCommunityWithMembersEvent($city);
+        $this->joinCommunity($attendee, $community);
+
+        // A public event in the same city, hosted by a different community.
+        [, $publicEvent] = $this->createCommunityWithMembersEvent($city, eventAttributes: [
+            'visibility' => EventVisibility::Public->value,
+        ]);
+
+        $response = $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?city_id='.$city->id);
+
+        $response->assertStatus(200)->assertJsonCount(2, 'data.events');
+
+        $ids = collect($response->json('data.events'))->pluck('id')->all();
+        $this->assertContains($memberEvent->id, $ids);
+        $this->assertContains($publicEvent->id, $ids);
+    }
+}


### PR DESCRIPTION
## Summary
Attendees who joined communities saw "No events in this city" because `GET /api/v1/events/discover` only returned `visibility=public` events, while community events default to `visibility=members`. Discover is now **viewer-aware**: an active member also sees the events of communities they belong to, alongside public events.

## Linked tracking item
Closes #50

## Type of change
- [x] 🐛 Bug fix
- [x] 📝 Docs

## Changes
- `EventDiscoveryService`: thread an optional `?Profile $viewer` through `discover()` → `discoverNearby()` / both geo impls / `discoverFiltered()` → `baseQuery()`.
- `baseQuery()` visibility gate is now `visibility = public OR community_id IN <viewer's active-membership community ids>`. New `memberCommunityIds()` helper queries `community_members` where `status = active`.
- `EventDiscoveryController` passes `$request->user()` as the viewer.
- Non-members / anonymous callers are unchanged (public only) — the §8.6 no-leak invariant holds. City / date / type / geo filters apply uniformly.
- New test `tests/Feature/Api/V1/EventDiscoveryMembershipTest.php` (6 cases).

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** Response shape of `/events/discover` is unchanged (same `EventResource`/`DiscoveredEvent` fields). Verified in `kolabing-app`: the discover call is authenticated (`discovery_service.dart` sends `Authorization: Bearer`), and there is no client-side visibility filtering — events render as returned. The fix takes effect on backend deploy with zero Flutter changes. Optional future polish (badge member-only events via the existing `visibility` field) is not required.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A — behavioral query change only.

## Testing
- [x] `php artisan test` passes — paste counts: **1134 passed (5320 assertions)**
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (member sees joined-community event; non-member excluded; city filter respected; inactive membership excluded; geo path; public+member combined — all covered by the new test)

## Docs & rules updated
- [x] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` (role/feed surfaces) — §7.1, §8.6, §12.6 added; Last updated bumped to 2026-06-23
- [x] No docs impact (BACKEND-SCHEMA / BACKLOG — no schema or backlog-item change; this was an unlisted bug, logged in the role-doc shipped checklist)

## Screenshots / notes
Reviewer note: tier-gated events currently surface to all active members of a joined community (matching the existing per-community `GET /events?community_id=` behavior, since §8.3 D3 defers tier enforcement). If tier gating should also apply on discover, that's a separate follow-up.

Follow-up: mirror the §7.1/§8.6/§12.6 doc edits into the `kolabing-app` copy of the two role docs per their sync note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)