### PR TITLE
Phase 2: repeat-partner visibility + monthly goal framing

### DIFF
--- a/app/Http/Resources/Api/V1/BusinessProfileResource.php
+++ b/app/Http/Resources/Api/V1/BusinessProfileResource.php
@@ -60,10 +60,11 @@ class BusinessProfileResource extends JsonResource
     }
 
     /**
-     * Subtle, public partner status badge — status and label only, no
-     * component breakdown (that stays private to the business's own dashboard).
+     * Subtle, public partner status badge. Carries status/label/icon plus a
+     * quiet repeat-partner count (e.g. "2 repeat partnerships") — the rest of
+     * the component breakdown stays private to the business's own dashboard.
      *
-     * @return array{status: string, label: string, icon: string}|null
+     * @return array{status: string, label: string, icon: string, repeat_partner_count: int}|null
      */
     private function partnerStatusBadge(): ?array
     {
@@ -77,6 +78,7 @@ class BusinessProfileResource extends JsonResource
             'status' => $status->value,
             'label' => $status->label(),
             'icon' => $status->icon(),
+            'repeat_partner_count' => $this->profile->businessPartnerStatus?->repeat_partner_count ?? 0,
         ];
     }
 

--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -27,7 +27,8 @@ class DashboardService
      *     collaborations: array{total: int, active: int, upcoming: int, completed: int},
      *     upcoming_collaborations: \Illuminate\Database\Eloquent\Collection,
      *     partner_status: array{status: string, label: string, icon: string, breakdown: array<string, mixed>},
-     *     next_action: array{key: string, title: string, body: string}|null
+     *     next_action: array{key: string, title: string, body: string}|null,
+     *     monthly_goal: array{completed: int, goal: int, met: bool}
      * }
      */
     public function getBusinessDashboard(Profile $profile): array
@@ -43,6 +44,31 @@ class DashboardService
             'upcoming_collaborations' => $this->getUpcomingCollaborations($profile),
             'partner_status' => $this->getPartnerStatus($profile),
             'next_action' => $this->getNextAction($profile, $opportunities, $applicationsReceived, $collaborations),
+            'monthly_goal' => $this->getMonthlyGoal($profile),
+        ];
+    }
+
+    /**
+     * Rolling calendar-month collaboration goal. Deliberately not a streak:
+     * a quiet month just resets to 0/goal, never shown as "broken" — business
+     * collaboration cadence is naturally seasonal, see
+     * config('gamification_business.monthly_goal_count') for the target.
+     *
+     * @return array{completed: int, goal: int, met: bool}
+     */
+    private function getMonthlyGoal(Profile $profile): array
+    {
+        $goal = (int) config('gamification_business.monthly_goal_count');
+
+        $completed = $this->getAllCollaborationsQuery($profile)
+            ->where('status', CollaborationStatus::Completed)
+            ->where('completed_at', '>=', now()->startOfMonth())
+            ->count();
+
+        return [
+            'completed' => $completed,
+            'goal' => $goal,
+            'met' => $completed >= $goal,
         ];
     }
 

--- a/config/gamification_business.php
+++ b/config/gamification_business.php
@@ -49,4 +49,19 @@ return [
     'reactivation_inactivity_days' => 14,
     'reactivation_resend_after_days' => 14,
 
+    /*
+    |--------------------------------------------------------------------
+    | Monthly goal
+    |--------------------------------------------------------------------
+    |
+    | A rolling calendar-month collaboration goal, shown as progress toward
+    | a target — deliberately NOT a streak. There is no "broken streak"
+    | state: a quiet month resets cleanly to 0/goal next month rather than
+    | penalising the business, since collaboration cadence for cafes,
+    | studios, and venues is naturally seasonal/lumpy (see the gamification
+    | audit, Part 4G).
+    |
+    */
+    'monthly_goal_count' => 1,
+
 ];

--- a/tests/Feature/Api/V1/BusinessRepeatPartnerVisibilityTest.php
+++ b/tests/Feature/Api/V1/BusinessRepeatPartnerVisibilityTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\PartnerStatusTier;
+use App\Models\BusinessPartnerStatus;
+use App\Models\BusinessProfile;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class BusinessRepeatPartnerVisibilityTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_repeat_partner_count_is_exposed_on_the_public_business_profile_badge(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+        BusinessPartnerStatus::factory()->create([
+            'profile_id' => $profile->id,
+            'status' => PartnerStatusTier::TrustedPartner,
+            'repeat_partner_count' => 2,
+        ]);
+
+        $response = $this->actingAs($profile)->getJson('/api/v1/auth/me');
+
+        $response->assertOk()
+            ->assertJsonPath('data.business_profile.partner_status.status', 'trusted_partner')
+            ->assertJsonPath('data.business_profile.partner_status.repeat_partner_count', 2);
+    }
+
+    public function test_repeat_partner_count_defaults_to_zero_without_a_status_row(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+
+        $response = $this->actingAs($profile)->getJson('/api/v1/auth/me');
+
+        $response->assertOk()
+            ->assertJsonPath('data.business_profile.partner_status.repeat_partner_count', 0);
+    }
+}

--- a/tests/Feature/Api/V1/DashboardMonthlyGoalTest.php
+++ b/tests/Feature/Api/V1/DashboardMonthlyGoalTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CollaborationStatus;
+use App\Models\Collaboration;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class DashboardMonthlyGoalTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_monthly_goal_reflects_this_months_completions(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        Collaboration::factory()
+            ->forCreator($business)
+            ->create([
+                'status' => CollaborationStatus::Completed,
+                'completed_at' => now()->startOfMonth()->addDays(2),
+            ]);
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.monthly_goal.completed', 1)
+            ->assertJsonPath('data.monthly_goal.goal', 1)
+            ->assertJsonPath('data.monthly_goal.met', true);
+    }
+
+    public function test_monthly_goal_excludes_last_months_completions_and_is_not_a_broken_streak(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        Collaboration::factory()
+            ->forCreator($business)
+            ->create([
+                'status' => CollaborationStatus::Completed,
+                'completed_at' => now()->subMonth(),
+            ]);
+
+        $response = $this->actingAs($business)->getJson('/api/v1/me/dashboard');
+
+        $response->assertOk()
+            ->assertJsonPath('data.monthly_goal.completed', 0)
+            ->assertJsonPath('data.monthly_goal.met', false);
+    }
+}


### PR DESCRIPTION
## Summary
Two more Phase 2 items from the business gamification plan:

- **Repeat-partner visibility**: `repeat_partner_count` (already computed by `BusinessPartnerStatusService`) now shows as a quiet detail on the public business profile badge — `partner_status: { status, label, icon, repeat_partner_count }`. No new public badge, per the original plan's guidance to keep this a small detail, not a separate achievement.
- **Monthly goal framing**: business dashboard now includes `monthly_goal: { completed, goal, met }` — a rolling calendar-month collaboration count against a configurable target (`config('gamification_business.monthly_goal_count')`, default 1). Deliberately **not** a streak: a quiet month just resets to 0/goal next month, never rendered as "broken" — collaboration cadence for cafes/studios/venues is naturally seasonal (audit Part 4G explicitly warns against streak mechanics for this reason).

## Test plan
- [x] `BusinessRepeatPartnerVisibilityTest.php` — 2 new tests
- [x] `DashboardMonthlyGoalTest.php` — 2 new tests
- [x] Regression: `DashboardTest.php`, `DashboardNextActionTest.php`, `PublicProfileTest.php` — all passing
- [x] `vendor/bin/pint --dirty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)