### PR TITLE
perf: fix four N+1s found by query-audit sweep

### DIFF
--- a/app/Http/Controllers/Api/V1/CommunityRewardsHubController.php
+++ b/app/Http/Controllers/Api/V1/CommunityRewardsHubController.php
@@ -51,14 +51,15 @@ class CommunityRewardsHubController extends Controller
             ->pluck('community_badge_id')
             ->all();
 
-        $goals = $community->goals()->where('is_active', true)->orderByDesc('created_at')->get()
-            ->map(function ($goal) use ($community, $profile): mixed {
-                $progress = $this->pointsService->goalProgress($community, $profile->id, $goal);
-                $goal->setAttribute('progress', $progress);
-                $goal->setAttribute('completed', $progress >= $goal->target);
+        $goalRows = $community->goals()->where('is_active', true)->orderByDesc('created_at')->get();
+        $progressByGoal = $this->pointsService->goalProgressForMany($community, $profile->id, $goalRows);
+        $goals = $goalRows->map(function ($goal) use ($progressByGoal): mixed {
+            $progress = $progressByGoal[$goal->id] ?? 0;
+            $goal->setAttribute('progress', $progress);
+            $goal->setAttribute('completed', $progress >= $goal->target);
 
-                return $goal;
-            });
+            return $goal;
+        });
 
         $badges = $community->badges()->where('is_active', true)->orderByDesc('created_at')->get()
             ->map(function ($badge) use ($earnedBadgeIds): mixed {

--- a/app/Http/Resources/Api/V1/CollaborationResource.php
+++ b/app/Http/Resources/Api/V1/CollaborationResource.php
@@ -37,6 +37,14 @@ class CollaborationResource extends JsonResource
     private ?array $pendingCompletionMemo = null;
 
     /**
+     * Per-instance memo of the review rows for the has_reviewed check, used
+     * only on the fallback (un-eager-loaded) path.
+     *
+     * @var \Illuminate\Support\Collection<int, CollaborationReview>|null
+     */
+    private ?\Illuminate\Support\Collection $reviewRowsMemo = null;
+
+    /**
      * Indicates if the resource should include application details.
      */
     protected bool $includeApplication = true;
@@ -180,10 +188,7 @@ class CollaborationResource extends JsonResource
             ]),
             'has_reviewed' => $this->when(
                 $currentProfile !== null && $this->isCompleted(),
-                fn () => CollaborationReview::query()
-                    ->where('collaboration_id', $this->id)
-                    ->where('reviewer_profile_id', $currentProfile->id)
-                    ->exists()
+                fn () => $this->hasReviewedBy($currentProfile->id)
             ),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
@@ -368,6 +373,24 @@ class CollaborationResource extends JsonResource
         return $this->completionRowsMemo ??= CollaborationCompletion::query()
             ->where('collaboration_id', $this->id)
             ->get();
+    }
+
+    /**
+     * Whether the given profile has reviewed this collaboration. Prefers the
+     * eager-loaded `reviews` relation (so the list path fires no per-row query),
+     * falling back to a single memoized fetch when the relation is not loaded.
+     */
+    private function hasReviewedBy(string $profileId): bool
+    {
+        $reviews = $this->resource->relationLoaded('reviews')
+            ? $this->resource->reviews
+            : ($this->reviewRowsMemo ??= CollaborationReview::query()
+                ->where('collaboration_id', $this->id)
+                ->get());
+
+        return $reviews->contains(
+            fn (CollaborationReview $review): bool => $review->reviewer_profile_id === $profileId
+        );
     }
 
     /**

--- a/app/Services/CommunityPointsService.php
+++ b/app/Services/CommunityPointsService.php
@@ -16,6 +16,7 @@ use App\Models\CommunityPointLedger;
 use App\Models\CommunityPoints;
 use App\Models\Event;
 use App\Models\EventCheckin;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -193,19 +194,28 @@ class CommunityPointsService
 
         $goals = $community->goals()->where('is_active', true)->get();
 
-        foreach ($goals as $goal) {
-            $alreadyPaid = CommunityPointLedger::query()
-                ->where('community_id', $community->id)
-                ->where('profile_id', $profileId)
-                ->where('source', CommunityPointSource::GoalCompleted->value)
-                ->where('reference_id', $goal->id)
-                ->exists();
+        if ($goals->isEmpty()) {
+            return;
+        }
 
-            if ($alreadyPaid) {
+        // Bulk-resolve the two per-goal reads that were previously an N+1: which
+        // goals are already paid, and each goal's progress.
+        $paidGoalIds = CommunityPointLedger::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $profileId)
+            ->where('source', CommunityPointSource::GoalCompleted->value)
+            ->whereIn('reference_id', $goals->pluck('id'))
+            ->pluck('reference_id')
+            ->all();
+
+        $progressByGoal = $this->goalProgressForMany($community, $profileId, $goals);
+
+        foreach ($goals as $goal) {
+            if (in_array($goal->id, $paidGoalIds, true)) {
                 continue;
             }
 
-            if ($this->goalProgress($community, $profileId, $goal) >= $goal->target) {
+            if (($progressByGoal[$goal->id] ?? 0) >= $goal->target) {
                 $this->award(
                     $community,
                     $profileId,
@@ -229,6 +239,63 @@ class CommunityPointsService
             CommunityGoalEarnType::DaysInCommunity => $this->daysInCommunity($community, $profileId),
             CommunityGoalEarnType::Challenge => $this->challengeVerifiedCount($community, $profileId, $goal->challenge_id),
         };
+    }
+
+    /**
+     * Progress for many goals of one community/member, keyed by goal id. Each
+     * earn-type is resolved with a bounded number of queries regardless of how
+     * many goals use it (no per-goal N+1): the community-wide check-in count and
+     * days-in-community are computed at most once each, and Challenge goals share
+     * a single grouped count over their challenge ids. Values match goalProgress().
+     *
+     * @param  Collection<int, CommunityGoal>  $goals
+     * @return array<string, int>
+     */
+    public function goalProgressForMany(Community $community, string $profileId, Collection $goals): array
+    {
+        if ($goals->isEmpty()) {
+            return [];
+        }
+
+        $checkinCount = $goals->contains(fn (CommunityGoal $g): bool => $g->earn_type === CommunityGoalEarnType::EventCheckIns)
+            ? $this->communityCheckinCount($community, $profileId)
+            : 0;
+
+        $days = $goals->contains(fn (CommunityGoal $g): bool => $g->earn_type === CommunityGoalEarnType::DaysInCommunity)
+            ? $this->daysInCommunity($community, $profileId)
+            : 0;
+
+        $challengeGoals = $goals->filter(fn (CommunityGoal $g): bool => $g->earn_type === CommunityGoalEarnType::Challenge);
+        $challengeIds = $challengeGoals->pluck('challenge_id')->filter()->unique()->values();
+
+        $challengeCounts = $challengeIds->isEmpty()
+            ? collect()
+            : ChallengeCompletion::query()
+                ->where('challenger_profile_id', $profileId)
+                ->where('status', \App\Enums\ChallengeCompletionStatus::Verified->value)
+                ->whereIn('event_id', Event::query()->where('community_id', $community->id)->select('id'))
+                ->whereIn('challenge_id', $challengeIds)
+                ->selectRaw('challenge_id, count(*) as aggregate')
+                ->groupBy('challenge_id')
+                ->pluck('aggregate', 'challenge_id');
+
+        // A Challenge goal with a null challenge_id counts ALL verified completions
+        // in the community (matching goalProgress → challengeVerifiedCount(null)).
+        $allVerifiedCount = $challengeGoals->contains(fn (CommunityGoal $g): bool => $g->challenge_id === null)
+            ? $this->challengeVerifiedCount($community, $profileId, null)
+            : 0;
+
+        return $goals->mapWithKeys(function (CommunityGoal $goal) use ($checkinCount, $days, $challengeCounts, $allVerifiedCount): array {
+            $progress = match ($goal->earn_type) {
+                CommunityGoalEarnType::EventCheckIns => $checkinCount,
+                CommunityGoalEarnType::DaysInCommunity => $days,
+                CommunityGoalEarnType::Challenge => $goal->challenge_id === null
+                    ? $allVerifiedCount
+                    : (int) ($challengeCounts[$goal->challenge_id] ?? 0),
+            };
+
+            return [(string) $goal->id => $progress];
+        })->all();
     }
 
     private function afterEarn(Community $community, string $profileId): void

--- a/app/Services/FriendshipService.php
+++ b/app/Services/FriendshipService.php
@@ -157,6 +157,7 @@ class FriendshipService
 
         return Profile::query()
             ->whereIn('id', $friendIds)
+            ->with(['attendeeProfile', 'businessProfile', 'communityProfile'])
             ->orderByDesc('created_at')
             ->paginate($perPage);
     }
@@ -176,6 +177,7 @@ class FriendshipService
 
         return Profile::query()
             ->whereIn('id', $requesterIds)
+            ->with(['attendeeProfile', 'businessProfile', 'communityProfile'])
             ->get();
     }
 

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -27,7 +27,7 @@ class NotificationService
     {
         return Notification::query()
             ->where('profile_id', $profile->id)
-            ->with(['actorProfile.businessProfile', 'actorProfile.communityProfile'])
+            ->with(['actorProfile.businessProfile', 'actorProfile.communityProfile', 'actorProfile.attendeeProfile'])
             ->orderByDesc('created_at')
             ->paginate($perPage);
     }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-12 (rewards-overview N+1 — §12)
+**Last updated:** 2026-07-12 (query-audit N+1 sweep — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -267,6 +267,13 @@ From [docs/ROLES-BACKEND-DB-MAP.md](ROLES-BACKEND-DB-MAP.md) §8 — still-open 
 **P2 — 100k+ scale:**
 - [ ] Event discovery Haversine (Postgres path) full-scans and recomputes trig per row with no bounding box → add a bounding-box prefilter or PostGIS / `cube`+GiST index. Owner: **backend**.
 - [ ] Move cache / queue / session drivers to Redis; enable Reverb so chat unread polling is replaced by push; add a read replica for read-heavy aggregates. Owner: **infra**.
+
+**Query-audit sweep (2026-07-12, #80) — additional N+1s found & fixed:**
+- [x] `CollaborationResource::has_reviewed` fired `CollaborationReview::exists()` per row on the collaborations list → now derives from the already eager-loaded `reviews` relation (single-query fallback only when unloaded).
+- [x] `CommunityRewardsHubController` goal progress ran per-goal count queries in BOTH the response map AND `CommunityPointsService::completeGoals()` → new `goalProgressForMany()` batches all earn-types (one grouped query for challenge goals); `completeGoals` bulk-loads already-paid goal ids.
+- [x] `NotificationService::getNotifications` missed `actorProfile.attendeeProfile` → attendee-actor rows lazy-loaded per row; added to eager loads.
+- [x] `FriendshipService::friendsOf` + `incomingRequests` loaded `Profile`s with no `with()` → `FriendResource` hit extended profiles per row; added `attendeeProfile`/`businessProfile`/`communityProfile` eager loads.
+- [ ] **Open:** the collaborations list nests `KolabResource`, which fires a per-row `saved_kolabs` `is_saved` existence check and lazy-loads `kolab.creatorProfile.businessProfile`/`communityProfile` per row. Fix: eager-load `kolab.creatorProfile.businessProfile`+`communityProfile` and annotate `is_saved` on the nested kolab via a scoped `withExists`. Owner: **backend**.
 
 ---
 

--- a/tests/Feature/Api/V1/RemainingNPlusOneTest.php
+++ b/tests/Feature/Api/V1/RemainingNPlusOneTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\ChallengeCompletionStatus;
+use App\Enums\CommunityGoalEarnType;
+use App\Models\AttendeeProfile;
+use App\Models\Challenge;
+use App\Models\ChallengeCompletion;
+use App\Models\Collaboration;
+use App\Models\Community;
+use App\Models\CommunityGoal;
+use App\Models\CommunityMember;
+use App\Models\Event;
+use App\Models\Friendship;
+use App\Models\Notification;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Regression guards for the four N+1 hotspots found by the query audit:
+ * collaborations `has_reviewed`, rewards-hub goal progress, notification
+ * actor extended profiles, and friend extended profiles. Each asserts the
+ * query count stays constant regardless of row count.
+ */
+class RemainingNPlusOneTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function attendee(): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        AttendeeProfile::factory()->create(['profile_id' => $profile->id]);
+
+        return $profile;
+    }
+
+    private function countQueries(\Closure $fn): int
+    {
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+        $fn();
+        $count = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        return $count;
+    }
+
+    public function test_notifications_index_query_count_is_constant_across_attendee_actors(): void
+    {
+        $makeViewerWith = function (int $n): Profile {
+            $viewer = $this->attendee();
+            for ($i = 0; $i < $n; $i++) {
+                $actor = $this->attendee();
+                Notification::factory()->create([
+                    'profile_id' => $viewer->id,
+                    'actor_profile_id' => $actor->id,
+                ]);
+            }
+
+            return $viewer;
+        };
+
+        $one = $makeViewerWith(1);
+        $many = $makeViewerWith(3);
+
+        $baseline = $this->countQueries(fn () => $this->actingAs($one)
+            ->getJson('/api/v1/me/notifications')->assertOk());
+        $scaled = $this->countQueries(fn () => $this->actingAs($many)
+            ->getJson('/api/v1/me/notifications')->assertOk());
+
+        $this->assertSame($baseline, $scaled,
+            "Notifications index must not lazy-load the actor's extended profile per row (1 actor: {$baseline}, 3 actors: {$scaled}).");
+    }
+
+    public function test_friends_index_query_count_is_constant_across_friends(): void
+    {
+        $makeViewerWith = function (int $n): Profile {
+            $viewer = $this->attendee();
+            for ($i = 0; $i < $n; $i++) {
+                $friend = $this->attendee();
+                Friendship::factory()->accepted()->create([
+                    'requester_profile_id' => $viewer->id,
+                    'addressee_profile_id' => $friend->id,
+                ]);
+            }
+
+            return $viewer;
+        };
+
+        $one = $makeViewerWith(1);
+        $many = $makeViewerWith(3);
+
+        $baseline = $this->countQueries(fn () => $this->actingAs($one)
+            ->getJson('/api/v1/me/friends')->assertOk());
+        $scaled = $this->countQueries(fn () => $this->actingAs($many)
+            ->getJson('/api/v1/me/friends')->assertOk());
+
+        $this->assertSame($baseline, $scaled,
+            "Friends index must eager-load friend extended profiles (1 friend: {$baseline}, 3 friends: {$scaled}).");
+    }
+
+    public function test_collaborations_index_does_not_query_reviews_per_row(): void
+    {
+        $countReviewQueries = function (Profile $viewer): int {
+            $n = 0;
+            DB::listen(function ($q) use (&$n): void {
+                if (str_contains($q->sql, 'from "collaboration_reviews"')) {
+                    $n++;
+                }
+            });
+            $this->actingAs($viewer)->getJson('/api/v1/collaborations')->assertOk();
+
+            return $n;
+        };
+
+        $makeViewerWith = function (int $n): Profile {
+            $viewer = Profile::factory()->business()->create();
+            for ($i = 0; $i < $n; $i++) {
+                $partner = Profile::factory()->community()->create();
+                Collaboration::factory()->completed()
+                    ->forCreator($viewer)
+                    ->forApplicant($partner)
+                    ->create();
+            }
+
+            return $viewer;
+        };
+
+        // has_reviewed must read the eager-loaded `reviews` relation, so the
+        // number of collaboration_reviews queries stays flat as rows grow (only
+        // the single eager-load whereIn), not one exists() per row.
+        $baseline = $countReviewQueries($makeViewerWith(1));
+        $scaled = $countReviewQueries($makeViewerWith(3));
+
+        $this->assertSame($baseline, $scaled,
+            "has_reviewed must derive from the loaded reviews relation, not query per row (1 collab: {$baseline}, 3 collabs: {$scaled}).");
+    }
+
+    public function test_rewards_hub_query_count_is_constant_across_goals(): void
+    {
+        $makeMemberInCommunityWith = function (int $goals): array {
+            $member = $this->attendee();
+            $community = Community::factory()->create();
+            CommunityMember::factory()->forCommunity($community)->create([
+                'profile_id' => $member->id,
+                'joined_at' => now()->subDays(5),
+            ]);
+            for ($i = 0; $i < $goals; $i++) {
+                CommunityGoal::factory()->forCommunity($community)->create([
+                    'earn_type' => CommunityGoalEarnType::DaysInCommunity->value,
+                    'target' => 9999, // never completed → pure read path, no awards fire
+                    'is_active' => true,
+                ]);
+            }
+
+            return [$member, $community];
+        };
+
+        [$member1, $communityA] = $makeMemberInCommunityWith(1);
+        [$member2, $communityB] = $makeMemberInCommunityWith(3);
+
+        $baseline = $this->countQueries(fn () => $this->actingAs($member1)
+            ->getJson("/api/v1/communities/{$communityA->id}/rewards-hub")->assertOk());
+        $scaled = $this->countQueries(fn () => $this->actingAs($member2)
+            ->getJson("/api/v1/communities/{$communityB->id}/rewards-hub")->assertOk());
+
+        $this->assertSame($baseline, $scaled,
+            "Rewards-hub goal progress must be batched, not queried per goal (1 goal: {$baseline}, 3 goals: {$scaled}).");
+    }
+
+    public function test_rewards_hub_challenge_goal_progress_is_correct_when_batched(): void
+    {
+        $member = $this->attendee();
+        $verifier = $this->attendee();
+        $community = Community::factory()->create();
+        CommunityMember::factory()->forCommunity($community)->create([
+            'profile_id' => $member->id,
+            'joined_at' => now()->subDays(5),
+        ]);
+
+        $event = Event::factory()->forProfile($verifier)->create(['community_id' => $community->id]);
+        $challengeA = Challenge::factory()->create();
+        $challengeB = Challenge::factory()->create();
+
+        // One verified completion for challenge A only.
+        ChallengeCompletion::query()->create([
+            'challenge_id' => $challengeA->id,
+            'event_id' => $event->id,
+            'challenger_profile_id' => $member->id,
+            'verifier_profile_id' => $verifier->id,
+            'status' => ChallengeCompletionStatus::Verified->value,
+            'points_earned' => 10,
+        ]);
+
+        $goalA = CommunityGoal::factory()->forCommunity($community)->create([
+            'earn_type' => CommunityGoalEarnType::Challenge->value,
+            'challenge_id' => $challengeA->id,
+            'target' => 1,
+        ]);
+        $goalB = CommunityGoal::factory()->forCommunity($community)->create([
+            'earn_type' => CommunityGoalEarnType::Challenge->value,
+            'challenge_id' => $challengeB->id,
+            'target' => 1,
+        ]);
+
+        $goals = collect(
+            $this->actingAs($member)
+                ->getJson("/api/v1/communities/{$community->id}/rewards-hub")
+                ->assertOk()
+                ->json('data.goals')
+        );
+
+        $a = $goals->firstWhere('id', $goalA->id);
+        $b = $goals->firstWhere('id', $goalB->id);
+
+        $this->assertSame(1, $a['progress'], 'Goal tied to the completed challenge must show progress 1.');
+        $this->assertTrue($a['completed']);
+        $this->assertSame(0, $b['progress'], 'Goal tied to the other challenge must show progress 0.');
+        $this->assertFalse($b['completed']);
+    }
+}


### PR DESCRIPTION
> **Stacked on #79 → #77 → #75 → #73.** Base is `perf/rewards-overview-n-plus-one`; GitHub retargets to `master` as ancestors merge. Merge order: #73 → #75 → #77 → #79 → this.

## Summary
A fresh query-audit sweep of the whole API surface found four remaining N+1s. All four are fixed here; each fix is behaviour-preserving (identical response shape and values). One further N+1 discovered during the sweep is logged as an open follow-up rather than rushed in (see notes).

## Linked tracking item
Closes #80

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests
- [ ] ⚠️ Breaking change

## Changes
1. **`CollaborationResource::has_reviewed`** (collaborations list) — replaced the per-row `CollaborationReview::exists()` with `hasReviewedBy()`, which reads the already eager-loaded `reviews` relation (memoized single-query fallback only when the relation isn't loaded — mirrors the existing `completionRows()` pattern).
2. **Rewards-hub goal progress** — new `CommunityPointsService::goalProgressForMany()` resolves all goals with a bounded query count (community-wide check-in/days computed once; challenge goals share one grouped count; null-challenge goals match the old "count all verified" semantics). Used by both `CommunityRewardsHubController@show` and `completeGoals()` (which previously ran a per-goal `exists()` + `goalProgress()` — now bulk-loads paid goal ids and reuses the batch; per-goal *writes* for newly-completed goals are unchanged).
3. **`NotificationService::getNotifications`** — added `actorProfile.attendeeProfile` to the eager loads (attendee-actor rows were lazy-loading their extended profile per row via `NotificationResource`).
4. **`FriendshipService::friendsOf` + `incomingRequests`** — eager-load `attendeeProfile`/`businessProfile`/`communityProfile` so `FriendResource::getExtendedProfile()` doesn't query per friend.

New `RemainingNPlusOneTest` — one query-count regression guard per fix (constant queries as rows/goals grow) plus a correctness test for the batched challenge-goal progress.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — response shapes and values are byte-identical; only query patterns changed.

## Database / migrations
- [x] No schema changes

## Testing
- [x] `php artisan test` passes — paste counts: **1310 passed (6261 assertions)** (was 1305; +5 new)
- [x] `vendor/bin/pint` clean
- [x] Manually verified: `CommunityGamificationTest` (goal completion/awards), notification, friendship, and collaboration suites all stay green — the fixes preserve behaviour.

## Docs & rules updated
- [x] `BACKLOG.md` — §12 query-audit sweep sub-section added (4 fixed + 1 open), date bumped
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [x] No docs impact (role behaviour) — all four are internal query-pattern changes; outputs unchanged
- [ ] `docs/BACKEND-SCHEMA.md`

## Screenshots / notes
- **One N+1 deliberately deferred:** the collaborations list nests `KolabResource`, which fires a per-row `saved_kolabs` `is_saved` existence check and lazy-loads `kolab.creatorProfile.businessProfile`/`communityProfile`. This is a *separate* N+1 from the reported four; fixing it well needs a scoped nested `withExists` for `is_saved` + extra eager loads, so it's logged as an open item in BACKLOG §12 for its own focused PR rather than rushed in here.
- **Cross-repo sync:** the BACKLOG §12 edits should be mirrored in `kolabing-app`.