### PR TITLE
feat(kolabs): Saved Kolabs API — save/unsave + saved list + is_saved flag

### DIFF
--- a/app/Http/Controllers/Api/V1/KolabController.php
+++ b/app/Http/Controllers/Api/V1/KolabController.php
@@ -43,6 +43,7 @@ class KolabController extends Controller
             'needs' => $request->query('needs'),
             'community_types' => $request->query('community_types'),
             'search' => $request->query('search'),
+            'saved' => $request->query('saved'),
         ];
 
         $perPage = (int) $request->query('per_page', 15);
@@ -145,6 +146,9 @@ class KolabController extends Controller
         }
 
         $kolab->load('creatorProfile');
+        $kolab->loadExists(['savedByProfiles as is_saved' => function ($q) use ($profile): void {
+            $q->whereKey($profile->id);
+        }]);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/Api/V1/SavedKolabController.php
+++ b/app/Http/Controllers/Api/V1/SavedKolabController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\KolabResource;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Services\KolabService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class SavedKolabController extends Controller
+{
+    public function __construct(
+        private readonly KolabService $kolabService,
+    ) {}
+
+    /**
+     * Save (bookmark) a kolab for the authenticated profile. Idempotent.
+     *
+     * POST /api/v1/kolabs/{kolab}/save
+     */
+    public function store(Request $request, Kolab $kolab): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($profile->cannot('view', $kolab)) {
+            return response()->json([
+                'success' => false,
+                'message' => __('You are not authorized to save this kolab.'),
+            ], 403);
+        }
+
+        $this->kolabService->save($profile, $kolab);
+
+        $kolab->load('creatorProfile');
+        $kolab->loadExists(['savedByProfiles as is_saved' => function ($q) use ($profile): void {
+            $q->whereKey($profile->id);
+        }]);
+
+        return response()->json([
+            'success' => true,
+            'message' => __('Kolab saved.'),
+            'data' => new KolabResource($kolab),
+        ]);
+    }
+
+    /**
+     * Remove a kolab from the authenticated profile's saved list. Idempotent.
+     *
+     * DELETE /api/v1/kolabs/{kolab}/save
+     */
+    public function destroy(Request $request, Kolab $kolab): Response
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        $this->kolabService->unsave($profile, $kolab);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Resources/Api/V1/Concerns/ResolvesSavedFlag.php
+++ b/app/Http/Resources/Api/V1/Concerns/ResolvesSavedFlag.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1\Concerns;
+
+use App\Models\Kolab;
+use Illuminate\Http\Request;
+
+/**
+ * Resolves the viewer-scoped `is_saved` flag for a kolab resource. Prefers a
+ * query-annotated `is_saved` attribute (set via withExists/loadExists in the
+ * list and detail paths, so no N+1) and falls back to a single existence check
+ * when the resource is rendered without that annotation (e.g. nested resources).
+ */
+trait ResolvesSavedFlag
+{
+    protected function resolveIsSaved(Request $request): bool
+    {
+        $viewer = $request->user();
+
+        if ($viewer === null) {
+            return false;
+        }
+
+        $model = $this->resource;
+
+        if (array_key_exists('is_saved', $model->getAttributes())) {
+            return (bool) $model->getAttribute('is_saved');
+        }
+
+        if (! $model instanceof Kolab) {
+            return false;
+        }
+
+        return $model->savedByProfiles()
+            ->whereKey($viewer->id)
+            ->exists();
+    }
+}

--- a/app/Http/Resources/Api/V1/KolabResource.php
+++ b/app/Http/Resources/Api/V1/KolabResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use App\Enums\IntentType;
+use App\Http\Resources\Api\V1\Concerns\ResolvesSavedFlag;
 use App\Models\Application;
 use App\Models\Kolab;
 use Illuminate\Http\Request;
@@ -17,6 +18,8 @@ use Illuminate\Support\Str;
  */
 class KolabResource extends JsonResource
 {
+    use ResolvesSavedFlag;
+
     /**
      * Transform the resource into an array.
      *
@@ -79,6 +82,7 @@ class KolabResource extends JsonResource
                 return new ProfileSummaryResource($this->creatorProfile);
             }),
             'is_own' => $request->user()?->id === $this->creator_profile_id,
+            'is_saved' => $this->resolveIsSaved($request),
             'applications_count' => $this->applications_count ?? 0,
         ];
     }

--- a/app/Http/Resources/Api/V1/OpportunitySummaryResource.php
+++ b/app/Http/Resources/Api/V1/OpportunitySummaryResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Http\Resources\Api\V1\Concerns\ResolvesSavedFlag;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -13,6 +14,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 class OpportunitySummaryResource extends JsonResource
 {
+    use ResolvesSavedFlag;
+
     /**
      * Transform the resource into an array.
      *
@@ -42,6 +45,7 @@ class OpportunitySummaryResource extends JsonResource
             'creator_profile' => $this->whenLoaded('creatorProfile', function () {
                 return new ProfileSummaryResource($this->creatorProfile);
             }),
+            'is_saved' => $this->resolveIsSaved($request),
         ];
     }
 

--- a/app/Models/Kolab.php
+++ b/app/Models/Kolab.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
@@ -180,6 +181,17 @@ class Kolab extends Model
     public function collaborations(): HasMany
     {
         return $this->hasMany(Collaboration::class, 'kolab_id');
+    }
+
+    /**
+     * Profiles that have saved/bookmarked this kolab.
+     *
+     * @return BelongsToMany<Profile, $this>
+     */
+    public function savedByProfiles(): BelongsToMany
+    {
+        return $this->belongsToMany(Profile::class, 'saved_kolabs', 'kolab_id', 'profile_id')
+            ->withTimestamps();
     }
 
     /**

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -328,6 +328,17 @@ class Profile extends Authenticatable
     }
 
     /**
+     * Kolabs this profile has saved/bookmarked.
+     *
+     * @return BelongsToMany<Kolab, $this>
+     */
+    public function savedKolabs(): BelongsToMany
+    {
+        return $this->belongsToMany(Kolab::class, 'saved_kolabs', 'profile_id', 'kolab_id')
+            ->withTimestamps();
+    }
+
+    /**
      * Get the gamification wallet for this profile.
      *
      * @return HasOne<Wallet, $this>

--- a/app/Services/KolabService.php
+++ b/app/Services/KolabService.php
@@ -36,13 +36,19 @@ class KolabService
      *     needs?: array<string>,
      *     community_types?: array<string>,
      *     search?: string,
+     *     saved?: string|bool,
      * }  $filters
      */
     public function browse(Profile $viewer, array $filters, int $perPage = 15): LengthAwarePaginator
     {
+        $savedOnly = filter_var($filters['saved'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
         $query = Kolab::query()
             ->where('status', KolabStatus::Published)
             ->withCount('applications')
+            ->withExists(['savedByProfiles as is_saved' => function (Builder $q) use ($viewer): void {
+                $q->whereKey($viewer->id);
+            }])
             ->with([
                 'creatorProfile' => function ($query) {
                     $query->with([
@@ -60,12 +66,40 @@ class KolabService
             ]);
 
         $this->applyRecipientVisibilityScope($query, $viewer);
-        $this->excludeAlreadyAppliedKolabs($query, $viewer);
+
+        if ($savedOnly) {
+            // The saved list returns exactly the viewer's saved kolabs — it does
+            // NOT hide ones they've already applied to (they explicitly saved them).
+            $query->whereHas('savedByProfiles', function (Builder $q) use ($viewer): void {
+                $q->whereKey($viewer->id);
+            });
+        } else {
+            $this->excludeAlreadyAppliedKolabs($query, $viewer);
+        }
+
         $this->applyFilters($query, $filters);
 
         return $query
             ->orderByDesc('published_at')
             ->paginate($perPage);
+    }
+
+    /**
+     * Save (bookmark) a kolab for a profile. Idempotent — saving an
+     * already-saved kolab is a no-op.
+     */
+    public function save(Profile $profile, Kolab $kolab): void
+    {
+        $profile->savedKolabs()->syncWithoutDetaching([$kolab->id]);
+    }
+
+    /**
+     * Remove a kolab from a profile's saved list. Idempotent — unsaving a
+     * kolab that was not saved is a no-op.
+     */
+    public function unsave(Profile $profile, Kolab $kolab): void
+    {
+        $profile->savedKolabs()->detach($kolab->id);
     }
 
     private function excludeAlreadyAppliedKolabs(Builder $query, Profile $viewer): void

--- a/database/migrations/2026_06_27_141702_create_saved_kolabs_table.php
+++ b/database/migrations/2026_06_27_141702_create_saved_kolabs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Pivot backing the app's "Saved Kolabs" feature: one row per
+     * (profile, kolab) a profile has bookmarked. A pure pivot — composite
+     * primary key, no UUID surrogate id (so belongsToMany attach/sync never
+     * trips the NOT NULL-id pitfall).
+     */
+    public function up(): void
+    {
+        Schema::create('saved_kolabs', function (Blueprint $table): void {
+            $table->foreignUuid('profile_id')
+                ->constrained('profiles')
+                ->cascadeOnDelete();
+            $table->foreignUuid('kolab_id')
+                ->constrained('kolabs')
+                ->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->primary(['profile_id', 'kolab_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('saved_kolabs');
+    }
+};

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -1,6 +1,6 @@
 # Kolabing — Roles → Backend → Database Map (Ground-Truth)
 
-**Last updated:** 2026-06-27 (PR #59 review fixes: completion-confirmation gate hardening — terminal-state guard, `pending = not-yes` resource/gate alignment, auto-complete grace anchored on `updated_at`, `Collaboration::roleFor()`, **legacy feedback fallback + backfill removed (`/complete` now gates purely on real completion confirmations)**, dead-code removal — §0 item 10, §3, §8, §10. Prior: 2026-06-26 PR 1 moved the `/complete` gate to `collaboration_completions`)
+**Last updated:** 2026-06-27 (#61 Saved Kolabs: new `saved_kolabs` pivot + save/unsave endpoints + `?saved=1` list + viewer-scoped `is_saved` flag — §7, §7.1. Earlier same day — PR #59 review fixes: completion-confirmation gate hardening — terminal-state guard, `pending = not-yes` resource/gate alignment, auto-complete grace anchored on `updated_at`, `Collaboration::roleFor()`, **legacy feedback fallback + backfill removed (`/complete` now gates purely on real completion confirmations)**, dead-code removal — §0 item 10, §3, §8, §10. Prior: 2026-06-26 PR 1 moved the `/complete` gate to `collaboration_completions`)
 **Status:** Authoritative companion to [`ROLES-AND-PERMISSIONS.md`](./ROLES-AND-PERMISSIONS.md). Read that first (the *what*), then this (the *where*).
 **Sync note:** Duplicated in both repos (`kolabing-app`, `kolabing-v2`). Keep identical, and **bump the Last updated date in both** when role behaviour or backend wiring changes.
 
@@ -143,6 +143,7 @@ profiles (id uuid PK, email UNIQUE, user_type[business|community|attendee], avat
  │                              product_promotion], status[draft|published|closed], media json,
  │                              needs json, community_types json, venue_preference, offering json,
  │                              published_at)                                                    ← System B (canonical)
+ │        └─N:M─ saved_kolabs   (profile_id FK, kolab_id FK, timestamps; PK(profile_id,kolab_id)) ← Saved/bookmarked kolabs (§7.1)
  ├─1:N─ events                 (profile_id FK, partner_id FK, event_date, attendee_count)        ← past events
  └─1:N─ applications           (applicant_profile_id FK, applicant_profile_type[business|community],
                                 kolab_id FK ← canonical, collab_opportunity_id FK ARCHIVED (no longer written, drop #31),
@@ -173,6 +174,15 @@ Lookups / admin:
 ```
 
 **Role lives in `profiles.user_type`. Subscription lives in `business_subscriptions.status` (with `source` as audit trail).** Everything else branches off those two.
+
+### 7.1 Saved Kolabs (bookmarks) — added 2026-06-27 (#61)
+
+Viewer-scoped bookmarks of published kolabs. Pivot `saved_kolabs` (`profile_id` FK→profiles cascade, `kolab_id` FK→kolabs cascade, timestamps, composite PK — no UUID surrogate, so `belongsToMany` attach/sync is safe). Relations: `Profile::savedKolabs()` / `Kolab::savedByProfiles()`; service `KolabService::save()/unsave()` (idempotent via `syncWithoutDetaching`/`detach`).
+
+- `POST /api/v1/kolabs/{kolab}/save` → 200 (idempotent); requires `can('view', $kolab)` so visibility/paywall rules are respected (you can only save what you can see).
+- `DELETE /api/v1/kolabs/{kolab}/save` → 204 (idempotent).
+- **List:** `GET /api/v1/kolabs?saved=1` reuses `KolabService::browse()` (identical resource shape + paging). The saved list keeps the published + recipient-visibility scope but, unlike the normal feed, does **not** hide kolabs the viewer already applied to.
+- **Flag:** `is_saved` (bool, viewer-scoped) on `KolabResource` and `OpportunitySummaryResource`. N+1-free in list/detail via `withExists`/`loadExists` annotation (`ResolvesSavedFlag` trait), with a single-existence-query fallback for nested resources. Not role-discriminatory — any authenticated profile may save any visible kolab.
 
 > **ARCHIVED (2026-06-19, #30):** `collab_opportunities` and the `collab_opportunity_id` columns on `applications`/`collaborations` are no longer read or written by application code. They are retained physically and scheduled for drop in #31. `kolabs` is the sole source of truth for the opportunity/kolab lifecycle; `kolab_id` is the canonical FK on applications/collaborations.
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,7 @@ use App\Http\Controllers\Api\V1\OpportunityController;
 use App\Http\Controllers\Api\V1\ProfileController;
 use App\Http\Controllers\Api\V1\ReferralController;
 use App\Http\Controllers\Api\V1\RewardWalletController;
+use App\Http\Controllers\Api\V1\SavedKolabController;
 use App\Http\Controllers\Api\V1\SpinWheelController;
 use App\Http\Controllers\Api\V1\SubscriptionController;
 use App\Http\Controllers\Api\V1\SystemChallengeController;
@@ -719,6 +720,12 @@ Route::prefix('v1')->group(function (): void {
         // Close kolab
         Route::post('kolabs/{kolab}/close', [KolabController::class, 'close'])
             ->name('api.v1.kolabs.close');
+
+        // Save / unsave a kolab (viewer-scoped bookmark). List via GET kolabs?saved=1
+        Route::post('kolabs/{kolab}/save', [SavedKolabController::class, 'store'])
+            ->name('api.v1.kolabs.save');
+        Route::delete('kolabs/{kolab}/save', [SavedKolabController::class, 'destroy'])
+            ->name('api.v1.kolabs.unsave');
 
         // List applications for a kolab (creator only)
         Route::get('kolabs/{kolab}/applications', [ApplicationController::class, 'forOpportunity'])

--- a/tests/Feature/Api/V1/SavedKolabTest.php
+++ b/tests/Feature/Api/V1/SavedKolabTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Application;
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class SavedKolabTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_save_bookmarks_a_kolab_and_marks_it_saved(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($viewer)
+            ->postJson(route('api.v1.kolabs.save', $kolab))
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.is_saved', true);
+
+        $this->assertDatabaseHas('saved_kolabs', [
+            'profile_id' => $viewer->id,
+            'kolab_id' => $kolab->id,
+        ]);
+    }
+
+    public function test_save_is_idempotent(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($viewer)->postJson(route('api.v1.kolabs.save', $kolab))->assertOk();
+        $this->actingAs($viewer)->postJson(route('api.v1.kolabs.save', $kolab))->assertOk();
+
+        $this->assertDatabaseCount('saved_kolabs', 1);
+    }
+
+    public function test_unsave_removes_the_bookmark(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($viewer)->postJson(route('api.v1.kolabs.save', $kolab))->assertOk();
+
+        $this->actingAs($viewer)
+            ->deleteJson(route('api.v1.kolabs.unsave', $kolab))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('saved_kolabs', [
+            'profile_id' => $viewer->id,
+            'kolab_id' => $kolab->id,
+        ]);
+    }
+
+    public function test_unsave_is_idempotent_when_not_saved(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($viewer)
+            ->deleteJson(route('api.v1.kolabs.unsave', $kolab))
+            ->assertNoContent();
+
+        $this->assertDatabaseCount('saved_kolabs', 0);
+    }
+
+    public function test_saved_list_returns_only_the_viewers_saved_kolabs(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $saved = Kolab::factory()->published()->create();
+        Kolab::factory()->published()->create(); // not saved
+
+        $this->actingAs($viewer)->postJson(route('api.v1.kolabs.save', $saved))->assertOk();
+
+        $response = $this->actingAs($viewer)->getJson('/api/v1/kolabs?saved=1');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.data.0.id', $saved->id)
+            ->assertJsonPath('data.data.0.is_saved', true);
+    }
+
+    public function test_is_saved_is_per_viewer_in_list_and_detail(): void
+    {
+        $saver = Profile::factory()->business()->create();
+        $other = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($saver)->postJson(route('api.v1.kolabs.save', $kolab))->assertOk();
+
+        // Detail: saver sees true, other sees false.
+        $this->actingAs($saver)
+            ->getJson(route('api.v1.kolabs.show', $kolab))
+            ->assertOk()
+            ->assertJsonPath('data.is_saved', true);
+
+        $this->actingAs($other)
+            ->getJson(route('api.v1.kolabs.show', $kolab))
+            ->assertOk()
+            ->assertJsonPath('data.is_saved', false);
+
+        // List: other sees the kolab with is_saved=false.
+        $this->actingAs($other)
+            ->getJson('/api/v1/kolabs')
+            ->assertOk()
+            ->assertJsonPath('data.data.0.is_saved', false);
+    }
+
+    public function test_saved_list_includes_kolabs_the_viewer_already_applied_to(): void
+    {
+        $viewer = Profile::factory()->community()->create();
+        $kolab = Kolab::factory()->published()->create();
+
+        $this->actingAs($viewer)->postJson(route('api.v1.kolabs.save', $kolab))->assertOk();
+
+        Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $viewer->id,
+        ]);
+
+        // Normal browse hides applied kolabs; the saved list must still show it.
+        $this->actingAs($viewer)
+            ->getJson('/api/v1/kolabs')
+            ->assertOk()
+            ->assertJsonPath('meta.total', 0);
+
+        $this->actingAs($viewer)
+            ->getJson('/api/v1/kolabs?saved=1')
+            ->assertOk()
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.data.0.id', $kolab->id);
+    }
+
+    public function test_cannot_save_a_kolab_the_viewer_cannot_view(): void
+    {
+        $viewer = Profile::factory()->business()->create();
+        $hidden = Kolab::factory()->create(); // draft, owned by someone else
+
+        $this->actingAs($viewer)
+            ->postJson(route('api.v1.kolabs.save', $hidden))
+            ->assertStatus(403);
+
+        $this->assertDatabaseCount('saved_kolabs', 0);
+    }
+}


### PR DESCRIPTION
## Summary
Implements the **Saved Kolabs** API (#61): a profile can save/unsave a kolab, list its saved kolabs, and every kolab resource carries a per-viewer `is_saved` flag. Backs the app's Saved Kolabs feature (`kolabing/kolabing-app`).

## Linked tracking item
Closes #61

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes
- **Migration** `saved_kolabs` pivot: `profile_id` (FK→profiles, cascade), `kolab_id` (FK→kolabs, cascade), timestamps, composite PK `(profile_id, kolab_id)` — a pure pivot with no UUID surrogate id, so `belongsToMany` attach/sync is safe.
- **Relations**: `Profile::savedKolabs()` and `Kolab::savedByProfiles()` (belongsToMany).
- **Service**: `KolabService::save()`/`unsave()` (idempotent via `syncWithoutDetaching`/`detach`); `browse()` gains a `saved` filter and a `withExists` `is_saved` annotation.
- **Endpoints** (Sanctum, viewer-scoped):
  - `POST /api/v1/kolabs/{kolab}/save` → `200`, idempotent, requires `can('view', $kolab)`.
  - `DELETE /api/v1/kolabs/{kolab}/save` → `204`, idempotent.
  - **List**: `GET /api/v1/kolabs?saved=1` — reuses `browse()` so shape/paging are identical; keeps the published + recipient-visibility scope but, unlike the normal feed, does **not** hide kolabs the viewer already applied to.
- **Resources**: viewer-scoped `is_saved` (bool) added to `KolabResource` **and** `OpportunitySummaryResource` via a shared `ResolvesSavedFlag` trait (annotated attribute → N+1-free in list/detail; single-existence-query fallback for nested resources). `show()` annotates via `loadExists`.
- **Authorization**: respects `KolabPolicy::view` — you can only save a kolab you can see (drafts/recipient-targeted kolabs of others 403). Saved list reuses the same resource, so no blurred identity is leaked.
- **Docs**: `docs/ROLES-BACKEND-DB-MAP.md` §7 schema map + new §7.1, date bumped.

## Mobile impact (kolabing-app)
- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** New endpoints `POST`/`DELETE /api/v1/kolabs/{kolab}/save`; saved list via `GET /api/v1/kolabs?saved=1` (same envelope as the normal kolab list: `data.data[]` + `meta`). Kolab resources (`KolabResource`, `OpportunitySummaryResource`) gain a `is_saved` boolean. No existing fields changed/removed (additive). Consumer ticket: `kolabing/kolabing-app` (Saved Kolabs).

## Database / migrations
- [x] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change (explain rollback below)

**Migration notes:** `2026_06_27_141702_create_saved_kolabs_table` — additive, reversible (`down()` drops the table). No backfill. **Needs `php artisan migrate` on the dev environment** for app integration (per the issue's acceptance criteria).

## Testing
- [x] `php artisan test` passes — paste counts: **1195 passed (5589 assertions)**
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — covered by 8 new feature tests in `tests/Feature/Api/V1/SavedKolabTest.php` (save, idempotent save, unsave, idempotent unsave, saved list, per-viewer `is_saved` in list+detail, saved list includes already-applied, 403 on un-viewable kolab).

## Docs & rules updated
- [ ] `BACKLOG.md` updated — N/A: this repo's `docs/BACKLOG.md` uses a numbered-topic structure, not the New/Incomplete/Fixes convention; left unedited per prior audit note rather than guessing the format.
- [x] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` — added the `saved_kolabs` table + §7.1 (Saved Kolabs) to the DB map and bumped its date. ROLES-AND-PERMISSIONS unchanged (no role/paywall behaviour change — saving is non-role-discriminatory).
- [ ] `docs/BACKEND-SCHEMA.md` — N/A: file does not exist in this repo; the live schema doc is `ROLES-BACKEND-DB-MAP.md`, which is updated.
- [ ] No docs impact

## Screenshots / notes
Backend-only. Quick API shape:
- `POST /api/v1/kolabs/{id}/save` → `{ success, message, data: { …kolab, is_saved: true } }`
- `GET /api/v1/kolabs?saved=1` → `{ success, data: { data: [ { …kolab, is_saved: true } ] }, meta }`

Scope note: the issue's "current state" referenced the legacy `collab_opportunities` table; the canonical kolab table is `kolabs` (legacy archived in #30), so the FK targets `kolabs`.
