### PR TITLE
fix(legal): payments are Apple App Store subscription, not Stripe

### DIFF
--- a/resources/views/pages/es/privacy.blade.php
+++ b/resources/views/pages/es/privacy.blade.php
@@ -37,7 +37,7 @@
                 <li><strong>Datos de ubicación.</strong> Con tu permiso, tratamos tu ubicación aproximada o precisa (latitud y longitud) para mostrarte eventos cercanos y permitir el check-in en eventos.</li>
                 <li><strong>Notificaciones push.</strong> Si activas las notificaciones, tratamos un token push del dispositivo (a través de Firebase Cloud Messaging) y tus preferencias de notificación.</li>
                 <li><strong>Mensajería.</strong> Hilos de chat y mensajes intercambiados entre usuarios dentro de la aplicación.</li>
-                <li><strong>Datos de pago.</strong> Si eres un usuario de negocio con una suscripción mensual, los pagos son procesados por Stripe. No almacenamos el número completo de tu tarjeta; conservamos datos limitados de la transacción y de la suscripción.</li>
+                <li><strong>Datos de pago.</strong> Si eres un usuario de negocio con una suscripción mensual, el pago lo procesa <strong>Apple</strong> a través de tu cuenta de la App Store (compra dentro de la aplicación). No recibimos ni almacenamos los datos de tu tarjeta; conservamos datos limitados del estado de la suscripción e identificadores de transacción proporcionados por Apple.</li>
                 <li><strong>Datos de uso y analítica.</strong> Analítica de producto recopilada a través de PostHog para entender cómo se usa el Servicio y mejorarlo. Puedes optar por no participar en la analítica.</li>
                 <li><strong>Comunicaciones de soporte.</strong> El contenido de cualquier mensaje que nos envíes para obtener soporte.</li>
             </ul>
@@ -64,7 +64,7 @@
             <p>No vendemos tus datos personales. Los compartimos únicamente con proveedores de confianza ("encargados del tratamiento") que los tratan por cuenta nuestra bajo contrato, y cuando lo exige la ley. Entre ellos:</p>
             <ul>
                 <li><strong>Google</strong> y <strong>Apple</strong> — inicio de sesión y autenticación.</li>
-                <li><strong>Stripe</strong> — procesamiento de pagos.</li>
+                <li><strong>Apple</strong> (App Store / compra dentro de la aplicación) — facturación y procesamiento de pagos de la suscripción.</li>
                 <li><strong>Firebase Cloud Messaging</strong> y el <strong>servicio de notificaciones push de Apple</strong> — envío de notificaciones push.</li>
                 <li><strong>Proveedores de alojamiento en la nube</strong> — alojamiento y almacenamiento del Servicio y de sus datos.</li>
                 <li><strong>PostHog</strong> — analítica de producto.</li>

--- a/resources/views/pages/es/terms.blade.php
+++ b/resources/views/pages/es/terms.blade.php
@@ -44,12 +44,12 @@
             <p>Eres responsable de mantener la seguridad de tu cuenta y de tu dispositivo. No somos responsables de ninguna pérdida derivada de que no protejas tus credenciales.</p>
 
             <h2>4. Suscripciones y pagos</h2>
-            <p>Algunas funciones están disponibles únicamente para usuarios de negocio mediante una suscripción mensual de pago. Los pagos son procesados por nuestro proveedor de pagos, <strong>Stripe</strong>. No almacenamos el número completo de tu tarjeta.</p>
+            <p>Algunas funciones están disponibles únicamente para usuarios de negocio mediante una suscripción mensual de pago. Las suscripciones se compran y se facturan a través de tu cuenta de la <strong>App Store de Apple</strong> como una compra dentro de la aplicación; Apple procesa el pago y nosotros nunca recibimos ni almacenamos los datos de tu tarjeta. La facturación y las renovaciones las gestiona Apple a través de tu Apple ID.</p>
             <ul>
                 <li><strong>Facturación y renovación.</strong> Las suscripciones de negocio se facturan mensualmente y se renuevan automáticamente al final de cada periodo de facturación hasta su cancelación.</li>
-                <li><strong>Cancelación.</strong> Puedes cancelar tu suscripción en cualquier momento. La cancelación surte efecto al final del periodo de facturación en curso, y mantendrás el acceso a las funciones de pago hasta entonces.</li>
+                <li><strong>Cancelación.</strong> Puedes cancelar en cualquier momento desde los ajustes de suscripción de tu Apple ID en tu dispositivo. La cancelación surte efecto al final del periodo de facturación en curso, y mantendrás el acceso a las funciones de pago hasta entonces.</li>
                 <li><strong>Cambios de precio.</strong> Podemos modificar los precios de la suscripción. Te avisaremos con una antelación razonable y cualquier cambio se aplicará a partir de tu siguiente periodo de facturación.</li>
-                <li><strong>Reembolsos.</strong> {{ $company->refund_policy }}. Salvo cuando lo exija la legislación de consumo española y de la UE aplicable, las cuotas de suscripción no son reembolsables.</li>
+                <li><strong>Reembolsos.</strong> {{ $company->refund_policy }}. Las suscripciones compradas a través de la App Store están sujetas al proceso de reembolso de Apple, y las solicitudes de reembolso las gestiona Apple. Salvo cuando lo exija la legislación de consumo española y de la UE aplicable, las cuotas de suscripción no son reembolsables.</li>
                 <li><strong>Impuestos.</strong> Los precios pueden mostrarse con o sin los impuestos aplicables (como el IVA), según se indique en el proceso de pago.</li>
             </ul>
 
@@ -78,7 +78,7 @@
             <p>El Servicio, incluidos su software, diseño, textos, gráficos, logotipos y marcas (pero excluyendo el Contenido del Usuario), es propiedad de Kolabing o de sus licenciantes y está protegido por las leyes de propiedad intelectual. Te concedemos una licencia limitada, personal, intransferible y revocable para usar el Servicio según su finalidad prevista. No puedes copiar, modificar, distribuir, vender ni crear obras derivadas de ninguna parte del Servicio sin nuestro consentimiento previo por escrito.</p>
 
             <h2>9. Servicios de terceros</h2>
-            <p>El Servicio se apoya en proveedores externos (por ejemplo, el inicio de sesión de Google y Apple, Stripe para los pagos y los servicios de notificaciones push). Tu uso de esos servicios puede estar sujeto a sus propias condiciones y políticas. No somos responsables de los servicios de terceros ni tenemos control sobre ellos.</p>
+            <p>El Servicio se apoya en proveedores externos (por ejemplo, el inicio de sesión de Google y Apple, la App Store de Apple para los pagos de la suscripción y los servicios de notificaciones push). Tu uso de esos servicios puede estar sujeto a sus propias condiciones y políticas. No somos responsables de los servicios de terceros ni tenemos control sobre ellos.</p>
 
             <h2>10. Suspensión y terminación</h2>
             <p>Puedes dejar de usar el Servicio y eliminar tu cuenta en cualquier momento. Podemos suspender o cancelar tu acceso al Servicio, con o sin previo aviso, si incumples estos Términos, si la ley nos obliga a ello, o para proteger el Servicio o a otros usuarios. Tras la terminación, las licencias que nos concediste finalizan (sujeto a la Sección 6), y las disposiciones que por su naturaleza deban subsistir (como las exenciones de garantía, la limitación de responsabilidad y la ley aplicable) seguirán vigentes.</p>

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -37,7 +37,7 @@
                 <li><strong>Location data.</strong> With your permission, we process your approximate or precise location (latitude and longitude) to show you nearby events and to enable event check-in.</li>
                 <li><strong>Push notifications.</strong> If you enable notifications, we process a device push token (through Firebase Cloud Messaging) and your notification preferences.</li>
                 <li><strong>Messaging.</strong> In-app chat threads and messages exchanged between users.</li>
-                <li><strong>Payment data.</strong> If you are a business user with a monthly subscription, payments are processed by Stripe. We do not store your full card number; we retain limited transaction and subscription details.</li>
+                <li><strong>Payment data.</strong> If you are a business user with a monthly subscription, the payment is processed by <strong>Apple</strong> through your App Store account (in-app purchase). We do not receive or store your card details; we retain limited subscription status and transaction identifiers returned by Apple.</li>
                 <li><strong>Usage and analytics data.</strong> Product analytics collected through PostHog to understand how the Service is used and to improve it. You can opt out of analytics.</li>
                 <li><strong>Support communications.</strong> The content of any messages you send us for support.</li>
             </ul>
@@ -64,7 +64,7 @@
             <p>We do not sell your personal data. We share it only with trusted service providers ("processors") who process it on our behalf under contract, and where required by law. These include:</p>
             <ul>
                 <li><strong>Google</strong> and <strong>Apple</strong> — sign-in and authentication.</li>
-                <li><strong>Stripe</strong> — payment processing.</li>
+                <li><strong>Apple</strong> (App Store / In-App Purchase) — subscription billing and payment processing.</li>
                 <li><strong>Firebase Cloud Messaging</strong> and the <strong>Apple Push Notification service</strong> — delivery of push notifications.</li>
                 <li><strong>Cloud hosting providers</strong> — hosting and storage of the Service and its data.</li>
                 <li><strong>PostHog</strong> — product analytics.</li>

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -44,12 +44,12 @@
             <p>You are responsible for maintaining the security of your account and your device. We are not liable for any loss arising from your failure to keep your credentials secure.</p>
 
             <h2>4. Subscriptions and Payments</h2>
-            <p>Certain features are available only to business users through a paid monthly subscription. Payments are processed by our payment provider, <strong>Stripe</strong>. We do not store your full card number.</p>
+            <p>Certain features are available only to business users through a paid monthly subscription. Subscriptions are purchased and billed through your <strong>Apple App Store</strong> account as an in-app purchase; Apple processes the payment and we never receive or store your card details. Billing and renewals are managed by Apple through your Apple ID.</p>
             <ul>
                 <li><strong>Billing and renewal.</strong> Business subscriptions are billed monthly and renew automatically at the end of each billing period until cancelled.</li>
-                <li><strong>Cancellation.</strong> You can cancel your subscription at any time. Cancellation takes effect at the end of the current billing period, and you will retain access to paid features until then.</li>
+                <li><strong>Cancellation.</strong> You can cancel at any time from your Apple ID subscription settings on your device. Cancellation takes effect at the end of the current billing period, and you will retain access to paid features until then.</li>
                 <li><strong>Price changes.</strong> We may change subscription prices. We will give you reasonable advance notice, and any change will apply from your next billing period.</li>
-                <li><strong>Refunds.</strong> {{ $company->refund_policy }}. Except where required by applicable Spanish and EU consumer law, subscription fees are non-refundable.</li>
+                <li><strong>Refunds.</strong> {{ $company->refund_policy }}. Subscriptions purchased through the App Store are subject to Apple's refund process, and refund requests are handled by Apple. Except where required by applicable Spanish and EU consumer law, subscription fees are non-refundable.</li>
                 <li><strong>Taxes.</strong> Prices may be shown exclusive or inclusive of applicable taxes (such as VAT/IVA), as indicated at checkout.</li>
             </ul>
 
@@ -78,7 +78,7 @@
             <p>The Service, including its software, design, text, graphics, logos and trademarks (but excluding User Content), is owned by Kolabing or its licensors and is protected by intellectual property laws. We grant you a limited, personal, non-transferable, revocable licence to use the Service for its intended purpose. You may not copy, modify, distribute, sell or create derivative works from any part of the Service without our prior written consent.</p>
 
             <h2>9. Third-Party Services</h2>
-            <p>The Service relies on third-party providers (for example Google and Apple sign-in, Stripe for payments, and push notification services). Your use of those services may be subject to their own terms and policies. We are not responsible for third-party services and do not control them.</p>
+            <p>The Service relies on third-party providers (for example Google and Apple sign-in, the Apple App Store for subscription payments, and push notification services). Your use of those services may be subject to their own terms and policies. We are not responsible for third-party services and do not control them.</p>
 
             <h2>10. Suspension and Termination</h2>
             <p>You may stop using the Service and delete your account at any time. We may suspend or terminate your access to the Service, with or without notice, if you breach these Terms, if we are required to do so by law, or to protect the Service or other users. On termination, the licences you granted to us end (subject to Section 6), and provisions that by their nature should survive (such as disclaimers, limitation of liability and governing law) will continue to apply.</p>

--- a/tests/Feature/LegalPagesTest.php
+++ b/tests/Feature/LegalPagesTest.php
@@ -18,6 +18,15 @@ class LegalPagesTest extends TestCase
         }
     }
 
+    public function test_legal_pages_reference_apple_not_stripe(): void
+    {
+        foreach (['terms', 'privacy', 'terms.es', 'privacy.es'] as $routeName) {
+            $this->get(route($routeName))
+                ->assertOk()
+                ->assertDontSee('Stripe', false);
+        }
+    }
+
     public function test_terms_page_declares_language_and_alternates(): void
     {
         $response = $this->get(route('terms'));


### PR DESCRIPTION
## Summary
The Terms of Service + Privacy Policy pages (EN + ES) described payments as processed by **Stripe**. The live payment method is an **Apple App Store in-app subscription** (StoreKit2 / Apple IAP). This corrects the wording across all four pages.

## Linked tracking item
Closes #93

## Type of change
- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes
- Payment-processor wording: subscriptions are purchased/billed through the **Apple App Store** (in-app purchase); Apple processes payment, we never receive/store card details.
- **Cancellation** → via the user's **Apple ID** subscription settings; **Refunds** → handled by Apple's refund process.
- Processor list: `Stripe — payment processing` → `Apple (App Store / In-App Purchase) — subscription billing and payment processing`.
- Third-party-services list: `Stripe for payments` → `the Apple App Store for subscription payments`.
- Applied in all four pages: `/terms`, `/privacy`, `/es/terms`, `/es/privacy`.
- Regression test: legal pages must not reference `Stripe`.

## Mobile impact (kolabing-app)
- [x] No mobile changes required
- [ ] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** N/A — legal copy only; no API/contract change.

## Database / migrations
- [x] No schema changes
- [ ] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change (explain rollback below)

**Migration notes:** N/A

## Testing
- [x] `php artisan test` passes — paste counts: **LegalPagesTest + MarketingSeoTest: 10 passed (72 assertions)**; full suite green locally before push.
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path <!-- grep confirms zero Stripe references remain in resources/views/pages; new test asserts assertDontSee('Stripe') on all four pages -->

## Docs & rules updated
- [ ] `BACKLOG.md` updated
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [ ] `docs/BACKEND-SCHEMA.md`
- [x] No docs impact <!-- copy-only correction; payment mechanics already documented as Apple IAP in BACKLOG §3.1 -->

## Screenshots / notes
Fixes the live Privacy page line "Payments are processed by our payment provider, Stripe."