### PR TITLE
Business Partner Status (Phase 1) — retention nudges, no points

### DIFF
--- a/app/Console/Commands/SendBusinessReactivationReminders.php
+++ b/app/Console/Commands/SendBusinessReactivationReminders.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\NotificationType;
+use App\Enums\UserType;
+use App\Models\Collaboration;
+use App\Models\Kolab;
+use App\Models\Notification;
+use App\Models\Profile;
+use App\Services\NotificationService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class SendBusinessReactivationReminders extends Command
+{
+    protected $signature = 'app:send-business-reactivation-reminders
+        {--dry-run : Log what would be sent without actually sending}';
+
+    protected $description = 'Nudge subscribed but inactive businesses back to Kolabing';
+
+    public function handle(NotificationService $notificationService): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $inactivityDays = (int) config('gamification_business.reactivation_inactivity_days');
+        $resendAfterDays = (int) config('gamification_business.reactivation_resend_after_days');
+        $cutoff = Carbon::now()->subDays($inactivityDays);
+
+        $candidates = Profile::query()
+            ->where('user_type', UserType::Business)
+            ->with('subscription')
+            ->get();
+
+        $sentCount = 0;
+
+        foreach ($candidates as $business) {
+            if (! $business->hasActiveSubscription()) {
+                continue;
+            }
+
+            $lastActivity = $this->lastActivityAt($business);
+
+            if ($lastActivity !== null && $lastActivity->isAfter($cutoff)) {
+                continue;
+            }
+
+            if ($this->reminderSentRecently($business, $resendAfterDays)) {
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->line("  [dry-run] Would send reactivation reminder to business {$business->id}");
+
+                continue;
+            }
+
+            $notificationService->notifyReactivation($business);
+            $sentCount++;
+        }
+
+        $this->info("Reactivation reminders sent: {$sentCount}.");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The most recent Kolab or collaboration activity for a business profile.
+     * There is no dedicated "last active" column on profiles, so this is
+     * derived from related activity — see the implementation plan's note
+     * on this being an approximation, not a true session/login signal.
+     */
+    private function lastActivityAt(Profile $business): ?Carbon
+    {
+        $lastKolabActivity = Kolab::query()
+            ->where('creator_profile_id', $business->id)
+            ->max('updated_at');
+
+        $lastCollaborationActivity = Collaboration::query()
+            ->where(function ($query) use ($business): void {
+                $query->where('creator_profile_id', $business->id)
+                    ->orWhere('applicant_profile_id', $business->id);
+            })
+            ->max('updated_at');
+
+        $timestamps = array_filter([
+            $business->updated_at,
+            $lastKolabActivity !== null ? Carbon::parse($lastKolabActivity) : null,
+            $lastCollaborationActivity !== null ? Carbon::parse($lastCollaborationActivity) : null,
+        ]);
+
+        if ($timestamps === []) {
+            return null;
+        }
+
+        return collect($timestamps)->max();
+    }
+
+    private function reminderSentRecently(Profile $business, int $resendAfterDays): bool
+    {
+        return Notification::query()
+            ->where('profile_id', $business->id)
+            ->where('type', NotificationType::ReactivationPrompt)
+            ->where('created_at', '>=', Carbon::now()->subDays($resendAfterDays))
+            ->exists();
+    }
+}

--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -34,6 +34,11 @@ enum NotificationType: string
     case CollaborationFeedbackReceived = 'collaboration_feedback_received';
     case CollaborationCompleted = 'collaboration_completed';
     case CollaborationCancelled = 'collaboration_cancelled';
+    case KolabPublished = 'kolab_published';
+    case ReviewReminder = 'review_reminder';
+    case SecondOfferPrompt = 'second_offer_prompt';
+    case PartnerStatusUpgraded = 'partner_status_upgraded';
+    case ReactivationPrompt = 'reactivation_prompt';
 
     /**
      * @return array<string>

--- a/app/Enums/PartnerStatusTier.php
+++ b/app/Enums/PartnerStatusTier.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum PartnerStatusTier: string
+{
+    case NewPartner = 'new_partner';
+    case ActivePartner = 'active_partner';
+    case TrustedPartner = 'trusted_partner';
+    case CommunityFavourite = 'community_favourite';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::NewPartner => 'New Partner',
+            self::ActivePartner => 'Active Partner',
+            self::TrustedPartner => 'Trusted Partner',
+            self::CommunityFavourite => 'Community Favourite',
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::NewPartner, self::ActivePartner => '',
+            self::TrustedPartner => '✓',
+            self::CommunityFavourite => '★',
+        };
+    }
+}

--- a/app/Http/Controllers/Api/V1/CollaborationController.php
+++ b/app/Http/Controllers/Api/V1/CollaborationController.php
@@ -19,11 +19,14 @@ use App\Http\Resources\Api\V1\CollaborationResource;
 use App\Models\Collaboration;
 use App\Models\CollaborationReview;
 use App\Models\Profile;
+use App\Services\BusinessPartnerStatusService;
 use App\Services\CollaborationCompletionService;
 use App\Services\CollaborationFeedbackService;
 use App\Services\CollaborationService;
 use App\Services\GamificationWalletService;
 use App\Services\MissionService;
+use App\Services\NotificationReminderService;
+use App\Services\NotificationService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -35,6 +38,9 @@ class CollaborationController extends Controller
         private readonly CollaborationFeedbackService $feedbackService,
         private readonly MissionService $missionService,
         private readonly CollaborationCompletionService $completionService,
+        private readonly BusinessPartnerStatusService $businessPartnerStatusService,
+        private readonly NotificationService $notificationService,
+        private readonly NotificationReminderService $notificationReminderService,
     ) {}
 
     /**
@@ -449,7 +455,18 @@ class CollaborationController extends Controller
                     ['reference_id' => $collaboration->id],
                 );
             }
+
+            if ($reviewedProfile->isBusiness()) {
+                $previousStatus = $this->businessPartnerStatusService->statusFor($reviewedProfile);
+                $newStatus = $this->businessPartnerStatusService->recalculate($reviewedProfile);
+
+                if ($newStatus !== $previousStatus) {
+                    $this->notificationService->notifyPartnerStatusUpgraded($reviewedProfile, $newStatus);
+                }
+            }
         }
+
+        $this->notificationReminderService->cancelReviewReminder($collaboration, $reviewer);
 
         // Mirror the review into a stub /feedback row so feedback-dependent
         // aggregates stay consistent for legacy /review-only clients. This does

--- a/app/Http/Resources/Api/V1/BusinessProfileResource.php
+++ b/app/Http/Resources/Api/V1/BusinessProfileResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use App\Models\BusinessProfile;
+use App\Services\BusinessPartnerStatusService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Str;
@@ -52,8 +53,30 @@ class BusinessProfileResource extends JsonResource
             'logo_url' => $logo,
             'primary_venue' => $this->primary_venue,
             'offer_photos' => $this->offer_photos ?? [],
+            'partner_status' => $this->partnerStatusBadge(),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Subtle, public partner status badge — status and label only, no
+     * component breakdown (that stays private to the business's own dashboard).
+     *
+     * @return array{status: string, label: string, icon: string}|null
+     */
+    private function partnerStatusBadge(): ?array
+    {
+        if ($this->profile === null) {
+            return null;
+        }
+
+        $status = app(BusinessPartnerStatusService::class)->statusFor($this->profile);
+
+        return [
+            'status' => $status->value,
+            'label' => $status->label(),
+            'icon' => $status->icon(),
         ];
     }
 

--- a/app/Models/BusinessPartnerStatus.php
+++ b/app/Models/BusinessPartnerStatus.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\PartnerStatusTier;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $profile_id
+ * @property PartnerStatusTier $status
+ * @property int $completed_kolabs_count
+ * @property int $review_count
+ * @property int $repeat_partner_count
+ * @property float|null $average_rating
+ * @property \Illuminate\Support\Carbon|null $recalculated_at
+ * @property-read Profile $profile
+ */
+class BusinessPartnerStatus extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'profile_id',
+        'status',
+        'completed_kolabs_count',
+        'review_count',
+        'repeat_partner_count',
+        'average_rating',
+        'recalculated_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => PartnerStatusTier::class,
+            'completed_kolabs_count' => 'integer',
+            'review_count' => 'integer',
+            'repeat_partner_count' => 'integer',
+            'average_rating' => 'float',
+            'recalculated_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -344,6 +344,16 @@ class Profile extends Authenticatable
     }
 
     /**
+     * Get the business partner status for this profile.
+     *
+     * @return HasOne<BusinessPartnerStatus, $this>
+     */
+    public function businessPartnerStatus(): HasOne
+    {
+        return $this->hasOne(BusinessPartnerStatus::class);
+    }
+
+    /**
      * Get the gamification wallet for this profile.
      *
      * @return HasOne<Wallet, $this>

--- a/app/Services/BusinessPartnerStatusService.php
+++ b/app/Services/BusinessPartnerStatusService.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\CollaborationStatus;
+use App\Enums\PartnerStatusTier;
+use App\Models\BusinessPartnerStatus;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Profile;
+
+class BusinessPartnerStatusService
+{
+    /**
+     * Recalculate and persist a business's partner status from its collaboration history.
+     * Returns the resulting status; callers can compare against the profile's previous
+     * status (via statusFor()) before calling this to detect an upgrade worth announcing.
+     */
+    public function recalculate(Profile $businessProfile): PartnerStatusTier
+    {
+        $completedCollaborations = $this->completedCollaborationsQuery($businessProfile)->get();
+        $completedKolabsCount = $completedCollaborations->count();
+        $repeatPartnerCount = $this->countRepeatPartners($businessProfile, $completedCollaborations);
+
+        $reviews = CollaborationReview::query()
+            ->where('reviewed_profile_id', $businessProfile->id)
+            ->get();
+        $reviewCount = $reviews->count();
+        $averageRating = $reviewCount > 0 ? round((float) $reviews->avg('rating'), 2) : null;
+
+        $status = $this->resolveTier($completedKolabsCount, $reviewCount, $averageRating, $repeatPartnerCount);
+
+        BusinessPartnerStatus::query()->updateOrCreate(
+            ['profile_id' => $businessProfile->id],
+            [
+                'status' => $status,
+                'completed_kolabs_count' => $completedKolabsCount,
+                'review_count' => $reviewCount,
+                'repeat_partner_count' => $repeatPartnerCount,
+                'average_rating' => $averageRating,
+                'recalculated_at' => now(),
+            ]
+        );
+
+        return $status;
+    }
+
+    /**
+     * Cheap read for API/resource use. Falls back to New Partner without
+     * recomputing if no status row exists yet.
+     */
+    public function statusFor(Profile $businessProfile): PartnerStatusTier
+    {
+        return $businessProfile->businessPartnerStatus?->status ?? PartnerStatusTier::NewPartner;
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Builder<Collaboration>
+     */
+    private function completedCollaborationsQuery(Profile $businessProfile): \Illuminate\Database\Eloquent\Builder
+    {
+        return Collaboration::query()
+            ->where('status', CollaborationStatus::Completed)
+            ->where(function ($query) use ($businessProfile): void {
+                $query->where('creator_profile_id', $businessProfile->id)
+                    ->orWhere('applicant_profile_id', $businessProfile->id);
+            });
+    }
+
+    /**
+     * A repeat partner is a counterpart profile the business has completed
+     * more than one Kolab with.
+     *
+     * @param  \Illuminate\Support\Collection<int, Collaboration>  $completedCollaborations
+     */
+    private function countRepeatPartners(Profile $businessProfile, \Illuminate\Support\Collection $completedCollaborations): int
+    {
+        return $completedCollaborations
+            ->map(fn (Collaboration $collaboration): string => $collaboration->creator_profile_id === $businessProfile->id
+                ? $collaboration->applicant_profile_id
+                : $collaboration->creator_profile_id)
+            ->countBy()
+            ->filter(fn (int $count): bool => $count > 1)
+            ->count();
+    }
+
+    private function resolveTier(
+        int $completedKolabsCount,
+        int $reviewCount,
+        ?float $averageRating,
+        int $repeatPartnerCount,
+    ): PartnerStatusTier {
+        $tiers = config('gamification_business.tiers');
+
+        if ($this->meetsThresholds($tiers['community_favourite'], $completedKolabsCount, $reviewCount, $averageRating, $repeatPartnerCount)) {
+            return PartnerStatusTier::CommunityFavourite;
+        }
+
+        if ($this->meetsThresholds($tiers['trusted_partner'], $completedKolabsCount, $reviewCount, $averageRating, $repeatPartnerCount)) {
+            return PartnerStatusTier::TrustedPartner;
+        }
+
+        if ($this->meetsThresholds($tiers['active_partner'], $completedKolabsCount, $reviewCount, $averageRating, $repeatPartnerCount)) {
+            return PartnerStatusTier::ActivePartner;
+        }
+
+        return PartnerStatusTier::NewPartner;
+    }
+
+    /**
+     * @param  array{min_completed_kolabs?: int, min_reviews?: int, min_average_rating?: float, min_repeat_partners?: int}  $thresholds
+     */
+    private function meetsThresholds(
+        array $thresholds,
+        int $completedKolabsCount,
+        int $reviewCount,
+        ?float $averageRating,
+        int $repeatPartnerCount,
+    ): bool {
+        if ($completedKolabsCount < ($thresholds['min_completed_kolabs'] ?? 0)) {
+            return false;
+        }
+
+        if ($reviewCount < ($thresholds['min_reviews'] ?? 0)) {
+            return false;
+        }
+
+        if (isset($thresholds['min_average_rating']) && ($averageRating ?? 0.0) < $thresholds['min_average_rating']) {
+            return false;
+        }
+
+        if ($repeatPartnerCount < ($thresholds['min_repeat_partners'] ?? 0)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Services/CollaborationService.php
+++ b/app/Services/CollaborationService.php
@@ -25,6 +25,8 @@ class CollaborationService
         private readonly CollaborationCompletionService $completionService,
         private readonly PostHogService $postHog,
         private readonly NotificationService $notificationService,
+        private readonly BusinessPartnerStatusService $businessPartnerStatusService,
+        private readonly NotificationReminderService $notificationReminderService,
     ) {}
 
     /**
@@ -196,6 +198,10 @@ class CollaborationService
             'application',
         ]);
 
+        $this->recalculateBusinessStatus($fresh);
+        $this->notificationReminderService->syncReviewReminder($fresh);
+        $this->notificationReminderService->syncSecondOfferPromptReminder($fresh);
+
         $this->dispatchNotification(fn () => $this->notificationService->notifyCollaborationCompleted(
             $fresh,
             $caller ?? $fresh->creatorProfile,
@@ -231,6 +237,10 @@ class CollaborationService
             'application',
         ]);
 
+        $this->recalculateBusinessStatus($fresh);
+        $this->notificationReminderService->syncReviewReminder($fresh);
+        $this->notificationReminderService->syncSecondOfferPromptReminder($fresh);
+
         $this->dispatchNotification(
             fn () => $this->notificationService->notifyCollaborationCompleted($fresh, null),
         );
@@ -264,6 +274,10 @@ class CollaborationService
             'applicantProfile',
             'application',
         ]);
+
+        $this->recalculateBusinessStatus($fresh);
+        $this->notificationReminderService->syncReviewReminder($fresh);
+        $this->notificationReminderService->syncSecondOfferPromptReminder($fresh);
 
         $this->dispatchNotification(
             fn () => $this->notificationService->notifyCollaborationCompleted($fresh, null),
@@ -487,5 +501,30 @@ class CollaborationService
         }
 
         return null;
+    }
+
+    /**
+     * Recalculate the business side's partner status and announce an upgrade, if any.
+     */
+    private function recalculateBusinessStatus(Collaboration $collaboration): void
+    {
+        $collaboration->loadMissing(['creatorProfile', 'applicantProfile']);
+
+        $businessProfile = match (true) {
+            $collaboration->creatorProfile->isBusiness() => $collaboration->creatorProfile,
+            $collaboration->applicantProfile->isBusiness() => $collaboration->applicantProfile,
+            default => null,
+        };
+
+        if ($businessProfile === null) {
+            return;
+        }
+
+        $previousStatus = $this->businessPartnerStatusService->statusFor($businessProfile);
+        $newStatus = $this->businessPartnerStatusService->recalculate($businessProfile);
+
+        if ($newStatus !== $previousStatus) {
+            $this->notificationService->notifyPartnerStatusUpgraded($businessProfile, $newStatus);
+        }
     }
 }

--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -14,6 +14,10 @@ use App\Models\Profile;
 
 class DashboardService
 {
+    public function __construct(
+        private readonly BusinessPartnerStatusService $businessPartnerStatusService,
+    ) {}
+
     /**
      * Get dashboard stats for a business user.
      *
@@ -21,17 +25,137 @@ class DashboardService
      *     opportunities: array{total: int, published: int, draft: int, closed: int},
      *     applications_received: array{total: int, pending: int, accepted: int, declined: int},
      *     collaborations: array{total: int, active: int, upcoming: int, completed: int},
-     *     upcoming_collaborations: \Illuminate\Database\Eloquent\Collection
+     *     upcoming_collaborations: \Illuminate\Database\Eloquent\Collection,
+     *     partner_status: array{status: string, label: string, icon: string, breakdown: array<string, mixed>},
+     *     next_action: array{key: string, title: string, body: string}|null
      * }
      */
     public function getBusinessDashboard(Profile $profile): array
     {
+        $opportunities = $this->getOpportunityStats($profile);
+        $applicationsReceived = $this->getReceivedApplicationStats($profile);
+        $collaborations = $this->getCollaborationStats($profile);
+
         return [
-            'opportunities' => $this->getOpportunityStats($profile),
-            'applications_received' => $this->getReceivedApplicationStats($profile),
-            'collaborations' => $this->getCollaborationStats($profile),
+            'opportunities' => $opportunities,
+            'applications_received' => $applicationsReceived,
+            'collaborations' => $collaborations,
             'upcoming_collaborations' => $this->getUpcomingCollaborations($profile),
+            'partner_status' => $this->getPartnerStatus($profile),
+            'next_action' => $this->getNextAction($profile, $opportunities, $applicationsReceived, $collaborations),
         ];
+    }
+
+    /**
+     * Build the business's partner status block, including the component
+     * breakdown the audit calls for showing transparently to the business itself.
+     *
+     * @return array{status: string, label: string, icon: string, breakdown: array<string, mixed>}
+     */
+    private function getPartnerStatus(Profile $profile): array
+    {
+        $status = $this->businessPartnerStatusService->statusFor($profile);
+        $record = $profile->businessPartnerStatus;
+
+        return [
+            'status' => $status->value,
+            'label' => $status->label(),
+            'icon' => $status->icon(),
+            'breakdown' => [
+                'completed_kolabs' => $record?->completed_kolabs_count ?? 0,
+                'review_count' => $record?->review_count ?? 0,
+                'average_rating' => $record?->average_rating,
+                'repeat_partner_count' => $record?->repeat_partner_count ?? 0,
+            ],
+        ];
+    }
+
+    /**
+     * Single next-best-action for the business dashboard, evaluated as a
+     * priority-ordered rule chain — first match wins.
+     *
+     * @param  array{total: int, published: int, draft: int, closed: int}  $opportunities
+     * @param  array{total: int, pending: int, accepted: int, declined: int}  $applicationsReceived
+     * @param  array{total: int, active: int, upcoming: int, completed: int}  $collaborations
+     * @return array{key: string, title: string, body: string}|null
+     */
+    private function getNextAction(
+        Profile $profile,
+        array $opportunities,
+        array $applicationsReceived,
+        array $collaborations,
+    ): ?array {
+        if (! $this->isProfileComplete($profile)) {
+            return [
+                'key' => 'complete_profile',
+                'title' => 'Complete your profile',
+                'body' => 'A complete profile helps communities trust you and apply with confidence.',
+            ];
+        }
+
+        if ($opportunities['published'] === 0) {
+            return [
+                'key' => 'create_first_offer',
+                'title' => 'Create your first Kolab',
+                'body' => 'Publish an offer so communities can discover and apply to it.',
+            ];
+        }
+
+        if ($applicationsReceived['pending'] > 0) {
+            $count = $applicationsReceived['pending'];
+
+            return [
+                'key' => 'review_pending_applications',
+                'title' => $count === 1 ? 'Review 1 pending application' : "Review {$count} pending applications",
+                'body' => 'A new application is waiting for your review.',
+            ];
+        }
+
+        if ($collaborations['completed'] === 0) {
+            return null;
+        }
+
+        if ($this->hasUnreviewedCompletedCollaboration($profile)) {
+            return [
+                'key' => 'leave_review',
+                'title' => 'Leave your review',
+                'body' => 'Your review helps future partners collaborate with confidence.',
+            ];
+        }
+
+        if ($collaborations['completed'] === 1 && $opportunities['published'] < 2) {
+            return [
+                'key' => 'create_second_offer',
+                'title' => 'Ready for your next Kolab?',
+                'body' => 'Build on the momentum and create your next offer.',
+            ];
+        }
+
+        return null;
+    }
+
+    private function isProfileComplete(Profile $profile): bool
+    {
+        $businessProfile = $profile->businessProfile;
+
+        if ($businessProfile === null) {
+            return false;
+        }
+
+        return filled($businessProfile->name)
+            && filled($businessProfile->about)
+            && filled($businessProfile->business_type)
+            && filled($businessProfile->city_id);
+    }
+
+    private function hasUnreviewedCompletedCollaboration(Profile $profile): bool
+    {
+        return $this->getAllCollaborationsQuery($profile)
+            ->where('status', CollaborationStatus::Completed)
+            ->whereDoesntHave('reviews', function ($query) use ($profile): void {
+                $query->where('reviewer_profile_id', $profile->id);
+            })
+            ->exists();
     }
 
     /**

--- a/app/Services/KolabService.php
+++ b/app/Services/KolabService.php
@@ -25,6 +25,7 @@ class KolabService
         private readonly NotificationReminderService $notificationReminderService,
         private readonly GamificationWalletService $walletService,
         private readonly MissionService $missionService,
+        private readonly NotificationService $notificationService,
     ) {}
 
     /**
@@ -291,6 +292,10 @@ class KolabService
         $this->notificationReminderService->syncKolabDraftReminder($kolab);
         $this->awardPublishXpOnce($kolab);
         $this->recordPublishMissions($kolab, $creator);
+
+        if ($creator->isBusiness()) {
+            $this->notificationService->notifyKolabPublished($kolab);
+        }
 
         return $kolab;
     }

--- a/app/Services/NotificationReminderService.php
+++ b/app/Services/NotificationReminderService.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\ApplicationStatus;
+use App\Enums\CollaborationStatus;
 use App\Enums\KolabStatus;
 use App\Enums\NotificationType;
 use App\Models\Application;
 use App\Models\ChatMessage;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
 use App\Models\Kolab;
 use App\Models\NotificationReminder;
 use App\Models\Profile;
@@ -24,6 +27,8 @@ class NotificationReminderService
     private const ENTITY_APPLICATION = 'application';
 
     private const ENTITY_KOLAB = 'kolab';
+
+    private const ENTITY_COLLABORATION = 'collaboration';
 
     public function __construct(
         private readonly NotificationService $notificationService,
@@ -68,6 +73,75 @@ class NotificationReminderService
             eligible: $application->status === ApplicationStatus::Pending,
             anchorAt: $application->created_at,
         );
+    }
+
+    /**
+     * Sync the review reminder for the business side of a just-completed collaboration.
+     * Cancelled once that business leaves a review (see cancelReviewReminder()).
+     */
+    public function syncReviewReminder(Collaboration $collaboration): void
+    {
+        $businessProfile = $this->resolveBusinessProfile($collaboration);
+
+        if ($businessProfile === null) {
+            return;
+        }
+
+        $this->syncReminder(
+            profileId: $businessProfile->id,
+            type: NotificationType::ReviewReminder,
+            entityId: $collaboration->id,
+            entityType: self::ENTITY_COLLABORATION,
+            eligible: $collaboration->status === CollaborationStatus::Completed,
+            anchorAt: $collaboration->completed_at,
+        );
+    }
+
+    public function cancelReviewReminder(Collaboration $collaboration, Profile $reviewer): void
+    {
+        $this->cancelReminder(
+            profileId: $reviewer->id,
+            type: NotificationType::ReviewReminder,
+            entityId: $collaboration->id,
+            entityType: self::ENTITY_COLLABORATION,
+        );
+    }
+
+    /**
+     * Sync the second-offer prompt after a business's first completed Kolab.
+     * Cancelled once the business publishes a second offer.
+     */
+    public function syncSecondOfferPromptReminder(Collaboration $collaboration): void
+    {
+        $businessProfile = $this->resolveBusinessProfile($collaboration);
+
+        if ($businessProfile === null) {
+            return;
+        }
+
+        $publishedOfferCount = $businessProfile->kolabs()
+            ->where('status', KolabStatus::Published)
+            ->count();
+
+        $this->syncReminder(
+            profileId: $businessProfile->id,
+            type: NotificationType::SecondOfferPrompt,
+            entityId: $collaboration->id,
+            entityType: self::ENTITY_COLLABORATION,
+            eligible: $publishedOfferCount < 2,
+            anchorAt: $collaboration->completed_at,
+        );
+    }
+
+    private function resolveBusinessProfile(Collaboration $collaboration): ?Profile
+    {
+        $collaboration->loadMissing(['creatorProfile', 'applicantProfile']);
+
+        return match (true) {
+            $collaboration->creatorProfile->isBusiness() => $collaboration->creatorProfile,
+            $collaboration->applicantProfile->isBusiness() => $collaboration->applicantProfile,
+            default => null,
+        };
     }
 
     public function syncUnreadMessageReminder(Application $application, Profile $recipient): void
@@ -171,11 +245,13 @@ class NotificationReminderService
             || $reminder->scheduled_for === null;
 
         if ($shouldReset) {
+            $cadenceHours = $this->cadenceHoursFor($type);
+
             $reminder->fill([
                 'anchor_at' => $anchorAt,
                 'next_sequence' => 0,
                 'last_sent_sequence' => null,
-                'scheduled_for' => $anchorAt->copy()->addHours(self::CADENCE_HOURS[0]),
+                'scheduled_for' => $anchorAt->copy()->addHours($cadenceHours[0]),
                 'sent_at' => null,
                 'cancelled_at' => null,
             ])->save();
@@ -222,7 +298,91 @@ class NotificationReminderService
             NotificationType::KolabCreateIncomplete => $this->refreshKolabDraftReminder($reminder),
             NotificationType::ApplicationPending => $this->refreshApplicationPendingReminder($reminder),
             NotificationType::UnreadMessage => $this->refreshUnreadMessageReminder($reminder),
+            NotificationType::ReviewReminder => $this->refreshReviewReminder($reminder),
+            NotificationType::SecondOfferPrompt => $this->refreshSecondOfferPromptReminder($reminder),
             default => false,
+        };
+    }
+
+    private function refreshReviewReminder(NotificationReminder $reminder): bool
+    {
+        $collaboration = Collaboration::query()->find($reminder->entity_id);
+
+        if ($collaboration === null || $collaboration->status !== CollaborationStatus::Completed) {
+            $this->cancelExistingReminder($reminder);
+
+            return false;
+        }
+
+        $alreadyReviewed = CollaborationReview::query()
+            ->where('collaboration_id', $collaboration->id)
+            ->where('reviewer_profile_id', $reminder->profile_id)
+            ->exists();
+
+        if ($alreadyReviewed) {
+            $this->cancelExistingReminder($reminder);
+
+            return false;
+        }
+
+        $this->syncReminder(
+            profileId: $reminder->profile_id,
+            type: NotificationType::ReviewReminder,
+            entityId: $collaboration->id,
+            entityType: self::ENTITY_COLLABORATION,
+            eligible: true,
+            anchorAt: $collaboration->completed_at,
+        );
+
+        $reminder->refresh();
+
+        return true;
+    }
+
+    private function refreshSecondOfferPromptReminder(NotificationReminder $reminder): bool
+    {
+        $collaboration = Collaboration::query()->find($reminder->entity_id);
+        $businessProfile = Profile::query()->find($reminder->profile_id);
+
+        if ($collaboration === null || $businessProfile === null) {
+            $this->cancelExistingReminder($reminder);
+
+            return false;
+        }
+
+        $publishedOfferCount = $businessProfile->kolabs()
+            ->where('status', KolabStatus::Published)
+            ->count();
+
+        if ($publishedOfferCount >= 2) {
+            $this->cancelExistingReminder($reminder);
+
+            return false;
+        }
+
+        $this->syncReminder(
+            profileId: $businessProfile->id,
+            type: NotificationType::SecondOfferPrompt,
+            entityId: $collaboration->id,
+            entityType: self::ENTITY_COLLABORATION,
+            eligible: true,
+            anchorAt: $collaboration->completed_at,
+        );
+
+        $reminder->refresh();
+
+        return true;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function cadenceHoursFor(NotificationType $type): array
+    {
+        return match ($type) {
+            NotificationType::ReviewReminder => config('gamification_business.review_reminder_cadence_hours'),
+            NotificationType::SecondOfferPrompt => config('gamification_business.second_offer_prompt_cadence_hours'),
+            default => self::CADENCE_HOURS,
         };
     }
 
@@ -339,26 +499,35 @@ class NotificationReminderService
                 'title' => 'You have an unread message',
                 'body' => 'Someone sent you a message about your Kolab. Open the chat to reply.',
             ],
+            NotificationType::ReviewReminder => [
+                'title' => 'Share your experience',
+                'body' => 'Your review helps future partners collaborate with confidence.',
+            ],
+            NotificationType::SecondOfferPrompt => [
+                'title' => 'Ready for your next Kolab?',
+                'body' => 'Build on the momentum and create your next offer.',
+            ],
             default => null,
         };
     }
 
     private function advanceReminder(NotificationReminder $reminder): void
     {
+        $cadenceHours = $this->cadenceHoursFor($reminder->type);
         $currentSequence = $reminder->next_sequence;
         $nextSequence = $currentSequence + 1;
         $now = now();
 
-        while ($nextSequence < count(self::CADENCE_HOURS)
-            && $reminder->anchor_at?->copy()->addHours(self::CADENCE_HOURS[$nextSequence])->lte($now)) {
+        while ($nextSequence < count($cadenceHours)
+            && $reminder->anchor_at?->copy()->addHours($cadenceHours[$nextSequence])->lte($now)) {
             $nextSequence++;
         }
 
         $reminder->update([
             'last_sent_sequence' => $currentSequence,
             'next_sequence' => $nextSequence,
-            'scheduled_for' => $nextSequence < count(self::CADENCE_HOURS)
-                ? $reminder->anchor_at?->copy()->addHours(self::CADENCE_HOURS[$nextSequence])
+            'scheduled_for' => $nextSequence < count($cadenceHours)
+                ? $reminder->anchor_at?->copy()->addHours($cadenceHours[$nextSequence])
                 : null,
             'sent_at' => $now,
         ]);

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\NotificationType;
+use App\Enums\PartnerStatusTier;
 use App\Jobs\SendPushNotification;
 use App\Models\Application;
 use App\Models\ChallengeCompletion;
 use App\Models\ChatMessage;
 use App\Models\Collaboration;
+use App\Models\Kolab;
 use App\Models\Notification;
 use App\Models\Profile;
 use App\Models\RewardClaim;
@@ -660,6 +662,54 @@ class NotificationService
     private function applicationOpportunity(Application $application): mixed
     {
         return $application->kolab;
+    }
+
+    /**
+     * Notify a business that their Kolab is now live and discoverable.
+     */
+    public function notifyKolabPublished(Kolab $kolab): void
+    {
+        $this->createNotification(
+            recipient: $kolab->creatorProfile,
+            type: NotificationType::KolabPublished,
+            title: 'Your offer is live',
+            body: 'Communities can now discover it and apply. We\'ll let you know when there\'s a match.',
+            targetId: $kolab->id,
+            targetType: 'kolab',
+        );
+    }
+
+    /**
+     * Notify a business their partner status has been upgraded.
+     */
+    public function notifyPartnerStatusUpgraded(Profile $business, PartnerStatusTier $status): void
+    {
+        $body = match ($status) {
+            PartnerStatusTier::ActivePartner => 'You\'re building your reputation as a Kolabing partner.',
+            PartnerStatusTier::TrustedPartner => 'Communities can now see you as a Trusted Partner on Kolabing.',
+            PartnerStatusTier::CommunityFavourite => 'You\'ve reached Community Favourite — the top partner status on Kolabing.',
+            PartnerStatusTier::NewPartner => 'Welcome to Kolabing.',
+        };
+
+        $this->createNotification(
+            recipient: $business,
+            type: NotificationType::PartnerStatusUpgraded,
+            title: "You're now a {$status->label()}",
+            body: $body,
+        );
+    }
+
+    /**
+     * Nudge a subscribed but inactive business back to the platform.
+     */
+    public function notifyReactivation(Profile $business): void
+    {
+        $this->createNotification(
+            recipient: $business,
+            type: NotificationType::ReactivationPrompt,
+            title: 'Ready for your next Kolab?',
+            body: 'Create a new offer or reuse one of your previous ideas.',
+        );
     }
 
     /**

--- a/config/gamification_business.php
+++ b/config/gamification_business.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------
+    | Partner status thresholds
+    |--------------------------------------------------------------------
+    |
+    | Minimums a business must meet to reach each tier. Evaluated from
+    | highest tier down; the first tier whose thresholds are all met wins.
+    | Cancellation rate is intentionally not a criterion yet: the schema
+    | has no column attributing a cancellation to the business vs. the
+    | community side, so it can't be scored fairly (see the gamification
+    | audit, Part 9, open decision on cancellation attribution).
+    |
+    */
+    'tiers' => [
+        'community_favourite' => [
+            'min_completed_kolabs' => 8,
+            'min_average_rating' => 4.5,
+            'min_repeat_partners' => 2,
+        ],
+        'trusted_partner' => [
+            'min_completed_kolabs' => 3,
+            'min_reviews' => 3,
+            'min_average_rating' => 4.0,
+        ],
+        'active_partner' => [
+            'min_completed_kolabs' => 1,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------
+    | Reminder cadences (hours after the anchor event)
+    |--------------------------------------------------------------------
+    */
+    'review_reminder_cadence_hours' => [0, 60, 168],
+    'second_offer_prompt_cadence_hours' => [72, 168, 336],
+
+    /*
+    |--------------------------------------------------------------------
+    | Reactivation
+    |--------------------------------------------------------------------
+    */
+    'reactivation_inactivity_days' => 14,
+    'reactivation_resend_after_days' => 14,
+
+];

--- a/database/factories/BusinessPartnerStatusFactory.php
+++ b/database/factories/BusinessPartnerStatusFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\PartnerStatusTier;
+use App\Models\Profile;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\BusinessPartnerStatus>
+ */
+class BusinessPartnerStatusFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'profile_id' => Profile::factory()->business(),
+            'status' => PartnerStatusTier::NewPartner,
+            'completed_kolabs_count' => 0,
+            'review_count' => 0,
+            'repeat_partner_count' => 0,
+            'average_rating' => null,
+            'recalculated_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_07_15_070219_create_business_partner_statuses_table.php
+++ b/database/migrations/2026_07_15_070219_create_business_partner_statuses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('business_partner_statuses', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('profile_id')
+                ->unique()
+                ->constrained('profiles')
+                ->cascadeOnDelete();
+            $table->string('status')->default('new_partner');
+            $table->unsignedInteger('completed_kolabs_count')->default(0);
+            $table->unsignedInteger('review_count')->default(0);
+            $table->unsignedInteger('repeat_partner_count')->default(0);
+            $table->decimal('average_rating', 3, 2)->nullable();
+            $table->timestamp('recalculated_at')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('business_partner_statuses');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -26,3 +26,7 @@ Schedule::command('app:auto-complete-stale-collaborations')->dailyAt('03:00');
 // earned (xp / tenure / events). Manual tiers are never auto-applied. On-check-in
 // hooks handle immediate promotion; this nightly pass catches tenure rollovers.
 Schedule::command('app:evaluate-community-tiers')->dailyAt('02:00');
+
+// Nudge subscribed but inactive businesses back to the platform.
+// Dedup is done via the notifications table so re-runs are safe.
+Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');

--- a/tests/Feature/Api/V1/BusinessPartnerStatusTest.php
+++ b/tests/Feature/Api/V1/BusinessPartnerStatusTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\BusinessProfile;
+use App\Models\Collaboration;
+use App\Models\CommunityProfile;
+use App\Models\NotificationReminder;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class BusinessPartnerStatusTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function createBusinessProfile(): Profile
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+
+        return $profile;
+    }
+
+    private function createCommunityProfile(): Profile
+    {
+        $profile = Profile::factory()->community()->create();
+        CommunityProfile::factory()->create(['profile_id' => $profile->id]);
+
+        return $profile;
+    }
+
+    /**
+     * /complete now gates on both parties having submitted a 'yes'
+     * completion confirmation first (PR 1, 2026-06-26).
+     */
+    private function confirmCompletionForBothParties(Collaboration $collaboration, Profile $creator, Profile $applicant): void
+    {
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/completion", ['status' => 'yes'])
+            ->assertCreated();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/completion", ['status' => 'yes'])
+            ->assertCreated();
+    }
+
+    public function test_completing_first_kolab_upgrades_business_to_active_partner_and_notifies(): void
+    {
+        $creator = $this->createBusinessProfile();
+        $applicant = $this->createCommunityProfile();
+
+        $collaboration = Collaboration::factory()
+            ->forCreator($creator)
+            ->forApplicant($applicant)
+            ->active()
+            ->create();
+
+        $this->confirmCompletionForBothParties($collaboration, $creator, $applicant);
+
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete")
+            ->assertOk();
+
+        $this->assertDatabaseHas('business_partner_statuses', [
+            'profile_id' => $creator->id,
+            'status' => 'active_partner',
+            'completed_kolabs_count' => 1,
+        ]);
+
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $creator->id,
+            'type' => 'partner_status_upgraded',
+        ]);
+    }
+
+    public function test_completing_kolab_does_not_create_a_partner_status_for_the_community_side(): void
+    {
+        $creator = $this->createBusinessProfile();
+        $applicant = $this->createCommunityProfile();
+
+        $collaboration = Collaboration::factory()
+            ->forCreator($creator)
+            ->forApplicant($applicant)
+            ->active()
+            ->create();
+
+        $this->confirmCompletionForBothParties($collaboration, $creator, $applicant);
+
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete")
+            ->assertOk();
+
+        $this->assertDatabaseMissing('business_partner_statuses', [
+            'profile_id' => $applicant->id,
+        ]);
+    }
+
+    public function test_leaving_a_review_recalculates_the_reviewed_businesss_status(): void
+    {
+        $creator = $this->createBusinessProfile();
+        $applicant = $this->createCommunityProfile();
+
+        $collaboration = Collaboration::factory()
+            ->forCreator($creator)
+            ->forApplicant($applicant)
+            ->completed()
+            ->create();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", [
+                'rating' => 5,
+            ])
+            ->assertCreated();
+
+        $this->assertDatabaseHas('business_partner_statuses', [
+            'profile_id' => $creator->id,
+            'review_count' => 1,
+        ]);
+    }
+
+    public function test_review_reminder_is_scheduled_after_completion_and_cancelled_after_review(): void
+    {
+        $creator = $this->createBusinessProfile();
+        $applicant = $this->createCommunityProfile();
+
+        $collaboration = Collaboration::factory()
+            ->forCreator($creator)
+            ->forApplicant($applicant)
+            ->active()
+            ->create();
+
+        $this->confirmCompletionForBothParties($collaboration, $creator, $applicant);
+
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/complete")
+            ->assertOk();
+
+        $this->assertDatabaseHas('notification_reminders', [
+            'profile_id' => $creator->id,
+            'type' => 'review_reminder',
+            'entity_id' => $collaboration->id,
+        ]);
+
+        $this->actingAs($creator)
+            ->postJson("/api/v1/collaborations/{$collaboration->id}/review", [
+                'rating' => 5,
+            ])
+            ->assertCreated();
+
+        $reminder = NotificationReminder::query()
+            ->where('profile_id', $creator->id)
+            ->where('type', 'review_reminder')
+            ->where('entity_id', $collaboration->id)
+            ->first();
+
+        $this->assertNotNull($reminder);
+        $this->assertNotNull($reminder->cancelled_at);
+    }
+}

--- a/tests/Feature/Api/V1/DashboardNextActionTest.php
+++ b/tests/Feature/Api/V1/DashboardNextActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CollaborationStatus;
+use App\Models\Application;
+use App\Models\BusinessProfile;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class DashboardNextActionTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function createCompleteBusinessProfile(): Profile
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create([
+            'profile_id' => $profile->id,
+            'name' => 'Test Cafe',
+            'about' => 'A lovely cafe.',
+            'business_type' => 'food_drink',
+        ]);
+
+        return $profile;
+    }
+
+    public function test_next_action_prompts_profile_completion_when_business_profile_missing(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action.key', 'complete_profile');
+    }
+
+    public function test_next_action_prompts_first_offer_when_profile_complete_and_no_published_kolabs(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action.key', 'create_first_offer');
+    }
+
+    public function test_next_action_prompts_pending_applications_when_present(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+        $kolab = Kolab::factory()->published()->forCreator($business)->create();
+        Application::factory()->forKolab($kolab)->pending()->create();
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action.key', 'review_pending_applications')
+            ->assertJsonPath('data.next_action.title', 'Review 1 pending application');
+    }
+
+    public function test_next_action_is_null_when_activated_with_no_further_action(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+        Kolab::factory()->published()->forCreator($business)->create();
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action', null);
+    }
+
+    public function test_next_action_prompts_review_for_unreviewed_completed_collaboration(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+        $community = Profile::factory()->community()->create();
+        $kolab = Kolab::factory()->published()->forCreator($business)->create();
+        $application = Application::factory()->forKolab($kolab)->forApplicant($community)->accepted()->create();
+
+        Collaboration::factory()
+            ->forCreator($business)
+            ->forApplicant($community)
+            ->create([
+                'kolab_id' => $kolab->id,
+                'application_id' => $application->id,
+                'status' => CollaborationStatus::Completed,
+                'completed_at' => now(),
+            ]);
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action.key', 'leave_review');
+    }
+
+    public function test_next_action_prompts_second_offer_after_first_kolab_reviewed(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+        $community = Profile::factory()->community()->create();
+        $kolab = Kolab::factory()->published()->forCreator($business)->create();
+        $application = Application::factory()->forKolab($kolab)->forApplicant($community)->accepted()->create();
+
+        $collaboration = Collaboration::factory()
+            ->forCreator($business)
+            ->forApplicant($community)
+            ->create([
+                'kolab_id' => $kolab->id,
+                'application_id' => $application->id,
+                'status' => CollaborationStatus::Completed,
+                'completed_at' => now(),
+            ]);
+
+        CollaborationReview::factory()->create([
+            'collaboration_id' => $collaboration->id,
+            'reviewer_profile_id' => $business->id,
+            'reviewed_profile_id' => $community->id,
+            'reviewer_role' => 'creator',
+            'rating' => 5,
+        ]);
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.next_action.key', 'create_second_offer');
+    }
+
+    public function test_partner_status_block_is_present_with_breakdown(): void
+    {
+        $business = $this->createCompleteBusinessProfile();
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.partner_status.status', 'new_partner')
+            ->assertJsonPath('data.partner_status.label', 'New Partner')
+            ->assertJsonStructure([
+                'data' => [
+                    'partner_status' => [
+                        'status', 'label', 'icon',
+                        'breakdown' => ['completed_kolabs', 'review_count', 'average_rating', 'repeat_partner_count'],
+                    ],
+                ],
+            ]);
+    }
+}

--- a/tests/Feature/Api/V1/KolabPublishedNotificationTest.php
+++ b/tests/Feature/Api/V1/KolabPublishedNotificationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class KolabPublishedNotificationTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_publishing_a_kolab_notifies_the_business_creator(): void
+    {
+        $business = Profile::factory()->business()->create();
+        $kolab = Kolab::factory()->forCreator($business)->create();
+
+        $this->actingAs($business)
+            ->postJson("/api/v1/kolabs/{$kolab->id}/publish")
+            ->assertOk();
+
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $business->id,
+            'type' => 'kolab_published',
+            'target_id' => $kolab->id,
+        ]);
+    }
+
+    public function test_publishing_a_kolab_does_not_notify_a_community_creator(): void
+    {
+        $community = Profile::factory()->community()->create();
+        $kolab = Kolab::factory()->forCreator($community)->create();
+
+        $this->actingAs($community)
+            ->postJson("/api/v1/kolabs/{$kolab->id}/publish")
+            ->assertOk();
+
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $community->id,
+            'type' => 'kolab_published',
+        ]);
+    }
+}

--- a/tests/Feature/Console/SendBusinessReactivationRemindersTest.php
+++ b/tests/Feature/Console/SendBusinessReactivationRemindersTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\BusinessSubscription;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SendBusinessReactivationRemindersTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Backdate a profile's updated_at directly via the query builder — Eloquent
+     * mass assignment guards timestamps, so create()/update() can't set this.
+     */
+    private function backdateActivity(Profile $profile, int $daysAgo): void
+    {
+        DB::table('profiles')->where('id', $profile->id)->update(['updated_at' => now()->subDays($daysAgo)]);
+    }
+
+    public function test_notifies_inactive_business_with_active_subscription(): void
+    {
+        $business = Profile::factory()->business()->create();
+        $this->backdateActivity($business, 20);
+        BusinessSubscription::factory()->active()->create(['profile_id' => $business->id]);
+
+        $this->artisan('app:send-business-reactivation-reminders')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('notifications', [
+            'profile_id' => $business->id,
+            'type' => 'reactivation_prompt',
+        ]);
+    }
+
+    public function test_does_not_notify_recently_active_business(): void
+    {
+        $business = Profile::factory()->business()->create();
+        $this->backdateActivity($business, 2);
+        BusinessSubscription::factory()->active()->create(['profile_id' => $business->id]);
+
+        $this->artisan('app:send-business-reactivation-reminders')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $business->id,
+            'type' => 'reactivation_prompt',
+        ]);
+    }
+
+    public function test_does_not_notify_business_without_active_subscription(): void
+    {
+        $business = Profile::factory()->business()->create();
+        $this->backdateActivity($business, 20);
+        BusinessSubscription::factory()->cancelled()->create(['profile_id' => $business->id]);
+
+        $this->artisan('app:send-business-reactivation-reminders')
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('notifications', [
+            'profile_id' => $business->id,
+            'type' => 'reactivation_prompt',
+        ]);
+    }
+
+    public function test_does_not_send_a_second_reminder_within_the_resend_window(): void
+    {
+        $business = Profile::factory()->business()->create();
+        $this->backdateActivity($business, 20);
+        BusinessSubscription::factory()->active()->create(['profile_id' => $business->id]);
+
+        $this->artisan('app:send-business-reactivation-reminders')->assertSuccessful();
+        $this->assertDatabaseCount('notifications', 1);
+
+        $this->artisan('app:send-business-reactivation-reminders')->assertSuccessful();
+        $this->assertDatabaseCount('notifications', 1);
+    }
+}

--- a/tests/Unit/Services/BusinessPartnerStatusServiceTest.php
+++ b/tests/Unit/Services/BusinessPartnerStatusServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Enums\PartnerStatusTier;
+use App\Models\Collaboration;
+use App\Models\CollaborationReview;
+use App\Models\Profile;
+use App\Services\BusinessPartnerStatusService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class BusinessPartnerStatusServiceTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_new_business_with_no_history_is_new_partner(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        $status = app(BusinessPartnerStatusService::class)->recalculate($business);
+
+        $this->assertSame(PartnerStatusTier::NewPartner, $status);
+    }
+
+    public function test_business_becomes_active_partner_after_one_completed_kolab(): void
+    {
+        $business = Profile::factory()->business()->create();
+        Collaboration::factory()->completed()->forCreator($business)->create();
+
+        $status = app(BusinessPartnerStatusService::class)->recalculate($business);
+
+        $this->assertSame(PartnerStatusTier::ActivePartner, $status);
+    }
+
+    public function test_business_becomes_trusted_partner_with_enough_completions_and_reviews(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        for ($i = 0; $i < 3; $i++) {
+            $collaboration = Collaboration::factory()->completed()->forCreator($business)->create();
+
+            CollaborationReview::factory()->create([
+                'collaboration_id' => $collaboration->id,
+                'reviewer_profile_id' => $collaboration->applicant_profile_id,
+                'reviewed_profile_id' => $business->id,
+                'reviewer_role' => 'applicant',
+                'rating' => 5,
+            ]);
+        }
+
+        $status = app(BusinessPartnerStatusService::class)->recalculate($business);
+
+        $this->assertSame(PartnerStatusTier::TrustedPartner, $status);
+    }
+
+    public function test_low_average_rating_prevents_trusted_partner_despite_enough_completions(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        for ($i = 0; $i < 3; $i++) {
+            $collaboration = Collaboration::factory()->completed()->forCreator($business)->create();
+
+            CollaborationReview::factory()->create([
+                'collaboration_id' => $collaboration->id,
+                'reviewer_profile_id' => $collaboration->applicant_profile_id,
+                'reviewed_profile_id' => $business->id,
+                'reviewer_role' => 'applicant',
+                'rating' => 2,
+            ]);
+        }
+
+        $status = app(BusinessPartnerStatusService::class)->recalculate($business);
+
+        $this->assertSame(PartnerStatusTier::ActivePartner, $status);
+    }
+
+    public function test_repeat_partner_counted_toward_community_favourite(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        // Two communities, each collaborated with twice (two repeat partners),
+        // plus enough additional distinct completions to clear the
+        // community-favourite bar.
+        foreach (Profile::factory()->community()->count(2)->create() as $repeatCommunity) {
+            for ($i = 0; $i < 2; $i++) {
+                $collaboration = Collaboration::factory()->completed()->forCreator($business)->forApplicant($repeatCommunity)->create();
+                CollaborationReview::factory()->create([
+                    'collaboration_id' => $collaboration->id,
+                    'reviewer_profile_id' => $repeatCommunity->id,
+                    'reviewed_profile_id' => $business->id,
+                    'reviewer_role' => 'applicant',
+                    'rating' => 5,
+                ]);
+            }
+        }
+
+        for ($i = 0; $i < 4; $i++) {
+            $collaboration = Collaboration::factory()->completed()->forCreator($business)->create();
+            CollaborationReview::factory()->create([
+                'collaboration_id' => $collaboration->id,
+                'reviewer_profile_id' => $collaboration->applicant_profile_id,
+                'reviewed_profile_id' => $business->id,
+                'reviewer_role' => 'applicant',
+                'rating' => 5,
+            ]);
+        }
+
+        $status = app(BusinessPartnerStatusService::class)->recalculate($business);
+
+        $this->assertSame(PartnerStatusTier::CommunityFavourite, $status);
+
+        $record = $business->fresh()->businessPartnerStatus;
+        $this->assertSame(2, $record->repeat_partner_count);
+    }
+
+    public function test_status_for_falls_back_to_new_partner_without_recomputing(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        $status = app(BusinessPartnerStatusService::class)->statusFor($business);
+
+        $this->assertSame(PartnerStatusTier::NewPartner, $status);
+    }
+}


### PR DESCRIPTION
## Summary
Implements Phase 1 of the business-only gamification/retention strategy (audit + plan discussed separately). Deliberately **not** points/XP-based — the reward is earned trust and visibility, not a virtual prize.

- **Partner Status** (`New Partner` → `Active Partner` → `Trusted Partner` → `Community Favourite`), computed from completed Kolabs, review count/average, and repeat partners. Thresholds live in `config/gamification_business.php`, not hardcoded.
- Recalculated on collaboration completion (all three completion paths: `complete`, `adminForceComplete`, `autoComplete`) and on review submission; fires a `PartnerStatusUpgraded` notification on tier change.
- Dynamic **next-best-action** + `partner_status` block on `GET /me/dashboard` (priority rule chain: complete profile → first offer → pending applications → leave review → second offer).
- Subtle public badge (`status`, `label`, `icon` only — no breakdown) on `BusinessProfileResource`; the private component breakdown stays on the business's own dashboard.
- New notifications: offer-published acknowledgement (`KolabService::publish()`), review reminder + second-offer prompt (reusing the existing `NotificationReminderService` cadence engine), and a 14-day inactivity reactivation nudge (`app:send-business-reactivation-reminders`, scheduled daily).

## Explicitly out of scope (per the plan)
Ranking boosts, financial rewards, multiple public badges, response-time scoring, subscription discounts, admin-configurable campaigns.

## Known open item
Cancellation attribution is **not** part of tier scoring — `collaborations` has no column distinguishing a business-caused vs. community-caused cancellation, so it can't be scored fairly yet. Flagged as a product decision, not a bug.

## Note on rebasing
This branch was built against an older `master` and had to be re-integrated after pulling ~316 upstream commits (mission/XP engine, community `TierAssignmentService`, and a reworked `CollaborationService` completion-confirmation gate). All conflicts were resolved by hand — not auto-merged blindly — and `createdOpportunities()`/`OfferStatus` references (removed upstream) were updated to `kolabs()`/`KolabStatus`. Full test suite for the touched areas is green (business partner status, dashboard, kolab publish, collaboration review/completion, mission/gamification, referral — 200+ passing assertions across the relevant suites).

## Test plan
- [x] `php artisan test --compact tests/Unit/Services/BusinessPartnerStatusServiceTest.php`
- [x] `php artisan test --compact tests/Feature/Api/V1/BusinessPartnerStatusTest.php`
- [x] `php artisan test --compact tests/Feature/Api/V1/DashboardNextActionTest.php`
- [x] `php artisan test --compact tests/Feature/Api/V1/KolabPublishedNotificationTest.php`
- [x] `php artisan test --compact tests/Feature/Console/SendBusinessReactivationRemindersTest.php`
- [x] Regression check: Dashboard, KolabPublishClose, CollaborationReview, PublicProfile, CollaborationCompletionConfirmation, Gamification*, Mission*, Referral suites — all passing
- [ ] Run `php artisan migrate` against a real dev DB (only exercised via SQLite in-memory test runs so far)
- [ ] Manual dashboard smoke test as a real business account
- [ ] Decide on a backfill strategy for existing businesses (currently lazy-recalculates on next completion/review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)