### PR TITLE
feat(reviews): admin visibility and moderation for Kolab reviews

### DIFF
--- a/app/Http/Controllers/Admin/ReviewController.php
+++ b/app/Http/Controllers/Admin/ReviewController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\CollaborationReview;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ReviewController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $reviews = CollaborationReview::query()
+            ->with([
+                'collaboration.kolab',
+                'reviewerProfile',
+                'reviewed',
+            ])
+            ->when($request->filled('reviewer_role'), fn ($q) => $q->where('reviewer_role', $request->string('reviewer_role')))
+            ->latest()
+            ->paginate(25)
+            ->withQueryString();
+
+        return view('admin.reviews.index', [
+            'reviews' => $reviews,
+            'filters' => [
+                'reviewer_role' => (string) $request->string('reviewer_role'),
+            ],
+        ]);
+    }
+
+    public function toggleComment(CollaborationReview $review): RedirectResponse
+    {
+        $review->update(['public_comment_visible' => ! $review->public_comment_visible]);
+
+        return redirect()->route('admin.reviews.index')
+            ->with('status', $review->public_comment_visible ? 'Comment unhidden.' : 'Comment hidden from public view.');
+    }
+}

--- a/app/Http/Resources/Api/V1/PublicProfileReviewResource.php
+++ b/app/Http/Resources/Api/V1/PublicProfileReviewResource.php
@@ -29,7 +29,7 @@ class PublicProfileReviewResource extends JsonResource
             'rating' => $this->rating,
             'overall_rating' => $this->overall_rating,
             'body' => $this->body ?? $this->note,
-            'public_comment' => $this->public_comment,
+            'public_comment' => $this->public_comment_visible ? $this->public_comment : null,
             'would_collaborate_again' => $this->would_collaborate_again,
             'created_at' => $this->created_at?->toIso8601String(),
             'reviewer' => [

--- a/app/Models/CollaborationReview.php
+++ b/app/Models/CollaborationReview.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $note
  * @property string|null $body
  * @property string|null $public_comment
+ * @property bool $public_comment_visible
  * @property bool|null $would_collaborate_again
  * @property-read float|null $overall_rating
  * @property \Illuminate\Support\Carbon|null $created_at
@@ -68,6 +69,7 @@ class CollaborationReview extends Model
         'note',
         'body',
         'public_comment',
+        'public_comment_visible',
         'would_collaborate_again',
     ];
 
@@ -84,6 +86,7 @@ class CollaborationReview extends Model
             'value_rating' => 'integer',
             'repeat_rating' => 'integer',
             'would_collaborate_again' => 'boolean',
+            'public_comment_visible' => 'boolean',
         ];
     }
 

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -332,6 +332,12 @@ return [
             'icon' => 'fas fa-fw fa-handshake',
             'active' => ['admin/kolabs', 'admin/kolabs/*'],
         ],
+        [
+            'text' => 'Reviews',
+            'route' => 'admin.reviews.index',
+            'icon' => 'fas fa-fw fa-star',
+            'active' => ['admin/reviews', 'admin/reviews/*'],
+        ],
         ['header' => 'INSIGHTS'],
         [
             'text' => 'Statistics',

--- a/database/migrations/2026_06_30_000001_add_public_comment_visible_to_collaboration_reviews_table.php
+++ b/database/migrations/2026_06_30_000001_add_public_comment_visible_to_collaboration_reviews_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('collaboration_reviews', function (Blueprint $table): void {
+            $table->boolean('public_comment_visible')->default(true)->after('public_comment');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('collaboration_reviews', function (Blueprint $table): void {
+            $table->dropColumn('public_comment_visible');
+        });
+    }
+};

--- a/resources/views/admin/reviews/index.blade.php
+++ b/resources/views/admin/reviews/index.blade.php
@@ -1,0 +1,83 @@
+@extends('admin.layout', ['title' => 'Reviews'])
+
+@section('page_title', 'Kolab reviews')
+@section('page_subtitle', 'Submitted 5-star Kolab reviews — view ratings and moderate public comments.')
+
+@section('admin_content')
+    <form method="GET" class="form-inline mb-3">
+        <select name="reviewer_role" class="form-control form-control-sm mr-2" onchange="this.form.submit()">
+            <option value="">All reviewer roles</option>
+            <option value="business" {{ $filters['reviewer_role'] === 'business' ? 'selected' : '' }}>Business</option>
+            <option value="community" {{ $filters['reviewer_role'] === 'community' ? 'selected' : '' }}>Community</option>
+        </select>
+    </form>
+
+    <div class="card">
+        <div class="card-body p-0">
+            <table class="table table-hover table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>Kolab</th>
+                        <th>Reviewer</th>
+                        <th>Reviewed</th>
+                        <th class="text-center">Comm.</th>
+                        <th class="text-center">Reliab.</th>
+                        <th class="text-center">Fit</th>
+                        <th class="text-center">Value</th>
+                        <th class="text-center">Repeat</th>
+                        <th class="text-center">Overall</th>
+                        <th>Public comment</th>
+                        <th>Created</th>
+                        <th class="text-right pr-3">Action</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse ($reviews as $review)
+                        <tr>
+                            <td>
+                                {{ $review->collaboration?->kolab?->title ?? 'Collab #'.$review->collaboration_id }}
+                            </td>
+                            <td>
+                                {{ $review->reviewerProfile?->getExtendedProfile()?->name ?? '—' }}
+                                <span class="badge badge-secondary">{{ $review->reviewer_role }}</span>
+                            </td>
+                            <td>
+                                {{ $review->reviewed?->getExtendedProfile()?->name ?? '—' }}
+                            </td>
+                            <td class="text-center">{{ $review->communication_rating ?? '—' }}</td>
+                            <td class="text-center">{{ $review->reliability_rating ?? '—' }}</td>
+                            <td class="text-center">{{ $review->fit_rating ?? '—' }}</td>
+                            <td class="text-center">{{ $review->value_rating ?? '—' }}</td>
+                            <td class="text-center">{{ $review->repeat_rating ?? '—' }}</td>
+                            <td class="text-center font-weight-bold">{{ $review->overall_rating ?? '—' }}</td>
+                            <td style="max-width:280px">
+                                @if ($review->public_comment)
+                                    <div class="text-truncate" title="{{ $review->public_comment }}">{{ $review->public_comment }}</div>
+                                @else
+                                    <span class="text-muted">—</span>
+                                @endif
+                            </td>
+                            <td class="text-nowrap">{{ $review->created_at?->format('Y-m-d H:i') }}</td>
+                            <td class="text-right pr-3 text-nowrap">
+                                @if ($review->public_comment)
+                                    <form method="POST" action="{{ route('admin.reviews.toggle-comment', $review) }}" class="d-inline">
+                                        @csrf
+                                        <button class="btn btn-sm {{ $review->public_comment_visible ? 'btn-success' : 'btn-outline-secondary' }}">
+                                            {{ $review->public_comment_visible ? 'Visible' : 'Hidden' }}
+                                        </button>
+                                    </form>
+                                @else
+                                    <span class="text-muted">No comment</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="12" class="text-center text-muted py-4">No reviews yet.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="mt-3">{{ $reviews->links() }}</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\Admin\KolabController as AdminKolabController;
 use App\Http\Controllers\Admin\ManagedUserController;
 use App\Http\Controllers\Admin\OfferOptionController as AdminOfferOptionController;
 use App\Http\Controllers\Admin\PartnerRewardController as AdminPartnerRewardController;
+use App\Http\Controllers\Admin\ReviewController as AdminReviewController;
 use App\Http\Controllers\Admin\RewardEconomicsController as AdminRewardEconomicsController;
 use App\Http\Controllers\Admin\StatsController as AdminStatsController;
 use App\Http\Controllers\Admin\TaskController as AdminTaskController;
@@ -58,6 +59,9 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
     Route::post('/kolabs/{kolab}/collaboration/complete', [AdminKolabController::class, 'completeCollaboration'])->name('kolabs.collaboration.complete');
 
     Route::get('/stats', [AdminStatsController::class, 'index'])->name('stats.index');
+
+    Route::get('/reviews', [AdminReviewController::class, 'index'])->name('reviews.index');
+    Route::post('/reviews/{review}/toggle-comment', [AdminReviewController::class, 'toggleComment'])->name('reviews.toggle-comment');
 
     // CRM (businesses / communities / ambassadors) + Tasks
     Route::get('/crm', [AdminCrmController::class, 'index'])->name('crm.index');

--- a/tests/Feature/Admin/ReviewModerationTest.php
+++ b/tests/Feature/Admin/ReviewModerationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\ApplicationStatus;
+use App\Models\Application;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class ReviewModerationTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    private function collaborationWithReview(array $reviewOverrides = []): CollaborationReview
+    {
+        $kolab = Kolab::factory()->published()->create(['title' => 'Beach Cleanup Kolab']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'status' => ApplicationStatus::Accepted,
+        ]);
+        $collaboration = Collaboration::factory()->completed()->create([
+            'kolab_id' => $kolab->id,
+            'application_id' => $application->id,
+        ]);
+
+        return CollaborationReview::factory()->create(array_merge([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => Profile::factory()->business(),
+            'reviewed_profile_id' => Profile::factory()->community(),
+            'reviewer_role' => 'business',
+            'communication_rating' => 5,
+            'reliability_rating' => 4,
+            'fit_rating' => 5,
+            'value_rating' => 4,
+            'repeat_rating' => 5,
+            'public_comment' => 'Great Kolab partner, would work with again!',
+        ], $reviewOverrides));
+    }
+
+    public function test_maintainer_sees_review_list_with_ratings_and_comment(): void
+    {
+        $this->collaborationWithReview();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.reviews.index'))
+            ->assertOk()
+            ->assertSee('Beach Cleanup Kolab')
+            ->assertSee('Great Kolab partner, would work with again!')
+            ->assertSee('4.6'); // overall_rating average of 5,4,5,4,5
+    }
+
+    public function test_non_maintainer_cannot_access_review_list(): void
+    {
+        $this->collaborationWithReview();
+        $nonMaintainer = User::factory()->create(['is_maintainer' => false]);
+
+        $this->actingAs($nonMaintainer, 'admin')
+            ->get(route('admin.reviews.index'))
+            ->assertForbidden();
+    }
+
+    public function test_maintainer_can_hide_public_comment(): void
+    {
+        $review = $this->collaborationWithReview();
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.reviews.toggle-comment', $review))
+            ->assertRedirect();
+
+        $this->assertFalse($review->fresh()->public_comment_visible);
+    }
+
+    public function test_maintainer_can_unhide_public_comment(): void
+    {
+        $review = $this->collaborationWithReview(['public_comment_visible' => false]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.reviews.toggle-comment', $review))
+            ->assertRedirect();
+
+        $this->assertTrue($review->fresh()->public_comment_visible);
+    }
+
+    public function test_hiding_public_comment_does_not_change_ratings(): void
+    {
+        $review = $this->collaborationWithReview();
+        $overallBefore = $review->overall_rating;
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.reviews.toggle-comment', $review));
+
+        $review->refresh();
+        $this->assertSame(5, $review->communication_rating);
+        $this->assertSame(4, $review->reliability_rating);
+        $this->assertSame(5, $review->fit_rating);
+        $this->assertSame(4, $review->value_rating);
+        $this->assertSame(5, $review->repeat_rating);
+        $this->assertSame($overallBefore, $review->fresh()->overall_rating);
+        $this->assertSame('Great Kolab partner, would work with again!', $review->public_comment);
+    }
+
+    public function test_hidden_comment_remains_visible_in_admin_list(): void
+    {
+        $review = $this->collaborationWithReview(['public_comment_visible' => false]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.reviews.index'))
+            ->assertOk()
+            ->assertSee('Great Kolab partner, would work with again!')
+            ->assertSee('Hidden');
+    }
+}

--- a/tests/Feature/Api/V1/CollaborationReviewTest.php
+++ b/tests/Feature/Api/V1/CollaborationReviewTest.php
@@ -278,4 +278,54 @@ class CollaborationReviewTest extends TestCase
         // to reach/stay in that state.
         $this->assertSame('completed', $collaboration->status->value ?? $collaboration->status);
     }
+
+    public function test_hidden_public_comment_is_not_exposed_on_public_profile(): void
+    {
+        [$collaboration, $business, $community] = $this->makeCollaboration();
+
+        CollaborationReview::factory()->create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewed_profile_id' => $community->id,
+            'reviewer_role' => 'creator',
+            'public_comment' => 'This should be hidden',
+            'public_comment_visible' => false,
+            'communication_rating' => 5,
+            'reliability_rating' => 5,
+            'fit_rating' => 5,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+        ]);
+
+        $response = $this->actingAs($business)
+            ->getJson("/api/v1/profiles/{$community->id}/reviews");
+
+        $response->assertOk();
+        $this->assertNull($response->json('data.0.public_comment'));
+    }
+
+    public function test_visible_public_comment_is_exposed_on_public_profile(): void
+    {
+        [$collaboration, $business, $community] = $this->makeCollaboration();
+
+        CollaborationReview::factory()->create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewed_profile_id' => $community->id,
+            'reviewer_role' => 'creator',
+            'public_comment' => 'This should be visible',
+            'public_comment_visible' => true,
+            'communication_rating' => 5,
+            'reliability_rating' => 5,
+            'fit_rating' => 5,
+            'value_rating' => 5,
+            'repeat_rating' => 5,
+        ]);
+
+        $response = $this->actingAs($business)
+            ->getJson("/api/v1/profiles/{$community->id}/reviews");
+
+        $response->assertOk();
+        $this->assertSame('This should be visible', $response->json('data.0.public_comment'));
+    }
 }


### PR DESCRIPTION
## Summary
Adds an admin-only `/admin/reviews` page where maintainers can view all submitted Kolab reviews (ratings + comments) and hide/unhide each review's public comment, without affecting star ratings or deleting any data.

## Linked tracking item
Closes #66

## Type of change
- [x] ✨ Feature

## Changes
- Migration: add `public_comment_visible` boolean column (`default(true)`) to `collaboration_reviews`, additive and reversible.
- `CollaborationReview` model: expose `public_comment_visible` via `$fillable` and `casts()`.
- New `Admin\ReviewController` (`index`, `toggleComment`) gated by the existing `auth:admin` + `maintainer` middleware, following the `OfferOptionController`/`KolabController` patterns — paginated list, single-button POST toggle, no JS required for the toggle action.
- New routes `admin.reviews.index` (`GET /admin/reviews`) and `admin.reviews.toggle-comment` (`POST /admin/reviews/{review}/toggle-comment`); new sidebar nav entry.
- New Blade view `resources/views/admin/reviews/index.blade.php` showing collaboration/kolab title, reviewer/reviewed profile, reviewer role, all 5 star ratings, overall_rating, public_comment, created_at, and a Visible/Hidden toggle button.
- `PublicProfileReviewResource`: `public_comment` now returns `null` when `public_comment_visible` is `false` — this is the only resource serving reviews to a non-participant audience (`GET /profiles/{id}/reviews` and `PublicProfileResource::recent_reviews`). `CollaborationResource` is intentionally untouched — it's viewer-scoped to the two collaboration participants only, confirmed via `CollaborationPolicy::view` (`isParticipant`) and scoped `index` queries, so it's not "public-facing."
- New tests: `tests/Feature/Admin/ReviewModerationTest.php` (6 tests — list view, non-maintainer forbidden, hide, unhide, ratings unaffected by hide, hidden comment still visible/marked in admin) and 2 new tests in `tests/Feature/Api/V1/CollaborationReviewTest.php` (hidden comment → null on public profile, visible comment → passthrough).

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — confirmed by reading `kolabing-app`'s `lib/features/profile/models/public_profile.dart`: `PublicProfileReview` only parses the `body` field from the API response; it does not read `public_comment` at all. Hiding `public_comment` server-side therefore has zero mobile UI impact today.

## Database / migrations
- [x] Includes migrations — additive & reversible

**Migration notes:** Adds one nullable-false boolean column with `default(true)`, positioned after `public_comment`. Existing rows default to visible (no review starts hidden). `down()` drops the column cleanly.

## Testing
- [x] `php artisan test` passes — 1273 tests, 6144 assertions (`php -d memory_limit=-1 vendor/bin/phpunit`)
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (migration run, model cast verified via tinker, XP config confirmed via tinker — see below)

**XP configuration status:** Confirmed both `ReviewPosted` ("Post a review") and `CollaborationCompletionConfirmed` ("Confirm Kolab completion") are already seeded `XpEarnRule` rows, fully editable via the existing `/admin/gamification/earn-rules` admin surface. No new XP admin work was needed for this PR.

**Review label audit:** The 5 star-rating labels (communication/reliability/fit/value/repeat) are hardcoded only in `StoreCollaborationReviewRequest`'s validation `messages()` (lines 61-65) — no admin-editable label store exists. Building one (a new config table, similar to `XpEarnRule.label`) is out of scope for this PR per the spec; flagged here as a known follow-up if ever needed.

## Docs & rules updated
- [x] No docs impact

## Screenshots / notes
**Intentionally not implemented (per spec):** dynamic review label editor/admin-editable labels, public reputation weighting, fake-review scoring, admin dashboard redesign, any change to the completion-confirmation flow or 5-star review structure, removal of legacy `rating`/`body`/`note` compatibility.

**Manual QA suggested before/after merge:** pagination behavior with >25 reviews; visual check of the Visible/Hidden toggle button (green "Visible" = click to hide, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)