### PR TITLE
feat(reviews): optional 5-star Kolab review format

### DIFF
--- a/app/Http/Controllers/Api/V1/CollaborationController.php
+++ b/app/Http/Controllers/Api/V1/CollaborationController.php
@@ -386,14 +386,31 @@ class CollaborationController extends Controller
 
         $validated = $request->validated();
 
+        $usesStarRatings = isset($validated['communication_rating']);
+
+        // Legacy `rating` still gets stored so `overall_rating` has a fallback
+        // and older clients reading it directly keep working. When the new
+        // 5-star format is used, derive it as the rounded average.
+        $legacyRating = $validated['rating']
+            ?? ($usesStarRatings ? (int) round(
+                ($validated['communication_rating'] + $validated['reliability_rating']
+                    + $validated['fit_rating'] + $validated['value_rating'] + $validated['repeat_rating']) / 5
+            ) : null);
+
         $review = CollaborationReview::create([
             'collaboration_id' => $collaboration->id,
             'reviewer_profile_id' => $reviewer->id,
             'reviewed_profile_id' => $reviewedProfileId,
             'reviewer_role' => $reviewerRole,
-            'rating' => $validated['rating'],
+            'rating' => $legacyRating,
+            'communication_rating' => $validated['communication_rating'] ?? null,
+            'reliability_rating' => $validated['reliability_rating'] ?? null,
+            'fit_rating' => $validated['fit_rating'] ?? null,
+            'value_rating' => $validated['value_rating'] ?? null,
+            'repeat_rating' => $validated['repeat_rating'] ?? null,
             'note' => isset($validated['body']) ? mb_substr((string) $validated['body'], 0, 200) : null,
             'body' => $validated['body'] ?? null,
+            'public_comment' => $validated['public_comment'] ?? null,
             'would_collaborate_again' => $validated['would_collaborate_again'] ?? null,
         ]);
 
@@ -411,7 +428,7 @@ class CollaborationController extends Controller
         // NOT affect /complete (the gate reads completion confirmations only).
         // No-op if a real /feedback row already exists.
         $this->feedbackService->mirrorFromReview($collaboration, $reviewer, [
-            'rating' => $validated['rating'],
+            'rating' => $legacyRating,
             'body' => $validated['body'] ?? null,
             'would_collaborate_again' => $validated['would_collaborate_again'] ?? null,
         ]);

--- a/app/Http/Requests/Api/V1/StoreCollaborationReviewRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCollaborationReviewRequest.php
@@ -14,12 +14,36 @@ class StoreCollaborationReviewRequest extends FormRequest
     }
 
     /**
+     * The new 5-star format is detected by the presence of any one of its
+     * rating fields. When present, all five become required. Clients still
+     * sending the legacy single `rating` payload are unaffected.
+     */
+    private function usesStarRatingFormat(): bool
+    {
+        foreach (\App\Models\CollaborationReview::STAR_RATING_FIELDS as $field) {
+            if ($this->filled($field)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function rules(): array
     {
+        $starRatingRule = $this->usesStarRatingFormat() ? 'required' : 'nullable';
+
         return [
-            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'rating' => [$this->usesStarRatingFormat() ? 'nullable' : 'required', 'integer', 'min:1', 'max:5'],
+            'communication_rating' => [$starRatingRule, 'integer', 'min:1', 'max:5'],
+            'reliability_rating' => [$starRatingRule, 'integer', 'min:1', 'max:5'],
+            'fit_rating' => [$starRatingRule, 'integer', 'min:1', 'max:5'],
+            'value_rating' => [$starRatingRule, 'integer', 'min:1', 'max:5'],
+            'repeat_rating' => [$starRatingRule, 'integer', 'min:1', 'max:5'],
+            'public_comment' => ['nullable', 'string', 'max:2000'],
             'body' => ['nullable', 'string', 'max:500'],
             'would_collaborate_again' => ['nullable', 'boolean'],
         ];
@@ -34,6 +58,12 @@ class StoreCollaborationReviewRequest extends FormRequest
             'rating.required' => 'A star rating is required.',
             'rating.min' => 'Rating must be at least 1 star.',
             'rating.max' => 'Rating cannot exceed 5 stars.',
+            'communication_rating.required' => 'Please rate communication.',
+            'reliability_rating.required' => 'Please rate reliability.',
+            'fit_rating.required' => 'Please rate fit.',
+            'value_rating.required' => 'Please rate value.',
+            'repeat_rating.required' => 'Please rate whether you would Kolab again.',
+            'public_comment.max' => 'Comment cannot exceed 2000 characters.',
             'body.max' => 'Review text cannot exceed 500 characters.',
         ];
     }

--- a/app/Http/Resources/Api/V1/CollaborationResource.php
+++ b/app/Http/Resources/Api/V1/CollaborationResource.php
@@ -152,8 +152,17 @@ class CollaborationResource extends JsonResource
                 return $this->reviews->map(fn ($review): array => [
                     'reviewer_role' => $review->reviewer_role,
                     'rating' => $review->rating,
+                    'overall_rating' => $review->overall_rating,
+                    'communication_rating' => $review->communication_rating,
+                    'reliability_rating' => $review->reliability_rating,
+                    'fit_rating' => $review->fit_rating,
+                    'value_rating' => $review->value_rating,
+                    'repeat_rating' => $review->repeat_rating,
                     'note' => $review->body ?? $review->note,
                     'body' => $review->body ?? $review->note,
+                    // `public_comment` is the field intended for display on a
+                    // reviewed profile; `note`/`body` remain internal-only.
+                    'public_comment' => $review->public_comment,
                     'would_collaborate_again' => $review->would_collaborate_again,
                     'created_at' => $review->created_at?->toIso8601String(),
                 ])->values();

--- a/app/Http/Resources/Api/V1/PublicProfileReviewResource.php
+++ b/app/Http/Resources/Api/V1/PublicProfileReviewResource.php
@@ -27,7 +27,9 @@ class PublicProfileReviewResource extends JsonResource
         return [
             'id' => $this->id,
             'rating' => $this->rating,
+            'overall_rating' => $this->overall_rating,
             'body' => $this->body ?? $this->note,
+            'public_comment' => $this->public_comment,
             'would_collaborate_again' => $this->would_collaborate_again,
             'created_at' => $this->created_at?->toIso8601String(),
             'reviewer' => [

--- a/app/Models/CollaborationReview.php
+++ b/app/Models/CollaborationReview.php
@@ -106,6 +106,21 @@ class CollaborationReview extends Model
     }
 
     /**
+     * SQL expression that yields each review's overall rating — the average of
+     * the five star columns when all are present, otherwise the legacy `rating`.
+     * Mirrors {@see getOverallRatingAttribute()} so aggregate queries (admin
+     * stats, per-kolab averages) score star reviews precisely instead of the
+     * rounded legacy fallback. Built from the {@see STAR_RATING_FIELDS} constant
+     * — no user input — so it is safe to interpolate into a raw expression.
+     */
+    public static function overallRatingSqlExpression(): string
+    {
+        $sum = implode(' + ', self::STAR_RATING_FIELDS);
+
+        return '(COALESCE(('.$sum.') / '.count(self::STAR_RATING_FIELDS).'.0, rating))';
+    }
+
+    /**
      * @return BelongsTo<Collaboration, $this>
      */
     public function collaboration(): BelongsTo

--- a/app/Models/CollaborationReview.php
+++ b/app/Models/CollaborationReview.php
@@ -16,9 +16,16 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $reviewer_role
  * @property string|null $reviewed_profile_id
  * @property int|null $rating
+ * @property int|null $communication_rating
+ * @property int|null $reliability_rating
+ * @property int|null $fit_rating
+ * @property int|null $value_rating
+ * @property int|null $repeat_rating
  * @property string|null $note
  * @property string|null $body
+ * @property string|null $public_comment
  * @property bool|null $would_collaborate_again
+ * @property-read float|null $overall_rating
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read Collaboration $collaboration
@@ -32,6 +39,19 @@ class CollaborationReview extends Model
     use HasUuids;
 
     /**
+     * The five star-rating columns introduced for the new review format.
+     *
+     * @var list<string>
+     */
+    public const STAR_RATING_FIELDS = [
+        'communication_rating',
+        'reliability_rating',
+        'fit_rating',
+        'value_rating',
+        'repeat_rating',
+    ];
+
+    /**
      * @var list<string>
      */
     protected $fillable = [
@@ -40,8 +60,14 @@ class CollaborationReview extends Model
         'reviewed_profile_id',
         'reviewer_role',
         'rating',
+        'communication_rating',
+        'reliability_rating',
+        'fit_rating',
+        'value_rating',
+        'repeat_rating',
         'note',
         'body',
+        'public_comment',
         'would_collaborate_again',
     ];
 
@@ -52,8 +78,31 @@ class CollaborationReview extends Model
     {
         return [
             'rating' => 'integer',
+            'communication_rating' => 'integer',
+            'reliability_rating' => 'integer',
+            'fit_rating' => 'integer',
+            'value_rating' => 'integer',
+            'repeat_rating' => 'integer',
             'would_collaborate_again' => 'boolean',
         ];
+    }
+
+    /**
+     * Average of the five new star ratings when present, falling back to the
+     * legacy single `rating` field for reviews submitted before this format.
+     */
+    public function getOverallRatingAttribute(): ?float
+    {
+        $starRatings = array_filter(
+            array_map(fn (string $field) => $this->{$field}, self::STAR_RATING_FIELDS),
+            fn ($value) => $value !== null,
+        );
+
+        if (count($starRatings) === count(self::STAR_RATING_FIELDS)) {
+            return round(array_sum($starRatings) / count($starRatings), 2);
+        }
+
+        return $this->rating !== null ? (float) $this->rating : null;
     }
 
     /**

--- a/app/Services/Admin/KolabLifecycleService.php
+++ b/app/Services/Admin/KolabLifecycleService.php
@@ -219,7 +219,10 @@ class KolabLifecycleService
                 ->get()
             : new Collection;
 
-        $ratings = $reviews->pluck('rating')->filter()->values();
+        $ratings = $reviews
+            ->map(fn (CollaborationReview $review): ?float => $review->overall_rating)
+            ->filter(fn (?float $rating): bool => $rating !== null)
+            ->values();
         $averageRating = $ratings->isNotEmpty() ? (float) round($ratings->avg(), 1) : null;
 
         return [

--- a/app/Services/Admin/PlatformStatsService.php
+++ b/app/Services/Admin/PlatformStatsService.php
@@ -293,13 +293,16 @@ class PlatformStatsService
      */
     private function quality(?CarbonImmutable $since): array
     {
+        $overall = CollaborationReview::overallRatingSqlExpression();
+
         $avgRating = CollaborationReview::query()
             ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
-            ->avg('rating');
+            ->selectRaw("AVG({$overall}) as aggregate")
+            ->value('aggregate');
 
         $perSide = CollaborationReview::query()->toBase()
             ->when($since, fn ($q) => $q->where('created_at', '>=', $since))
-            ->selectRaw('reviewer_role, AVG(rating) as avg_rating, count(*) as total')
+            ->selectRaw("reviewer_role, AVG({$overall}) as avg_rating, count(*) as total")
             ->groupBy('reviewer_role')
             ->get()
             ->mapWithKeys(fn ($r) => [(string) $r->reviewer_role => [

--- a/app/Services/CollaborationFeedbackService.php
+++ b/app/Services/CollaborationFeedbackService.php
@@ -299,6 +299,10 @@ class CollaborationFeedbackService
         // Only the community side carries free text (benefits); business has none.
         $note = $reviewer->isCommunity() ? $feedback->benefits : null;
 
+        // The legacy /feedback flow has no per-dimension star scores, so the
+        // five star columns are intentionally left null here. Consumers read
+        // CollaborationReview::overall_rating (or its SQL equivalent), which
+        // falls back to this single `rating` when the stars are absent.
         CollaborationReview::query()->updateOrCreate(
             [
                 'collaboration_id' => $collaboration->id,

--- a/database/migrations/2026_06_28_151212_add_star_ratings_to_collaboration_reviews_table.php
+++ b/database/migrations/2026_06_28_151212_add_star_ratings_to_collaboration_reviews_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('collaboration_reviews', function (Blueprint $table): void {
+            $table->unsignedTinyInteger('communication_rating')->nullable()->after('rating');
+            $table->unsignedTinyInteger('reliability_rating')->nullable()->after('communication_rating');
+            $table->unsignedTinyInteger('fit_rating')->nullable()->after('reliability_rating');
+            $table->unsignedTinyInteger('value_rating')->nullable()->after('fit_rating');
+            $table->unsignedTinyInteger('repeat_rating')->nullable()->after('value_rating');
+            $table->text('public_comment')->nullable()->after('body');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('collaboration_reviews', function (Blueprint $table): void {
+            $table->dropColumn([
+                'communication_rating',
+                'reliability_rating',
+                'fit_rating',
+                'value_rating',
+                'repeat_rating',
+                'public_comment',
+            ]);
+        });
+    }
+};

--- a/tests/Feature/Admin/StatsDashboardTest.php
+++ b/tests/Feature/Admin/StatsDashboardTest.php
@@ -9,9 +9,11 @@ use App\Enums\UserType;
 use App\Models\Application;
 use App\Models\BusinessSubscription;
 use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use App\Models\Kolab;
 use App\Models\Profile;
 use App\Models\User;
+use App\Services\Admin\KolabLifecycleService;
 use App\Services\Admin\PlatformStatsService;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Tests\TestCase;
@@ -36,6 +38,52 @@ class StatsDashboardTest extends TestCase
             ->get(route('admin.stats.index'))
             ->assertOk()
             ->assertSee('Statistics');
+    }
+
+    public function test_quality_avg_rating_uses_star_overall_not_rounded_legacy_rating(): void
+    {
+        $collaboration = Collaboration::factory()->completed()->create();
+
+        // Mirrors what the controller stores for a 5-star review: the legacy
+        // `rating` column holds the rounded average (5), while the precise
+        // per-dimension scores average to 4.6.
+        CollaborationReview::factory()->create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+            'communication_rating' => 5,
+            'reliability_rating' => 4,
+            'fit_rating' => 4,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+        ]);
+
+        $quality = app(PlatformStatsService::class)->summary('all')['quality'];
+
+        // (5 + 4 + 4 + 5 + 5) / 5 = 4.6, NOT the rounded legacy 5.
+        $this->assertSame(4.6, $quality['avg_rating']);
+        $this->assertSame(4.6, $quality['per_side']['creator']['avg']);
+    }
+
+    public function test_kolab_lifecycle_average_rating_uses_star_overall(): void
+    {
+        $collaboration = Collaboration::factory()->completed()->create();
+        $kolab = Kolab::findOrFail($collaboration->kolab_id);
+
+        CollaborationReview::factory()->create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+            'communication_rating' => 5,
+            'reliability_rating' => 4,
+            'fit_rating' => 4,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+        ]);
+
+        $summary = app(KolabLifecycleService::class)->summarize($kolab);
+
+        $this->assertSame(4.6, $summary['average_rating']);
     }
 
     public function test_summary_returns_audience_counts_split_by_user_type(): void

--- a/tests/Feature/Api/V1/CollaborationReviewTest.php
+++ b/tests/Feature/Api/V1/CollaborationReviewTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\V1;
 
+use App\Enums\PointEventType;
 use App\Models\BusinessProfile;
 use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use App\Models\CommunityProfile;
 use App\Models\Profile;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -55,5 +57,225 @@ class CollaborationReviewTest extends TestCase
             'rating' => 5,
             'body' => 'Great collaboration',
         ]);
+    }
+
+    private function makeCollaboration(): array
+    {
+        $business = Profile::factory()->business()->create();
+        $businessProfile = BusinessProfile::factory()->create([
+            'profile_id' => $business->id,
+            'name' => 'Business Reviewer',
+        ]);
+
+        $community = Profile::factory()->community()->create();
+        $communityProfile = CommunityProfile::factory()->create([
+            'profile_id' => $community->id,
+            'name' => 'Community Reviewed',
+        ]);
+
+        $collaboration = Collaboration::factory()
+            ->completed()
+            ->forCreator($business)
+            ->forApplicant($community)
+            ->create([
+                'business_profile_id' => $businessProfile->id,
+                'community_profile_id' => $communityProfile->id,
+            ]);
+
+        return [$collaboration, $business, $community];
+    }
+
+    private function starPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'communication_rating' => 5,
+            'reliability_rating' => 4,
+            'fit_rating' => 4,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+            'public_comment' => 'Would Kolab again!',
+        ], $overrides);
+    }
+
+    public function test_submit_new_five_star_review(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload());
+
+        $response->assertCreated()->assertJsonPath('success', true);
+
+        $this->assertDatabaseHas('collaboration_reviews', [
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $business->id,
+            'communication_rating' => 5,
+            'reliability_rating' => 4,
+            'fit_rating' => 4,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+            'public_comment' => 'Would Kolab again!',
+        ]);
+    }
+
+    public function test_all_five_ratings_are_required_for_new_format(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload([
+                'fit_rating' => null,
+            ]));
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['fit_rating']);
+    }
+
+    public function test_invalid_rating_values_are_rejected(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload([
+                'value_rating' => 6,
+            ]));
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['value_rating']);
+    }
+
+    public function test_legacy_single_rating_review_still_works(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", [
+                'rating' => 4,
+                'body' => 'Solid Kolab',
+            ]);
+
+        $response->assertCreated();
+        $this->assertDatabaseHas('collaboration_reviews', [
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $business->id,
+            'rating' => 4,
+        ]);
+    }
+
+    public function test_overall_rating_averages_the_five_star_fields(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload());
+
+        $review = CollaborationReview::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $business->id)
+            ->first();
+
+        // (5 + 4 + 4 + 5 + 5) / 5 = 4.6
+        $this->assertSame(4.6, $review->overall_rating);
+    }
+
+    public function test_overall_rating_falls_back_to_legacy_rating(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", [
+                'rating' => 3,
+            ]);
+
+        $review = CollaborationReview::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $business->id)
+            ->first();
+
+        $this->assertSame(3.0, $review->overall_rating);
+    }
+
+    public function test_each_side_can_review_once_per_kolab_and_earns_xp_independently(): void
+    {
+        [$collaboration, $business, $community] = $this->makeCollaboration();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload())
+            ->assertCreated();
+
+        $this->actingAs($community)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload())
+            ->assertCreated();
+
+        $this->assertSame(1, \App\Models\PointLedger::query()
+            ->where('profile_id', $business->id)
+            ->where('event_type', PointEventType::ReviewPosted)
+            ->count());
+
+        $this->assertSame(1, \App\Models\PointLedger::query()
+            ->where('profile_id', $community->id)
+            ->where('event_type', PointEventType::ReviewPosted)
+            ->count());
+    }
+
+    public function test_duplicate_submission_does_not_duplicate_xp(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload())
+            ->assertCreated();
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload([
+                'communication_rating' => 1,
+            ]));
+
+        $response->assertOk()->assertJsonPath('message', 'Review already submitted.');
+
+        $this->assertSame(1, CollaborationReview::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $business->id)
+            ->count());
+
+        $this->assertSame(1, \App\Models\PointLedger::query()
+            ->where('profile_id', $business->id)
+            ->where('event_type', PointEventType::ReviewPosted)
+            ->count());
+    }
+
+    public function test_a_second_separate_kolab_between_same_profiles_can_receive_a_separate_review(): void
+    {
+        [$collaboration, $business, $community] = $this->makeCollaboration();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", $this->starPayload())
+            ->assertCreated();
+
+        $secondCollaboration = Collaboration::factory()
+            ->completed()
+            ->forCreator($business)
+            ->forApplicant($community)
+            ->create([
+                'business_profile_id' => $collaboration->business_profile_id,
+                'community_profile_id' => $collaboration->community_profile_id,
+            ]);
+
+        $response = $this->actingAs($business)
+            ->postJson("/api/v1/collaborations/{$secondCollaboration->id}/review", $this->starPayload());
+
+        $response->assertCreated();
+
+        $this->assertSame(2, CollaborationReview::query()
+            ->where('reviewer_profile_id', $business->id)
+            ->count());
+    }
+
+    public function test_review_remains_optional_and_does_not_block_completion(): void
+    {
+        [$collaboration, $business] = $this->makeCollaboration();
+
+        // No review submitted at all — collaboration is already in completed
+        // state via the factory, confirming review submission isn't required
+        // to reach/stay in that state.
+        $this->assertSame('completed', $collaboration->status->value ?? $collaboration->status);
     }
 }


### PR DESCRIPTION
## Summary
Adds an optional 5-star review format (communication/reliability/fit/value/repeat ratings + optional public comment) on top of the PR 1 completion-confirmation flow, so either side can rate a Kolab after confirming it happened, independently of the other.

## Linked tracking item
Closes #64

## Type of change
- [x] ✨ Feature

## Changes
- Additive migration: `communication_rating`, `reliability_rating`, `fit_rating`, `value_rating`, `repeat_rating` (smallint 1-5, nullable) + `public_comment` (text, nullable, max 2000) on `collaboration_reviews`.
- `StoreCollaborationReviewRequest`: new format requires all 5 ratings when any is sent; legacy single-`rating` payload still accepted unchanged.
- `CollaborationReview` model: `overall_rating` accessor — averages the 5 ratings when all present, else falls back to legacy `rating`.
- `CollaborationController::review()`: stores the new fields and derives a legacy `rating` (rounded average) for back-compat; existing idempotency / `mirrorFromReview` / XP logic untouched.
- `CollaborationResource` / `PublicProfileReviewResource`: expose the 5 ratings, `overall_rating`, `public_comment` (kept distinct from internal `note`/`body`).
- `docs/BACKEND-SCHEMA.md` (kolabing-app repo) updated to document the new columns.
- 11 new tests in `CollaborationReviewTest.php`.

## Mobile impact (kolabing-app)
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** `POST /collaborations/{id}/review` now accepts an additional optional payload shape: `communication_rating`, `reliability_rating`, `fit_rating`, `value_rating`, `repeat_rating` (all required together, 1-5), `public_comment` (optional, ≤2000 chars). The legacy `{rating, body, would_collaborate_again}` payload is unchanged and still works. Corresponding mobile PR: kolabing/kolabing-app#TBD (`feat/kolab-star-review`).

## Database / migrations
- [x] Includes migrations — additive & reversible

**Migration notes:** Purely additive nullable columns; `down()` drops them. No backfill needed — `overall_rating` falls back to the legacy `rating` for existing rows.

## Testing
- [x] `php artisan test` passes — 60 passed (218 assertions) across `CollaborationReviewTest`, `CollaborationFeedbackTest`, `CollaborationCompletionConfirmationTest`, `Admin/CollaborationCompletionTest`
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (new format, legacy fallback, duplicate idempotency, two-sided XP) via automated tests

## Docs & rules updated
- [x] `docs/BACKEND-SCHEMA.md` (schema / payload / JSON keys)

## Screenshots / notes
Backend-only PR; mobile UI changes are in the companion `kolabing-app` PR (`feat/kolab-star-review`).