### PR TITLE
perf(collaborations): remove nested-kolab N+1 in the list

### DIFF
--- a/app/Services/CollaborationService.php
+++ b/app/Services/CollaborationService.php
@@ -45,8 +45,19 @@ class CollaborationService
 
         $paginator = $query
             ->with([
-                'kolab',
-                'kolab.creatorProfile',
+                // Annotate the nested kolab with the viewer-scoped flags its
+                // KolabResource / OpportunitySummaryResource render, so they read
+                // preloaded attributes instead of one query per row (is_saved,
+                // has_applied). Creator extended profiles are eager-loaded for the
+                // nested creator_profile summary.
+                'kolab' => function ($kolabQuery) use ($profile): void {
+                    $kolabQuery->withExists([
+                        'savedByProfiles as is_saved' => fn ($q) => $q->whereKey($profile->id),
+                        'applications as has_applied' => fn ($q) => $q->where('applicant_profile_id', $profile->id),
+                    ]);
+                },
+                'kolab.creatorProfile.businessProfile',
+                'kolab.creatorProfile.communityProfile',
                 // The collaboration's own business/community profiles carry the
                 // partner logo (profile_photo) the Active/Finished cards show —
                 // load them so CollaborationResource surfaces business_profile /

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -273,7 +273,7 @@ From [docs/ROLES-BACKEND-DB-MAP.md](ROLES-BACKEND-DB-MAP.md) §8 — still-open 
 - [x] `CommunityRewardsHubController` goal progress ran per-goal count queries in BOTH the response map AND `CommunityPointsService::completeGoals()` → new `goalProgressForMany()` batches all earn-types (one grouped query for challenge goals); `completeGoals` bulk-loads already-paid goal ids.
 - [x] `NotificationService::getNotifications` missed `actorProfile.attendeeProfile` → attendee-actor rows lazy-loaded per row; added to eager loads.
 - [x] `FriendshipService::friendsOf` + `incomingRequests` loaded `Profile`s with no `with()` → `FriendResource` hit extended profiles per row; added `attendeeProfile`/`businessProfile`/`communityProfile` eager loads.
-- [ ] **Open:** the collaborations list nests `KolabResource`, which fires a per-row `saved_kolabs` `is_saved` existence check and lazy-loads `kolab.creatorProfile.businessProfile`/`communityProfile` per row. Fix: eager-load `kolab.creatorProfile.businessProfile`+`communityProfile` and annotate `is_saved` on the nested kolab via a scoped `withExists`. Owner: **backend**.
+- [x] The collaborations list nests `KolabResource` + `OpportunitySummaryResource`, which fired a per-row `saved_kolabs` `is_saved` check (both resources), a `has_applied` check (KolabResource), and lazy-loaded `kolab.creatorProfile.businessProfile`/`communityProfile` per row. **Shipped 2026-07-12 (#82):** `CollaborationService::getForProfile` now annotates `is_saved` + `has_applied` on the nested kolab via a viewer-scoped `withExists`, and eager-loads the kolab creator's extended profiles. Query count is constant across rows. Owner: **backend**.
 
 ---
 

--- a/tests/Feature/Api/V1/CollaborationListNestedKolabNPlusOneTest.php
+++ b/tests/Feature/Api/V1/CollaborationListNestedKolabNPlusOneTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Collaboration;
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * The collaborations list nests KolabResource + OpportunitySummaryResource for
+ * each row. Both resolve the viewer-scoped `is_saved` flag, KolabResource also
+ * resolves `has_applied`, and both render the kolab's creator profile. Without
+ * annotation/eager-loading these fire per row. This guards that the list issues
+ * a constant number of queries regardless of row count.
+ */
+class CollaborationListNestedKolabNPlusOneTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function countQueries(\Closure $fn): int
+    {
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+        $fn();
+        $count = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        return $count;
+    }
+
+    /**
+     * @return Profile the community applicant who sees the collaborations
+     */
+    private function communityWith(int $collaborations): Profile
+    {
+        $viewer = Profile::factory()->community()->create();
+
+        for ($i = 0; $i < $collaborations; $i++) {
+            $business = Profile::factory()->business()->create();
+            // VenuePromotion (not CommunitySeeking) so KolabResource's
+            // negotiation_triggers/has_applied path is active for a non-creator viewer.
+            $kolab = Kolab::factory()->published()->venuePromotion()->forCreator($business)->create();
+            Collaboration::factory()->completed()
+                ->forCreator($business)
+                ->forApplicant($viewer)
+                ->create(['kolab_id' => $kolab->id]);
+        }
+
+        return $viewer;
+    }
+
+    public function test_collaborations_list_query_count_is_constant_across_rows(): void
+    {
+        // Build data OUTSIDE the measurement window so only the GET is counted.
+        $viewerOne = $this->communityWith(1);
+        $viewerMany = $this->communityWith(3);
+
+        $baseline = $this->countQueries(fn () => $this->actingAs($viewerOne)
+            ->getJson('/api/v1/collaborations')->assertOk());
+        $scaled = $this->countQueries(fn () => $this->actingAs($viewerMany)
+            ->getJson('/api/v1/collaborations')->assertOk());
+
+        $this->assertSame($baseline, $scaled,
+            "Collaborations list must not fire per-row queries for the nested kolab's is_saved / has_applied / creator profile (1 row: {$baseline}, 3 rows: {$scaled}).");
+    }
+}


### PR DESCRIPTION
> **Stacked on #81 → #79 → #77 → #75 → #73.** Base retargets to `master` as ancestors merge. Merge order: #73 → #75 → #77 → #79 → #81 → this.

## Summary
The collaborations list (`GET /collaborations`) nests `KolabResource` + `OpportunitySummaryResource` per row. Both resolve the viewer-scoped `is_saved` flag, `KolabResource` also resolves `has_applied`, and both render the kolab's creator profile — all firing per row. This was the N+1 deliberately deferred from #81.

## Linked tracking item
Closes the open item in BACKLOG §12 (query-audit sweep). Follow-up to #80.

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes
- `CollaborationService::getForProfile` — the nested `kolab` eager-load now carries a viewer-scoped `withExists` for `is_saved` (`savedByProfiles`) and `has_applied` (`applications` where applicant = viewer), so `KolabResource`/`OpportunitySummaryResource` read preloaded attributes instead of querying per row. Added `kolab.creatorProfile.businessProfile` + `kolab.creatorProfile.communityProfile` eager loads for the nested creator summary.
- New `CollaborationListNestedKolabNPlusOneTest` — asserts the list's query count is constant across rows, viewing as the community **applicant** (so the `has_applied` path is active) with VenuePromotion kolabs.

## Mobile impact (kolabing-app)
- [x] No mobile changes required — response shape/values unchanged.

## Database / migrations
- [x] No schema changes

## Testing
- [x] `php artisan test` — **1311 passed (6264 assertions)** (+1 new)
- [x] `vendor/bin/pint` clean
- [x] TDD verified: with the fix stashed the guard fails (1 row: 21, 3 rows: 29 → ~4 per-row queries); with it, constant.

## Docs & rules updated
- [x] `BACKLOG.md` — §12 open item ticked (#82)
- [x] No docs impact (role behaviour) — internal query-pattern change