### PR TITLE
perf(feed): eliminate browse-feed N+1 behind negotiation_triggers

### DIFF
--- a/app/Http/Controllers/Api/V1/KolabController.php
+++ b/app/Http/Controllers/Api/V1/KolabController.php
@@ -146,9 +146,14 @@ class KolabController extends Controller
         }
 
         $kolab->load('creatorProfile');
-        $kolab->loadExists(['savedByProfiles as is_saved' => function ($q) use ($profile): void {
-            $q->whereKey($profile->id);
-        }]);
+        $kolab->loadExists([
+            'savedByProfiles as is_saved' => function ($q) use ($profile): void {
+                $q->whereKey($profile->id);
+            },
+            'applications as has_applied' => function ($q) use ($profile): void {
+                $q->where('applicant_profile_id', $profile->id);
+            },
+        ]);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Resources/Api/V1/KolabResource.php
+++ b/app/Http/Resources/Api/V1/KolabResource.php
@@ -220,9 +220,26 @@ class KolabResource extends JsonResource
             return true;
         }
 
+        return $this->viewerHasApplied($viewer->id);
+    }
+
+    /**
+     * Whether the viewer has applied to this kolab. Prefers a query-annotated
+     * `has_applied` attribute (set via withExists/loadExists in the list and
+     * detail paths, so no N+1) and falls back to a single existence check when
+     * the resource is rendered without that annotation (e.g. nested resources).
+     */
+    private function viewerHasApplied(string $viewerId): bool
+    {
+        $model = $this->resource;
+
+        if (array_key_exists('has_applied', $model->getAttributes())) {
+            return (bool) $model->getAttribute('has_applied');
+        }
+
         return Application::query()
             ->where('kolab_id', $this->id)
-            ->where('applicant_profile_id', $viewer->id)
+            ->where('applicant_profile_id', $viewerId)
             ->exists();
     }
 

--- a/app/Services/KolabService.php
+++ b/app/Services/KolabService.php
@@ -48,9 +48,14 @@ class KolabService
         $query = Kolab::query()
             ->where('status', KolabStatus::Published)
             ->withCount('applications')
-            ->withExists(['savedByProfiles as is_saved' => function (Builder $q) use ($viewer): void {
-                $q->whereKey($viewer->id);
-            }])
+            ->withExists([
+                'savedByProfiles as is_saved' => function (Builder $q) use ($viewer): void {
+                    $q->whereKey($viewer->id);
+                },
+                'applications as has_applied' => function (Builder $q) use ($viewer): void {
+                    $q->where('applicant_profile_id', $viewer->id);
+                },
+            ])
             ->with([
                 'creatorProfile' => function ($query) {
                     $query->with([

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-12
+**Last updated:** 2026-07-12 (feed N+1 fix — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -257,7 +257,7 @@ From [docs/ROLES-BACKEND-DB-MAP.md](ROLES-BACKEND-DB-MAP.md) §8 — still-open 
 **Status:** Indexing shipped (#72, `perf/db-scalability-indexes`) — 37 previously-unindexed foreign keys + hot-path composite/partial indexes (`kolabs(status,published_at)`, `attendee_profiles(total_points)`, `community_members(community_id,status)`, `community_points(community_id,points)`, `challenge_completions(event_id,status)`, `collaboration_reviews(reviewed_profile_id,rating,created_at)`, partial `chat_messages(...) WHERE read_at IS NULL`). Live catalog shows 0 unindexed FKs remaining. Sufficient for the ~5k-user target at the DB layer. The items below are **algorithmic** issues an index cannot fix, surfaced by the same audit.
 
 **P1 — needed before ~50k users:**
-- [ ] `KolabResource::negotiation_triggers` fires a per-row `Application::exists()` on the browse feed → pre-annotate via `withExists` in `KolabService::browse()`. Owner: **backend**.
+- [x] `KolabResource::negotiation_triggers` fires a per-row `Application::exists()` on the browse feed → pre-annotate via `withExists` in `KolabService::browse()`. **Shipped 2026-07-12 (#74):** `has_applied` annotated via `withExists` in `browse()` + `loadExists` in `show()`; resource prefers the annotation, single-query fallback only for unannotated nested resources (mirrors `ResolvesSavedFlag`). Owner: **backend**.
 - [ ] `ChatService::visibleThreads` is unpaginated (fetches all threads, sorts in PHP) → paginate / order in SQL. Owner: **backend**.
 - [ ] Leaderboards (`getCommunityPointsLeaderboard`, global) hydrate all members then sort in PHP → move ranking + LIMIT into SQL. Owner: **backend**.
 - [ ] `PublicProfileResource` runs ~7 uncached queries per profile view (reputation window fn + double `completed_kolabs_count`) → cache or denormalise `reputation` / `completed_kolabs_count` onto `profiles`. Owner: **backend**.

--- a/tests/Feature/Api/V1/KolabFeedNPlusOneTest.php
+++ b/tests/Feature/Api/V1/KolabFeedNPlusOneTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Application;
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class KolabFeedNPlusOneTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Standalone existence queries against the applications table are the
+     * per-row "has this viewer applied?" check behind `negotiation_triggers`.
+     * The folded subqueries (withCount / withExists / whereNotExists) all carry
+     * `from "kolabs"` as their outer table, so excluding those isolates the N+1.
+     */
+    private function listenForStandaloneApplicationQueries(int &$counter): void
+    {
+        DB::listen(function ($query) use (&$counter): void {
+            if (str_contains($query->sql, 'from "applications"') && ! str_contains($query->sql, 'from "kolabs"')) {
+                $counter++;
+            }
+        });
+    }
+
+    public function test_browse_feed_does_not_run_per_row_application_existence_queries(): void
+    {
+        $creator = Profile::factory()->business()->create();
+        $viewer = Profile::factory()->community()->create();
+
+        Kolab::factory()->count(4)->published()->venuePromotion()->forCreator($creator)->create([
+            'negotiation_triggers' => [
+                ['condition' => 'Groups of 20+', 'additional_offer' => 'Dessert pairing.'],
+            ],
+        ]);
+
+        $standaloneApplicationQueries = 0;
+        $this->listenForStandaloneApplicationQueries($standaloneApplicationQueries);
+
+        $response = $this->actingAs($viewer)
+            ->getJson('/api/v1/kolabs')
+            ->assertOk();
+
+        $this->assertCount(4, $response->json('data.data'));
+        $this->assertSame(
+            0,
+            $standaloneApplicationQueries,
+            'Browse feed must not fire a per-row applications existence query (N+1).'
+        );
+    }
+
+    public function test_saved_feed_exposes_negotiation_triggers_via_annotation_for_applied_kolab(): void
+    {
+        $creator = Profile::factory()->business()->create();
+        $viewer = Profile::factory()->community()->create();
+
+        $kolab = Kolab::factory()->published()->venuePromotion()->forCreator($creator)->create([
+            'negotiation_triggers' => [
+                ['condition' => 'Groups of 20+', 'additional_offer' => 'Dessert pairing.'],
+            ],
+        ]);
+
+        Application::factory()->forKolab($kolab)->forApplicant($viewer)->create();
+        $viewer->savedKolabs()->syncWithoutDetaching([$kolab->id]);
+
+        $standaloneApplicationQueries = 0;
+        $this->listenForStandaloneApplicationQueries($standaloneApplicationQueries);
+
+        $response = $this->actingAs($viewer)
+            ->getJson('/api/v1/kolabs?saved=1')
+            ->assertOk();
+
+        $this->assertCount(1, $response->json('data.data'));
+        $this->assertSame(
+            'Groups of 20+',
+            $response->json('data.data.0.negotiation_triggers.0.condition'),
+            'A viewer who applied must see negotiation_triggers in the saved feed.'
+        );
+        $this->assertSame(
+            0,
+            $standaloneApplicationQueries,
+            'Annotated has_applied must serve exposure without a per-row query.'
+        );
+    }
+}


### PR DESCRIPTION
Replaces #75 (auto-closed when its stacked base branch was deleted during the merge sequence). Same commit, now targeting master directly.

## Summary
Removes the per-row `Application::exists()` that `KolabResource` fired for every non-creator viewer on the browse feed.

## Linked tracking item
Closes #74

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes
- `KolabService::browse()` annotates `has_applied` via `withExists`; `KolabController::show()` via `loadExists`; `KolabResource` prefers the annotation, single-query fallback only for unannotated nested resources (mirrors `ResolvesSavedFlag`).
- `KolabFeedNPlusOneTest` asserts the feed fires zero per-row applications queries.

## Mobile impact (kolabing-app)
- [x] No mobile changes required — `negotiation_triggers` exposure unchanged.

## Database / migrations
- [x] No schema changes

## Testing
- [x] `php artisan test` green (full suite 1311 passing on the tip of the stack)
- [x] `vendor/bin/pint` clean

## Docs & rules updated
- [x] `BACKLOG.md` §12 (feed N+1 ticked)
- [x] No role-doc impact