### PR TITLE
perf(rewards-overview): eliminate per-community N+1

### DIFF
--- a/app/Http/Controllers/Api/V1/CommunityController.php
+++ b/app/Http/Controllers/Api/V1/CommunityController.php
@@ -6,7 +6,6 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Enums\CommunityMemberStatus;
 use App\Enums\JoinPolicy;
-use App\Enums\JoinRequestStatus;
 use App\Exceptions\CommunityLimitReachedException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CommunityOnboardingRequest;
@@ -17,11 +16,9 @@ use App\Http\Resources\Api\V1\CommunityMemberResource;
 use App\Http\Resources\Api\V1\CommunityResource;
 use App\Http\Resources\Api\V1\CommunityTierResource;
 use App\Models\Community;
-use App\Models\CommunityJoinRequest;
-use App\Models\CommunityMember;
-use App\Models\CommunityPoints;
 use App\Models\Profile;
 use App\Services\CommunityMemberService;
+use App\Services\CommunityMembershipHydrator;
 use App\Services\CommunityService;
 use DomainException;
 use Illuminate\Http\JsonResponse;
@@ -33,6 +30,7 @@ class CommunityController extends Controller
     public function __construct(
         private readonly CommunityService $communityService,
         private readonly CommunityMemberService $memberService,
+        private readonly CommunityMembershipHydrator $membershipHydrator,
     ) {}
 
     /**
@@ -206,7 +204,7 @@ class CommunityController extends Controller
             ->with(['community', 'tier'])
             ->get();
 
-        $this->hydrateMembershipCommunities($profile, $memberships);
+        $this->membershipHydrator->hydrate($profile, $memberships);
 
         $data = $memberships->map(fn ($member) => [
             'community' => new CommunityResource($member->community),
@@ -220,70 +218,6 @@ class CommunityController extends Controller
             'success' => true,
             'data' => $data,
         ]);
-    }
-
-    /**
-     * Bulk-resolve the viewer-scoped fields CommunityResource would otherwise
-     * query once per community (member count, points, tier, join-request status)
-     * and stash them as transient attributes. This turns the memberships list
-     * from ~5 queries per community into a constant handful (PHP-LARAVEL-7).
-     *
-     * @param  \Illuminate\Support\Collection<int, CommunityMember>  $memberships
-     */
-    private function hydrateMembershipCommunities(Profile $profile, $memberships): void
-    {
-        $communityIds = $memberships->pluck('community')->filter()->pluck('id')->all();
-
-        if ($communityIds === []) {
-            return;
-        }
-
-        $memberCounts = CommunityMember::query()
-            ->whereIn('community_id', $communityIds)
-            ->where('status', CommunityMemberStatus::Active->value)
-            ->selectRaw('community_id, count(*) as aggregate')
-            ->groupBy('community_id')
-            ->pluck('aggregate', 'community_id');
-
-        $points = CommunityPoints::query()
-            ->whereIn('community_id', $communityIds)
-            ->where('profile_id', $profile->id)
-            ->pluck('points', 'community_id');
-
-        $joinStatuses = CommunityJoinRequest::query()
-            ->whereIn('community_id', $communityIds)
-            ->where('profile_id', $profile->id)
-            ->orderByDesc('created_at')
-            ->get(['community_id', 'status'])
-            ->groupBy('community_id')
-            ->map(static function ($requests): ?string {
-                $status = $requests->first()->status;
-
-                if ($status === null) {
-                    return null;
-                }
-
-                return $status instanceof JoinRequestStatus ? $status->value : (string) $status;
-            });
-
-        foreach ($memberships as $member) {
-            $community = $member->community;
-            if ($community === null) {
-                continue;
-            }
-
-            $community->setAttribute('member_count', (int) ($memberCounts[$community->id] ?? 0));
-            // Every row in this list is the viewer's own ACTIVE membership.
-            $community->setAttribute('viewer_is_member', true);
-            $community->setAttribute('viewer_join_request_status', $joinStatuses[$community->id] ?? null);
-            $community->setAttribute('viewer_points', (int) ($points[$community->id] ?? 0));
-            $community->setAttribute('viewer_tier', $member->tier ? [
-                'id' => $member->tier->id,
-                'name' => $member->tier->name,
-                'color' => $member->tier->color,
-                'rank' => $member->tier->rank,
-            ] : null);
-        }
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/MeRewardsOverviewController.php
+++ b/app/Http/Controllers/Api/V1/MeRewardsOverviewController.php
@@ -11,14 +11,15 @@ use App\Http\Resources\Api\V1\CommunityRewardResource;
 use App\Http\Resources\Api\V1\PartnerRewardResource;
 use App\Models\PartnerReward;
 use App\Models\Profile;
-use App\Services\CommunityPointsService;
+use App\Services\CommunityMembershipHydrator;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class MeRewardsOverviewController extends Controller
 {
     public function __construct(
-        private readonly CommunityPointsService $pointsService,
+        private readonly CommunityMembershipHydrator $membershipHydrator,
     ) {}
 
     /**
@@ -43,19 +44,27 @@ class MeRewardsOverviewController extends Controller
 
         $memberships = $profile->communityMemberships()
             ->where('status', CommunityMemberStatus::Active->value)
-            ->with('community')
+            ->with([
+                'tier',
+                'community.communityProfile',
+                'community.rewards' => function (Builder $query): void {
+                    $query->where('is_active', true)->orderBy('cost_points');
+                },
+            ])
             ->get();
+
+        // Bulk-resolve the viewer-scoped CommunityResource fields (member count,
+        // points, tier, …) once, and reuse the returned points map for the
+        // per-community balance + reward affordability — no per-community N+1.
+        $balances = $this->membershipHydrator->hydrate($profile, $memberships);
 
         $communities = $memberships
             ->filter(fn ($m) => $m->community !== null)
-            ->map(function ($membership) use ($profile): array {
+            ->map(function ($membership) use ($balances): array {
                 $community = $membership->community;
-                $myPoints = $this->pointsService->balance($community, $profile->id);
+                $myPoints = $balances[$community->id] ?? 0;
 
-                $rewards = $community->rewards()
-                    ->where('is_active', true)
-                    ->orderBy('cost_points')
-                    ->get()
+                $rewards = $community->rewards
                     ->map(function ($reward) use ($myPoints): mixed {
                         $inStock = $reward->stock === null || $reward->stock > 0;
                         $reward->setAttribute('affordable', $myPoints >= $reward->cost_points && $inStock);

--- a/app/Services/CommunityMembershipHydrator.php
+++ b/app/Services/CommunityMembershipHydrator.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\JoinRequestStatus;
+use App\Models\CommunityJoinRequest;
+use App\Models\CommunityMember;
+use App\Models\CommunityPoints;
+use App\Models\Profile;
+use Illuminate\Support\Collection;
+
+class CommunityMembershipHydrator
+{
+    /**
+     * Bulk-resolve the viewer-scoped fields CommunityResource would otherwise
+     * query once per community (member count, points, tier, join-request status,
+     * is-member) and stash them as transient attributes on each community model.
+     * This turns membership-backed lists from ~5 queries per community into a
+     * constant handful (PHP-LARAVEL-7).
+     *
+     * Each membership must have its `community` (and `tier`, when set) loaded.
+     * Returns the per-community points map (community_id => points) so callers
+     * that also need the raw balances (e.g. reward affordability) can reuse it
+     * without a second query.
+     *
+     * @param  Collection<int, CommunityMember>  $memberships
+     * @return array<string, int>
+     */
+    public function hydrate(Profile $profile, Collection $memberships): array
+    {
+        $communityIds = $memberships->pluck('community')->filter()->pluck('id')->all();
+
+        if ($communityIds === []) {
+            return [];
+        }
+
+        $memberCounts = CommunityMember::query()
+            ->whereIn('community_id', $communityIds)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->selectRaw('community_id, count(*) as aggregate')
+            ->groupBy('community_id')
+            ->pluck('aggregate', 'community_id');
+
+        $points = CommunityPoints::query()
+            ->whereIn('community_id', $communityIds)
+            ->where('profile_id', $profile->id)
+            ->pluck('points', 'community_id');
+
+        $joinStatuses = CommunityJoinRequest::query()
+            ->whereIn('community_id', $communityIds)
+            ->where('profile_id', $profile->id)
+            ->orderByDesc('created_at')
+            ->get(['community_id', 'status'])
+            ->groupBy('community_id')
+            ->map(static function ($requests): ?string {
+                $status = $requests->first()->status;
+
+                if ($status === null) {
+                    return null;
+                }
+
+                return $status instanceof JoinRequestStatus ? $status->value : (string) $status;
+            });
+
+        foreach ($memberships as $member) {
+            $community = $member->community;
+            if ($community === null) {
+                continue;
+            }
+
+            $community->setAttribute('member_count', (int) ($memberCounts[$community->id] ?? 0));
+            // Every row in a membership list is the viewer's own ACTIVE membership.
+            $community->setAttribute('viewer_is_member', true);
+            $community->setAttribute('viewer_join_request_status', $joinStatuses[$community->id] ?? null);
+            $community->setAttribute('viewer_points', (int) ($points[$community->id] ?? 0));
+            $community->setAttribute('viewer_tier', $member->tier ? [
+                'id' => $member->tier->id,
+                'name' => $member->tier->name,
+                'color' => $member->tier->color,
+                'rank' => $member->tier->rank,
+            ] : null);
+        }
+
+        return $points->mapWithKeys(static fn ($value, $communityId): array => [
+            (string) $communityId => (int) $value,
+        ])->all();
+    }
+}

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-12 (profile reputation cache — §12)
+**Last updated:** 2026-07-12 (rewards-overview N+1 — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -262,7 +262,7 @@ From [docs/ROLES-BACKEND-DB-MAP.md](ROLES-BACKEND-DB-MAP.md) §8 — still-open 
 - [ ] Leaderboards (`getCommunityPointsLeaderboard`, global) hydrate all members then sort in PHP → move ranking + LIMIT into SQL. Owner: **backend**.
 - [x] `PublicProfileResource` runs ~7 uncached queries per profile view (reputation window fn + double `completed_kolabs_count`) → cache or denormalise `reputation` / `completed_kolabs_count` onto `profiles`. **Shipped 2026-07-12 (#76):** `ProfileService::getReputationSummary()` cached per profile (`profile:reputation:{id}`, 24h backstop TTL) and busted by `CollaborationReviewObserver` (reviews received) + `CollaborationObserver` (completed-status changes) so it is always fresh; the duplicate `completed_kolabs_count` COUNT removed (resource reads it from the single cached summary). Owner: **backend**.
 - [ ] `/me/dashboard` fires 4–5 live aggregate queries uncached → short-TTL cache. Owner: **backend**.
-- [ ] `/me/rewards-overview` N+1 (2 queries per active membership) → batch with `whereIn`. Owner: **backend**.
+- [x] `/me/rewards-overview` N+1 (2 queries per active membership) → batch with `whereIn`. **Shipped 2026-07-12 (#78):** extracted `CommunityMembershipHydrator` (shared with `/me/memberships`) to bulk-resolve the viewer-scoped `CommunityResource` fields, and eager-loaded `community.rewards` + `community.communityProfile`; reward affordability reuses the hydrator's points map. Query count is now constant regardless of membership count. Owner: **backend**.
 
 **P2 — 100k+ scale:**
 - [ ] Event discovery Haversine (Postgres path) full-scans and recomputes trig per row with no bounding box → add a bounding-box prefilter or PostGIS / `cube`+GiST index. Owner: **backend**.

--- a/tests/Feature/Api/V1/MeRewardsOverviewNPlusOneTest.php
+++ b/tests/Feature/Api/V1/MeRewardsOverviewNPlusOneTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\AttendeeProfile;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\CommunityPoints;
+use App\Models\CommunityReward;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MeRewardsOverviewNPlusOneTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function attendee(): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        AttendeeProfile::factory()->create(['profile_id' => $profile->id]);
+
+        return $profile;
+    }
+
+    /**
+     * @return array{0: Community, 1: CommunityReward}
+     */
+    private function joinedCommunityWithReward(Profile $member, int $points, int $rewardCost): array
+    {
+        $community = Community::factory()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $member->id,
+            'joined_at' => now()->subDays(10),
+        ]);
+        CommunityPoints::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $member->id,
+            'points' => $points,
+        ]);
+        $reward = CommunityReward::factory()->forCommunity($community)->create([
+            'is_active' => true,
+            'cost_points' => $rewardCost,
+        ]);
+
+        return [$community, $reward];
+    }
+
+    public function test_rewards_overview_query_count_does_not_grow_with_community_count(): void
+    {
+        // Baseline: a member in a single community.
+        $member1 = $this->attendee();
+        $this->joinedCommunityWithReward($member1, 100, 50);
+
+        // Scaled: a member in four communities, each with points + a reward.
+        $member2 = $this->attendee();
+        for ($i = 0; $i < 4; $i++) {
+            $this->joinedCommunityWithReward($member2, 100, 50);
+        }
+
+        DB::enableQueryLog();
+
+        DB::flushQueryLog();
+        $this->actingAs($member1)->getJson('/api/v1/me/rewards-overview')->assertOk();
+        $baseline = count(DB::getQueryLog());
+
+        DB::flushQueryLog();
+        $this->actingAs($member2)->getJson('/api/v1/me/rewards-overview')->assertOk();
+        $scaled = count(DB::getQueryLog());
+
+        DB::disableQueryLog();
+
+        $this->assertSame(
+            $baseline,
+            $scaled,
+            "Query count must be constant regardless of community count (1 community: {$baseline}, 4 communities: {$scaled}) — no per-community N+1."
+        );
+    }
+
+    public function test_rewards_overview_returns_correct_points_and_affordability_per_community(): void
+    {
+        $member = $this->attendee();
+        [$richCommunity, $affordableReward] = $this->joinedCommunityWithReward($member, 100, 50);
+        [$poorCommunity, $tooExpensiveReward] = $this->joinedCommunityWithReward($member, 10, 500);
+
+        $response = $this->actingAs($member)
+            ->getJson('/api/v1/me/rewards-overview')
+            ->assertOk();
+
+        $communities = collect($response->json('data.communities'));
+        $this->assertCount(2, $communities);
+
+        $rich = $communities->firstWhere('community.id', $richCommunity->id);
+        $poor = $communities->firstWhere('community.id', $poorCommunity->id);
+
+        $this->assertSame(100, $rich['my_points']);
+        $this->assertSame(10, $poor['my_points']);
+
+        $this->assertTrue($rich['rewards'][0]['affordable'], 'Reward within balance must be affordable.');
+        $this->assertFalse($poor['rewards'][0]['affordable'], 'Reward above balance must not be affordable.');
+    }
+}


### PR DESCRIPTION
> **Stacked on #77 → #75 → #73.** Base is `perf/profile-reputation-cache`; GitHub retargets to `master` as ancestors merge. Merge order: #73 → #75 → #77 → this.

## Summary
`GET /me/rewards-overview` fired per-community queries that scaled with membership count — the audit's `/me/rewards-overview` N+1 item. Now a constant number of queries regardless of how many communities the viewer belongs to, with identical response shape and values.

## Linked tracking item
Closes #78

## Type of change
- [x] 🐛 Bug fix
- [x] ♻️ Refactor
- [x] 🧪 Tests
- [ ] ⚠️ Breaking change

## Changes
- **New `CommunityMembershipHydrator` service** — the viewer-scoped bulk-resolution logic (`member_count`, `viewer_is_member`, join status, `viewer_points`, `viewer_tier`) extracted **verbatim** from `CommunityController::hydrateMembershipCommunities`. Now returns the per-community points map so callers can reuse balances. `CommunityController::myMemberships` calls the service (private method + 3 now-dead imports removed) — byte-identical behaviour.
- **`MeRewardsOverviewController::show`** — eager-loads `community.communityProfile` + `community.rewards` (active, ordered by `cost_points`) and `tier`, calls the hydrator once, and computes reward affordability from the returned points map. Removes the per-community `balance()` call and the per-community `rewards()` query.
- The N+1 was **two layers**: the controller's own points+rewards loops *and* `CommunityResource`'s 5 per-row viewer-scoped lookups + `communityProfile`. Both are now bulk-resolved.
- New `MeRewardsOverviewNPlusOneTest`: (1) query count is identical for a 1-community vs 4-community member (constant), and (2) per-community `my_points` + reward `affordable` remain correct.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — response shape and values are byte-identical; only the query pattern changed.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A.

## Testing
- [x] `php artisan test` passes — paste counts: **1305 passed (6244 assertions)** (was 1303; +2 new)
- [x] `vendor/bin/pint` clean
- [x] Manually verified: `MembershipsListTest` stays green (the extraction is behaviour-preserving), and the constant-query-count assertion proves the CommunityResource per-row lookups are gone too.

## Docs & rules updated
- [x] `BACKLOG.md` — §12 rewards-overview item ticked (shipped 2026-07-12, #78), date bumped
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [x] No docs impact (role behaviour) — internal hydration refactor; the community-members/tiers surface behaviour and output are unchanged, and no ROLES doc referenced the extracted method
- [ ] `docs/BACKEND-SCHEMA.md`

## Screenshots / notes
- **DRY win:** `/me/memberships` and `/me/rewards-overview` now share one hydration path, so future viewer-scoped community fields only need wiring once.
- **Cross-repo sync:** the BACKLOG §12 tick should be mirrored in `kolabing-app`.