### PR TITLE
Phase 2: visibility boost for Trusted+ partner status

### DIFF
--- a/app/Services/DiscoveryOpportunityService.php
+++ b/app/Services/DiscoveryOpportunityService.php
@@ -23,6 +23,10 @@ use InvalidArgumentException;
 
 class DiscoveryOpportunityService
 {
+    public function __construct(
+        private readonly BusinessPartnerStatusService $businessPartnerStatusService,
+    ) {}
+
     /**
      * @var array<string, array<int, string>>
      */
@@ -1050,13 +1054,43 @@ class DiscoveryOpportunityService
             fn (array $signal): float => $signal['weight'] * $signal['score']
         ) * 100);
 
+        $partnerStatusBoost = $this->resolvePartnerStatusBoost($kolab, $viewerRole);
+        $score = min(100, $score + $partnerStatusBoost['points']);
+
         return [
             'feed' => $filters['feed'],
             'score' => $score,
             'tier' => $this->resolveScoreTier($score),
             'reasons' => array_values(array_unique($reasons)),
             'breakdown' => $breakdown,
+            'partner_status_boost' => $partnerStatusBoost,
         ];
+    }
+
+    /**
+     * Additive visibility boost for a business-authored Kolab based on the
+     * business's partner status, kept separate from the fit-relevance
+     * MATCH_SIGNALS so "why this ranked here" stays legible: fit vs. trust
+     * are different concepts, not blended into one weighted average.
+     *
+     * @return array{tier: ?string, points: int}
+     */
+    private function resolvePartnerStatusBoost(Kolab $kolab, string $viewerRole): array
+    {
+        if ($viewerRole !== 'community') {
+            return ['tier' => null, 'points' => 0];
+        }
+
+        $creator = $kolab->creatorProfile;
+
+        if ($creator === null || ! $creator->isBusiness()) {
+            return ['tier' => null, 'points' => 0];
+        }
+
+        $tier = $this->businessPartnerStatusService->statusFor($creator);
+        $points = (int) (config("gamification_business.visibility_boost_points.{$tier->value}") ?? 0);
+
+        return ['tier' => $tier->value, 'points' => $points];
     }
 
     private function resolveFreshnessScore(?Carbon $publishedAt): int

--- a/config/gamification_business.php
+++ b/config/gamification_business.php
@@ -35,6 +35,23 @@ return [
 
     /*
     |--------------------------------------------------------------------
+    | Discovery visibility boost
+    |--------------------------------------------------------------------
+    |
+    | Additive points added to a business-authored Kolab's discovery match
+    | score for a community viewer, based on the business's partner status.
+    | Kept separate from the fit-relevance signals in
+    | DiscoveryOpportunityService::MATCH_SIGNALS so "why this ranked here"
+    | stays legible: fit vs. trust are different concepts.
+    |
+    */
+    'visibility_boost_points' => [
+        'trusted_partner' => 5,
+        'community_favourite' => 10,
+    ],
+
+    /*
+    |--------------------------------------------------------------------
     | Reminder cadences (hours after the anchor event)
     |--------------------------------------------------------------------
     */

--- a/tests/Feature/Api/V1/DiscoveryPartnerStatusBoostTest.php
+++ b/tests/Feature/Api/V1/DiscoveryPartnerStatusBoostTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\PartnerStatusTier;
+use App\Models\BusinessPartnerStatus;
+use App\Models\BusinessProfile;
+use App\Models\CommunityProfile;
+use App\Models\Kolab;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class DiscoveryPartnerStatusBoostTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function createBusinessCreator(string $name, ?PartnerStatusTier $tier = null): Profile
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create([
+            'profile_id' => $profile->id,
+            'name' => $name,
+            'business_type' => 'cafe',
+            'categories' => ['cafe'],
+            'city_name' => 'Barcelona',
+            'primary_venue' => [
+                'name' => $name,
+                'venue_type' => 'cafe',
+                'capacity' => 120,
+                'formatted_address' => 'Rambla 10, Barcelona',
+                'city' => 'Barcelona',
+                'country' => 'Spain',
+                'photos' => [],
+            ],
+        ]);
+
+        if ($tier !== null) {
+            BusinessPartnerStatus::factory()->create([
+                'profile_id' => $profile->id,
+                'status' => $tier,
+            ]);
+        }
+
+        return $profile;
+    }
+
+    private function createIdenticalVenueKolab(Profile $creator, string $title): Kolab
+    {
+        return Kolab::factory()->published()->venuePromotion()->forCreator($creator)->create([
+            'title' => $title,
+            'preferred_city' => 'Barcelona',
+            'venue_type' => 'cafe',
+            'offering' => ['venue_space', 'free_drinks'],
+            'seeking_communities' => ['Run Club'],
+            'min_community_size' => 80,
+            'expects' => ['social_media'],
+            'availability_start' => now()->addDays(10),
+            'availability_end' => now()->addDays(12),
+        ]);
+    }
+
+    private function createCommunityViewer(): Profile
+    {
+        $viewer = Profile::factory()->community()->create();
+        CommunityProfile::factory()->create([
+            'profile_id' => $viewer->id,
+            'name' => 'Barcelona Run Club',
+            'community_type' => 'run_club',
+        ]);
+
+        return $viewer;
+    }
+
+    public function test_trusted_partner_business_kolab_outranks_otherwise_identical_new_partner_kolab(): void
+    {
+        $viewer = $this->createCommunityViewer();
+
+        $newPartner = $this->createBusinessCreator('New Partner Cafe');
+        $trustedPartner = $this->createBusinessCreator('Trusted Partner Cafe', PartnerStatusTier::TrustedPartner);
+
+        $newPartnerKolab = $this->createIdenticalVenueKolab($newPartner, 'New partner offer');
+        $trustedPartnerKolab = $this->createIdenticalVenueKolab($trustedPartner, 'Trusted partner offer');
+
+        $response = $this->actingAs($viewer)
+            ->getJson('/api/v1/discovery/opportunities?feed=all&sort=recommended');
+
+        $response->assertOk()
+            ->assertJsonPath('data.data.0.id', $trustedPartnerKolab->id)
+            ->assertJsonPath('data.data.0.match.partner_status_boost.tier', 'trusted_partner')
+            ->assertJsonPath('data.data.0.match.partner_status_boost.points', 5);
+
+        $newPartnerEntry = collect($response->json('data.data'))
+            ->firstWhere('id', $newPartnerKolab->id);
+
+        $this->assertSame(0, $newPartnerEntry['match']['partner_status_boost']['points']);
+        $this->assertSame('new_partner', $newPartnerEntry['match']['partner_status_boost']['tier']);
+
+        $trustedEntry = collect($response->json('data.data'))
+            ->firstWhere('id', $trustedPartnerKolab->id);
+
+        $this->assertGreaterThan($newPartnerEntry['match']['score'], $trustedEntry['match']['score']);
+    }
+
+    public function test_community_favourite_boost_is_larger_than_trusted_partner(): void
+    {
+        $viewer = $this->createCommunityViewer();
+
+        $favourite = $this->createBusinessCreator('Favourite Cafe', PartnerStatusTier::CommunityFavourite);
+        $this->createIdenticalVenueKolab($favourite, 'Favourite offer');
+
+        $response = $this->actingAs($viewer)
+            ->getJson('/api/v1/discovery/opportunities?feed=all&sort=recommended');
+
+        $response->assertOk()
+            ->assertJsonPath('data.data.0.match.partner_status_boost.tier', 'community_favourite')
+            ->assertJsonPath('data.data.0.match.partner_status_boost.points', 10);
+    }
+
+    public function test_boost_is_not_applied_when_business_views_community_kolabs(): void
+    {
+        $businessViewer = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $businessViewer->id]);
+
+        $communityCreator = Profile::factory()->community()->create();
+        CommunityProfile::factory()->create(['profile_id' => $communityCreator->id]);
+
+        $kolab = Kolab::factory()->published()->forCreator($communityCreator)->create([
+            'intent_type' => 'community_seeking',
+            'preferred_city' => 'Barcelona',
+        ]);
+
+        $response = $this->actingAs($businessViewer)
+            ->getJson('/api/v1/discovery/opportunities?feed=all');
+
+        $response->assertOk()
+            ->assertJsonPath('data.meta.viewer_role', 'business');
+
+        $entry = collect($response->json('data.data'))->firstWhere('id', $kolab->id);
+
+        $this->assertSame(0, $entry['match']['partner_status_boost']['points']);
+        $this->assertNull($entry['match']['partner_status_boost']['tier']);
+    }
+
+    public function test_score_is_capped_at_one_hundred_after_boost(): void
+    {
+        $viewer = $this->createCommunityViewer();
+        $favourite = $this->createBusinessCreator('Max Score Cafe', PartnerStatusTier::CommunityFavourite);
+
+        $kolab = Kolab::factory()->published()->venuePromotion()->forCreator($favourite)->create([
+            'preferred_city' => 'Barcelona',
+            'venue_type' => 'cafe',
+            'offering' => ['venue_space', 'free_drinks'],
+            'seeking_communities' => ['Run Club'],
+            'min_community_size' => 80,
+            'expects' => ['social_media'],
+            'availability_start' => now()->addDay(),
+            'availability_end' => now()->addDays(2),
+            'published_at' => now(),
+        ]);
+
+        $response = $this->actingAs($viewer)
+            ->getJson('/api/v1/discovery/opportunities?feed=all');
+
+        $entry = collect($response->json('data.data'))->firstWhere('id', $kolab->id);
+
+        $this->assertLessThanOrEqual(100, $entry['match']['score']);
+    }
+}


### PR DESCRIPTION
## Summary
First Phase 2 item from the business gamification plan: Trusted Partner and Community Favourite businesses get a modest, transparent score boost in the community-facing discovery feed. This is the piece the whole plan is built around — status → trust → more applications — Phase 1 (#86) deliberately stopped short of any ranking effect.

- Boost only applies to business-authored Kolabs viewed by a community (`viewerRole === 'community'`), scored via `BusinessPartnerStatusService::statusFor()`.
- **Additive bonus, not blended into the existing weighted fit signals** (`category_fit`, `location`, `value_fit`, `past_activity` in `DiscoveryOpportunityService::MATCH_SIGNALS`) — fit and trust are different concepts, and mixing them would make the per-signal breakdown misleading to communities.
- Values: `trusted_partner` +5, `community_favourite` +10, configurable via `config/gamification_business.php` (`visibility_boost_points`), consistent with how Phase 1 tier thresholds are configured.
- Score capped at 100 after the boost.
- Returned as its own `match.partner_status_boost: { tier, points }` key in the API response — transparent, not hidden inside the existing `breakdown`.

## Scope note
This was one of four Phase 2/3 items discussed (visibility boost, repeat-partner profile surfacing, monthly goal framing, admin-configurable reward campaigns). Visibility boost was prioritized first as the highest-leverage item; the other three are still open.

## Test plan
- [x] `php artisan test --compact tests/Feature/Api/V1/DiscoveryPartnerStatusBoostTest.php` — 4 new tests (Trusted outranks New Partner, Community Favourite boost is larger, no boost in the reverse business-viewing-community direction, score capped at 100)
- [x] `php artisan test --compact tests/Feature/Api/V1/DiscoveryOpportunityControllerTest.php` — no regressions in existing fit-scoring tests
- [x] `tests/Unit/Services/BusinessPartnerStatusServiceTest.php`, `BusinessPartnerStatusTest.php`, `DashboardNextActionTest.php`, `KolabBrowseTest.php`, `KolabPublishCloseTest.php` — all passing
- [x] `vendor/bin/pint --dirty`
- [ ] Manual check: query discovery feed as a community viewer with businesses at mixed tiers, confirm ordering + `match.partner_status_boost` in the JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)