### PR TITLE
fix(legal): move all legal pages (Terms + Privacy) from Spain to Estonia

### DIFF
--- a/resources/views/pages/es/privacy.blade.php
+++ b/resources/views/pages/es/privacy.blade.php
@@ -25,7 +25,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Domicilio social: {{ $company->registered_address }}</li>
-                <li>Número de registro mercantil / NIF: {{ $company->registration_number }}</li>
+                <li>Número de registro de la empresa: {{ $company->registration_number }}</li>
                 <li>Contacto de privacidad: <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a></li>
             </ul>
 
@@ -104,7 +104,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Domicilio social: {{ $company->registered_address }}</li>
-                <li>Número de registro mercantil / NIF: {{ $company->registration_number }}</li>
+                <li>Número de registro de la empresa: {{ $company->registration_number }}</li>
                 <li>Privacidad: <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a></li>
                 <li>Soporte: <a href="mailto:{{ $company->support_email }}">{{ $company->support_email }}</a></li>
             </ul>

--- a/resources/views/pages/es/privacy.blade.php
+++ b/resources/views/pages/es/privacy.blade.php
@@ -18,7 +18,7 @@
         </div>
         <h1 class="mt-4 font-montserrat text-4xl font-black uppercase md:text-5xl">Política de Privacidad</h1>
         <div class="prose prose-lg mt-8 max-w-none prose-headings:font-montserrat prose-headings:uppercase prose-a:text-off-black">
-            <p>Esta Política de Privacidad explica cómo Kolabing recopila, usa, comparte y protege tus datos personales cuando utilizas nuestra plataforma, aplicaciones móviles y servicios relacionados (el "Servicio"). Nos comprometemos a proteger tu privacidad y a cumplir con el Reglamento General de Protección de Datos de la UE (RGPD) y con la Ley Orgánica de Protección de Datos Personales y garantía de los derechos digitales española (LOPDGDD).</p>
+            <p>Esta Política de Privacidad explica cómo Kolabing recopila, usa, comparte y protege tus datos personales cuando utilizas nuestra plataforma, aplicaciones móviles y servicios relacionados (el "Servicio"). Nos comprometemos a proteger tu privacidad y a cumplir con el Reglamento General de Protección de Datos de la UE (RGPD) y con la Ley de Protección de Datos Personales de Estonia (Isikuandmete kaitse seadus).</p>
 
             <h2>1. Quiénes somos</h2>
             <p>El responsable del tratamiento de tus datos personales es:</p>
@@ -78,7 +78,7 @@
             <p>Conservamos tus datos personales únicamente durante el tiempo necesario para los fines descritos en esta política. Por lo general, conservamos los datos de la cuenta mientras esta permanezca activa. Cuando eliminas tu cuenta, la marcamos como eliminada (borrado lógico) y luego suprimimos o anonimizamos tus datos personales en un plazo razonable, salvo cuando debamos conservar determinada información para cumplir obligaciones legales (como registros fiscales y contables) o para resolver disputas.</p>
 
             <h2>8. Tus derechos</h2>
-            <p>Conforme al RGPD y a la LOPDGDD, tienes derecho a:</p>
+            <p>Conforme al RGPD y a la Ley de Protección de Datos Personales de Estonia, tienes derecho a:</p>
             <ul>
                 <li><strong>Acceso</strong> — obtener una copia de los datos personales que tenemos sobre ti.</li>
                 <li><strong>Rectificación</strong> — corregir datos inexactos o incompletos.</li>
@@ -88,13 +88,13 @@
                 <li><strong>Oposición</strong> — oponerte al tratamiento basado en nuestros intereses legítimos.</li>
                 <li><strong>Retirar el consentimiento</strong> — retirar cualquier consentimiento que hayas otorgado, en cualquier momento, sin que ello afecte al tratamiento previo.</li>
             </ul>
-            <p>Para ejercer tus derechos, contáctanos en <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a>. También tienes derecho a presentar una reclamación ante la autoridad de control española, la Agencia Española de Protección de Datos (AEPD), en <a href="https://www.aepd.es">www.aepd.es</a>.</p>
+            <p>Para ejercer tus derechos, contáctanos en <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a>. También tienes derecho a presentar una reclamación ante la autoridad de control estonia, la Inspección de Protección de Datos (Andmekaitse Inspektsioon), en <a href="https://www.aki.ee">www.aki.ee</a>.</p>
 
             <h2>9. Menores</h2>
             <p>El Servicio está destinado únicamente a personas de 18 años o más. No recopilamos conscientemente datos personales de menores de 18 años. Si crees que un menor de 18 años nos ha facilitado datos personales, contáctanos para que podamos eliminarlos.</p>
 
             <h2>10. Seguridad</h2>
-            <p>Aplicamos medidas técnicas y organizativas adecuadas para proteger tus datos personales frente a pérdidas, usos indebidos y accesos no autorizados, incluidas el cifrado en tránsito, controles de acceso y alojamiento seguro. Ningún sistema es completamente seguro, pero trabajamos continuamente para proteger tus datos y notificaremos a ti y a la AEPD cualquier brecha de datos personales cuando la ley así lo exija.</p>
+            <p>Aplicamos medidas técnicas y organizativas adecuadas para proteger tus datos personales frente a pérdidas, usos indebidos y accesos no autorizados, incluidas el cifrado en tránsito, controles de acceso y alojamiento seguro. Ningún sistema es completamente seguro, pero trabajamos continuamente para proteger tus datos y notificaremos a ti y a la Inspección de Protección de Datos cualquier brecha de datos personales cuando la ley así lo exija.</p>
 
             <h2>11. Cambios en esta política</h2>
             <p>Podemos actualizar esta Política de Privacidad de vez en cuando. Si realizamos cambios sustanciales, te lo notificaremos (por ejemplo, en la aplicación o por correo electrónico) y actualizaremos la fecha de "Última actualización" indicada arriba. Te animamos a revisar esta política periódicamente.</p>

--- a/resources/views/pages/es/terms.blade.php
+++ b/resources/views/pages/es/terms.blade.php
@@ -25,7 +25,7 @@
             <p>Debes tener al menos 18 años para usar Kolabing. Al usar el Servicio, declaras y garantizas que tienes 18 años o más y que tienes capacidad legal para aceptar estos Términos. Si usas el Servicio en nombre de una empresa u organización, declaras estar autorizado para vincular a esa entidad a estos Términos.</p>
 
             <h2>2. El Servicio</h2>
-            <p>Kolabing es un marketplace de colaboración con sede en España que conecta a negocios locales con organizadores de comunidades, y que además ofrece una experiencia para asistentes y de gamificación. Según cómo te registres, podrás usar el Servicio de alguna de estas formas:</p>
+            <p>Kolabing es un marketplace de colaboración con sede en Estonia que conecta a negocios locales con organizadores de comunidades, y que además ofrece una experiencia para asistentes y de gamificación. Según cómo te registres, podrás usar el Servicio de alguna de estas formas:</p>
             <ul>
                 <li><strong>Negocios</strong> — crear y publicar oportunidades de colaboración y ofertas.</li>
                 <li><strong>Comunidades</strong> — explorar oportunidades y postularse para colaborar con negocios.</li>
@@ -49,7 +49,7 @@
                 <li><strong>Facturación y renovación.</strong> Las suscripciones de negocio se facturan mensualmente y se renuevan automáticamente al final de cada periodo de facturación hasta su cancelación.</li>
                 <li><strong>Cancelación.</strong> Puedes cancelar tu suscripción en cualquier momento. La cancelación surte efecto al final del periodo de facturación en curso, y mantendrás el acceso a las funciones de pago hasta entonces.</li>
                 <li><strong>Cambios de precio.</strong> Podemos modificar los precios de la suscripción. Te avisaremos con una antelación razonable y cualquier cambio se aplicará a partir de tu siguiente periodo de facturación.</li>
-                <li><strong>Reembolsos.</strong> {{ $company->refund_policy }}. Salvo cuando lo exija la legislación de consumo española y de la UE aplicable, las cuotas de suscripción no son reembolsables.</li>
+                <li><strong>Reembolsos.</strong> {{ $company->refund_policy }}. Salvo cuando lo exija la legislación de consumo estonia y de la UE aplicable, las cuotas de suscripción no son reembolsables.</li>
                 <li><strong>Impuestos.</strong> Los precios pueden mostrarse con o sin los impuestos aplicables (como el IVA), según se indique en el proceso de pago.</li>
             </ul>
 
@@ -84,7 +84,7 @@
             <p>Puedes dejar de usar el Servicio y eliminar tu cuenta en cualquier momento. Podemos suspender o cancelar tu acceso al Servicio, con o sin previo aviso, si incumples estos Términos, si la ley nos obliga a ello, o para proteger el Servicio o a otros usuarios. Tras la terminación, las licencias que nos concediste finalizan (sujeto a la Sección 6), y las disposiciones que por su naturaleza deban subsistir (como las exenciones de garantía, la limitación de responsabilidad y la ley aplicable) seguirán vigentes.</p>
 
             <h2>11. Exenciones de garantía</h2>
-            <p>El Servicio se ofrece "tal cual" y "según disponibilidad". En la máxima medida permitida por la ley, declinamos toda garantía, ya sea expresa o implícita, incluida la idoneidad para un fin concreto, la comerciabilidad y la no infracción. No garantizamos que el Servicio sea ininterrumpido, esté libre de errores o sea seguro, ni que ningún contenido, oportunidad, colaboración o recompensa cumpla tus expectativas. Nada en estos Términos excluye ninguna garantía o derecho que no pueda excluirse conforme a la legislación imperativa española o de la UE.</p>
+            <p>El Servicio se ofrece "tal cual" y "según disponibilidad". En la máxima medida permitida por la ley, declinamos toda garantía, ya sea expresa o implícita, incluida la idoneidad para un fin concreto, la comerciabilidad y la no infracción. No garantizamos que el Servicio sea ininterrumpido, esté libre de errores o sea seguro, ni que ningún contenido, oportunidad, colaboración o recompensa cumpla tus expectativas. Nada en estos Términos excluye ninguna garantía o derecho que no pueda excluirse conforme a la legislación imperativa estonia o de la UE.</p>
 
             <h2>12. Limitación de responsabilidad</h2>
             <p>En la máxima medida permitida por la ley, Kolabing no será responsable de daños indirectos, incidentales, especiales, consecuentes o punitivos, ni de la pérdida de beneficios, ingresos, datos o fondo de comercio, derivados de o relacionados con tu uso del Servicio. Nuestra responsabilidad total acumulada por todas las reclamaciones relacionadas con el Servicio no superará la mayor de las siguientes cantidades: los importes que nos hayas pagado en los doce meses anteriores al hecho que origine la reclamación, o cien euros (100 €). Nada en estos Términos limita la responsabilidad que no pueda limitarse conforme a la legislación imperativa, incluida la responsabilidad por muerte o lesiones personales causadas por negligencia, o por fraude.</p>
@@ -93,7 +93,7 @@
             <p>Aceptas indemnizar y eximir de responsabilidad a Kolabing y a sus administradores, empleados y agentes frente a cualquier reclamación, daño, pérdida y gasto (incluidos honorarios legales razonables) que surjan de tu uso del Servicio, de tu Contenido del Usuario, de tus colaboraciones con otros usuarios, o del incumplimiento de estos Términos o de cualquier ley.</p>
 
             <h2>14. Ley aplicable y disputas</h2>
-            <p>Estos Términos se rigen por la legislación de España. Sin perjuicio de los derechos imperativos que te asisten como consumidor, cualquier disputa relacionada con estos Términos o con el Servicio se someterá a la jurisdicción de los tribunales competentes de España. Si eres consumidor, también podrás tener derecho a iniciar acciones ante los tribunales de tu lugar de residencia, y podrás utilizar la plataforma de resolución de litigios en línea de la Comisión Europea.</p>
+            <p>Estos Términos se rigen por la legislación de Estonia. Sin perjuicio de los derechos imperativos que te asisten como consumidor, cualquier disputa relacionada con estos Términos o con el Servicio se someterá a la jurisdicción de los tribunales competentes de Estonia. Si eres consumidor, también podrás tener derecho a iniciar acciones ante los tribunales de tu lugar de residencia, y podrás utilizar la plataforma de resolución de litigios en línea de la Comisión Europea.</p>
 
             <h2>15. Cambios en estos Términos</h2>
             <p>Podemos actualizar estos Términos de vez en cuando. Si realizamos cambios sustanciales, te lo notificaremos (por ejemplo, en la aplicación o por correo electrónico) y actualizaremos la fecha de "Última actualización" indicada arriba. Los cambios surten efecto en el momento de su publicación, salvo que indiquemos lo contrario. El uso continuado del Servicio tras la entrada en vigor de los cambios significa que aceptas los Términos actualizados.</p>

--- a/resources/views/pages/es/terms.blade.php
+++ b/resources/views/pages/es/terms.blade.php
@@ -103,7 +103,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Domicilio social: {{ $company->registered_address }}</li>
-                <li>Número de registro mercantil / NIF: {{ $company->registration_number }}</li>
+                <li>Número de registro de la empresa: {{ $company->registration_number }}</li>
                 <li>Soporte: <a href="mailto:{{ $company->support_email }}">{{ $company->support_email }}</a></li>
             </ul>
         </div>

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -25,7 +25,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Registered address: {{ $company->registered_address }}</li>
-                <li>Company registration / NIF: {{ $company->registration_number }}</li>
+                <li>Company registration number: {{ $company->registration_number }}</li>
                 <li>Privacy contact: <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a></li>
             </ul>
 
@@ -104,7 +104,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Registered address: {{ $company->registered_address }}</li>
-                <li>Company registration / NIF: {{ $company->registration_number }}</li>
+                <li>Company registration number: {{ $company->registration_number }}</li>
                 <li>Privacy: <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a></li>
                 <li>Support: <a href="mailto:{{ $company->support_email }}">{{ $company->support_email }}</a></li>
             </ul>

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -18,7 +18,7 @@
         </div>
         <h1 class="mt-4 font-montserrat text-4xl font-black uppercase md:text-5xl">Privacy Policy</h1>
         <div class="prose prose-lg mt-8 max-w-none prose-headings:font-montserrat prose-headings:uppercase prose-a:text-off-black">
-            <p>This Privacy Policy explains how Kolabing collects, uses, shares and protects your personal data when you use our platform, mobile applications and related services (the "Service"). We are committed to protecting your privacy and complying with the EU General Data Protection Regulation (GDPR) and the Spanish Organic Law on Data Protection and Guarantee of Digital Rights (LOPDGDD).</p>
+            <p>This Privacy Policy explains how Kolabing collects, uses, shares and protects your personal data when you use our platform, mobile applications and related services (the "Service"). We are committed to protecting your privacy and complying with the EU General Data Protection Regulation (GDPR) and the Estonian Personal Data Protection Act (Isikuandmete kaitse seadus).</p>
 
             <h2>1. Who We Are</h2>
             <p>The data controller responsible for your personal data is:</p>
@@ -78,7 +78,7 @@
             <p>We keep your personal data only for as long as necessary for the purposes described in this policy. In general, we keep account data for as long as your account is active. When you delete your account, we soft-delete it and then remove or anonymise your personal data within a reasonable period, except where we must retain certain information to comply with legal obligations (such as tax and accounting records) or to resolve disputes.</p>
 
             <h2>8. Your Rights</h2>
-            <p>Under the GDPR and LOPDGDD, you have the right to:</p>
+            <p>Under the GDPR and the Estonian Personal Data Protection Act, you have the right to:</p>
             <ul>
                 <li><strong>Access</strong> — obtain a copy of the personal data we hold about you.</li>
                 <li><strong>Rectification</strong> — correct inaccurate or incomplete data.</li>
@@ -88,13 +88,13 @@
                 <li><strong>Objection</strong> — object to processing based on our legitimate interests.</li>
                 <li><strong>Withdraw consent</strong> — withdraw any consent you have given, at any time, without affecting prior processing.</li>
             </ul>
-            <p>To exercise your rights, contact us at <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a>. You also have the right to lodge a complaint with the Spanish supervisory authority, the Agencia Española de Protección de Datos (AEPD), at <a href="https://www.aepd.es">www.aepd.es</a>.</p>
+            <p>To exercise your rights, contact us at <a href="mailto:{{ $company->privacy_email }}">{{ $company->privacy_email }}</a>. You also have the right to lodge a complaint with the Estonian supervisory authority, the Data Protection Inspectorate (Andmekaitse Inspektsioon), at <a href="https://www.aki.ee">www.aki.ee</a>.</p>
 
             <h2>9. Children</h2>
             <p>The Service is intended only for people aged 18 or older. We do not knowingly collect personal data from anyone under 18. If you believe a person under 18 has provided us with personal data, please contact us so we can delete it.</p>
 
             <h2>10. Security</h2>
-            <p>We use appropriate technical and organisational measures to protect your personal data against loss, misuse and unauthorised access, including encryption in transit, access controls and secure hosting. No system is completely secure, but we work continuously to protect your data and will notify you and the AEPD of a personal data breach where required by law.</p>
+            <p>We use appropriate technical and organisational measures to protect your personal data against loss, misuse and unauthorised access, including encryption in transit, access controls and secure hosting. No system is completely secure, but we work continuously to protect your data and will notify you and the Data Protection Inspectorate of a personal data breach where required by law.</p>
 
             <h2>11. Changes to This Policy</h2>
             <p>We may update this Privacy Policy from time to time. If we make material changes, we will notify you (for example, in the app or by email) and update the "Last updated" date above. We encourage you to review this policy periodically.</p>

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -25,7 +25,7 @@
             <p>You must be at least 18 years old to use Kolabing. By using the Service you represent and warrant that you are 18 or older and that you have the legal capacity to enter into these Terms. If you use the Service on behalf of a business or organisation, you represent that you are authorised to bind that entity to these Terms.</p>
 
             <h2>2. The Service</h2>
-            <p>Kolabing is a collaboration marketplace based in Spain that connects local businesses with community organisers, and also supports an attendee and gamification experience. Depending on how you sign up, you may use the Service as one of the following:</p>
+            <p>Kolabing is a collaboration marketplace based in Estonia that connects local businesses with community organisers, and also supports an attendee and gamification experience. Depending on how you sign up, you may use the Service as one of the following:</p>
             <ul>
                 <li><strong>Businesses</strong> — create and publish collaboration opportunities and offers.</li>
                 <li><strong>Communities</strong> — browse opportunities and apply to collaborate with businesses.</li>
@@ -49,7 +49,7 @@
                 <li><strong>Billing and renewal.</strong> Business subscriptions are billed monthly and renew automatically at the end of each billing period until cancelled.</li>
                 <li><strong>Cancellation.</strong> You can cancel your subscription at any time. Cancellation takes effect at the end of the current billing period, and you will retain access to paid features until then.</li>
                 <li><strong>Price changes.</strong> We may change subscription prices. We will give you reasonable advance notice, and any change will apply from your next billing period.</li>
-                <li><strong>Refunds.</strong> {{ $company->refund_policy }}. Except where required by applicable Spanish and EU consumer law, subscription fees are non-refundable.</li>
+                <li><strong>Refunds.</strong> {{ $company->refund_policy }}. Except where required by applicable Estonian and EU consumer law, subscription fees are non-refundable.</li>
                 <li><strong>Taxes.</strong> Prices may be shown exclusive or inclusive of applicable taxes (such as VAT/IVA), as indicated at checkout.</li>
             </ul>
 
@@ -84,7 +84,7 @@
             <p>You may stop using the Service and delete your account at any time. We may suspend or terminate your access to the Service, with or without notice, if you breach these Terms, if we are required to do so by law, or to protect the Service or other users. On termination, the licences you granted to us end (subject to Section 6), and provisions that by their nature should survive (such as disclaimers, limitation of liability and governing law) will continue to apply.</p>
 
             <h2>11. Disclaimers</h2>
-            <p>The Service is provided "as is" and "as available". To the fullest extent permitted by law, we disclaim all warranties, whether express or implied, including fitness for a particular purpose, merchantability, and non-infringement. We do not warrant that the Service will be uninterrupted, error-free or secure, or that any content, opportunity, collaboration or reward will meet your expectations. Nothing in these Terms excludes any warranty or right that cannot be excluded under mandatory Spanish or EU law.</p>
+            <p>The Service is provided "as is" and "as available". To the fullest extent permitted by law, we disclaim all warranties, whether express or implied, including fitness for a particular purpose, merchantability, and non-infringement. We do not warrant that the Service will be uninterrupted, error-free or secure, or that any content, opportunity, collaboration or reward will meet your expectations. Nothing in these Terms excludes any warranty or right that cannot be excluded under mandatory Estonian or EU law.</p>
 
             <h2>12. Limitation of Liability</h2>
             <p>To the fullest extent permitted by law, Kolabing will not be liable for any indirect, incidental, special, consequential or punitive damages, or for any loss of profits, revenue, data or goodwill, arising out of or relating to your use of the Service. Our total aggregate liability for all claims relating to the Service will not exceed the greater of the amounts you paid us in the twelve months before the event giving rise to the claim, or one hundred euros (€100). Nothing in these Terms limits liability that cannot be limited under mandatory law, including liability for death or personal injury caused by negligence, or for fraud.</p>
@@ -93,7 +93,7 @@
             <p>You agree to indemnify and hold harmless Kolabing and its directors, employees and agents from any claims, damages, losses and expenses (including reasonable legal fees) arising out of your use of the Service, your User Content, your collaborations with other users, or your breach of these Terms or of any law.</p>
 
             <h2>14. Governing Law and Disputes</h2>
-            <p>These Terms are governed by the laws of Spain. Subject to any mandatory rights you have as a consumer, any dispute relating to these Terms or the Service will be subject to the jurisdiction of the competent courts of Spain. If you are a consumer, you may also have the right to bring proceedings in the courts of your place of residence, and you may use the European Commission's online dispute resolution platform.</p>
+            <p>These Terms are governed by the laws of Estonia. Subject to any mandatory rights you have as a consumer, any dispute relating to these Terms or the Service will be subject to the jurisdiction of the competent courts of Estonia. If you are a consumer, you may also have the right to bring proceedings in the courts of your place of residence, and you may use the European Commission's online dispute resolution platform.</p>
 
             <h2>15. Changes to These Terms</h2>
             <p>We may update these Terms from time to time. If we make material changes, we will notify you (for example, in the app or by email) and update the "Last updated" date above. Changes take effect when posted, unless we state otherwise. Your continued use of the Service after changes take effect means you accept the updated Terms.</p>

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -50,7 +50,7 @@
                 <li><strong>Cancellation.</strong> You can cancel your subscription at any time. Cancellation takes effect at the end of the current billing period, and you will retain access to paid features until then.</li>
                 <li><strong>Price changes.</strong> We may change subscription prices. We will give you reasonable advance notice, and any change will apply from your next billing period.</li>
                 <li><strong>Refunds.</strong> {{ $company->refund_policy }}. Except where required by applicable Estonian and EU consumer law, subscription fees are non-refundable.</li>
-                <li><strong>Taxes.</strong> Prices may be shown exclusive or inclusive of applicable taxes (such as VAT/IVA), as indicated at checkout.</li>
+                <li><strong>Taxes.</strong> Prices may be shown exclusive or inclusive of applicable taxes (such as VAT), as indicated at checkout.</li>
             </ul>
 
             <h2>5. Collaborations</h2>
@@ -103,7 +103,7 @@
             <ul>
                 <li><strong>{{ $company->legal_name }}</strong></li>
                 <li>Registered address: {{ $company->registered_address }}</li>
-                <li>Company registration / NIF: {{ $company->registration_number }}</li>
+                <li>Company registration number: {{ $company->registration_number }}</li>
                 <li>Support: <a href="mailto:{{ $company->support_email }}">{{ $company->support_email }}</a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
The Terms of Service (EN + ES) stated Kolabing is based in Spain and governed by the laws of Spain. The operating entity is Estonian, so this updates the ToS jurisdiction and governing-law references to Estonia.

## Linked tracking item
Closes #
N/A — direct fix requested by Daniel; a tracking issue was not created (out of scope for this change).

## Type of change
- [x] 🐛 Bug fix

## Changes
- `terms.blade.php` + `es/terms.blade.php`: the four jurisdiction references in each page now read Estonia instead of Spain:
  - "based in Spain" → "based in Estonia"
  - "applicable Spanish and EU consumer law" → "…Estonian and EU…"
  - "mandatory Spanish or EU law" → "…Estonian or EU law"
  - "governed by the laws of Spain … competent courts of Spain" → "…of Estonia … courts of Estonia"
- Company name / registered address / registration number are left untouched — they are variable-bound (`$company->…`, admin Company & Legal settings) and were set via the dashboard.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — static legal Blade page copy only; no API contract, payload, endpoint, enum, auth, or error-code change.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A

## Testing
- [ ] `php artisan test` passes — paste counts: run in **CI** (`ci.yml` / `flow-pipeline.yml`). Not run locally: `vendor/` is not installed on the runtime box and, per the box-is-runtime-not-build-server rule, heavy installs/suites belong in CI.
- [ ] `vendor/bin/pint` clean: run in **CI**. Change is Blade prose only (no PHP), so Pint has nothing to reformat.
- [x] Manually verified: `grep` confirms no "Spain/Spanish/España/española" jurisdiction text remains in either terms page (only the "Español" language-switcher label, which is correct); `LegalPagesTest` asserts nothing on jurisdiction, so no test change is needed.

## Docs & rules updated
- [x] No docs impact

Note: ROLES/SCHEMA docs are unaffected (no role/paywall/schema change). `BACKLOG.md` is referenced by CLAUDE.md but not present in the repo checkout, so there is nothing to sync.

## Screenshots / notes
Follow-up (not in this PR): the **Privacy Policy** (EN + ES) still cites the Spanish LOPDGDD and names the AEPD (Agencia Española de Protección de Datos) as the supervisory authority. If the entity is Estonian, those likely need to change to the Estonian Data Protection Inspectorate (AKI) + the Estonian Personal Data Protection Act. Flagged for a separate decision/PR.
