### PR TITLE
Add artisan command to backfill partner_status for out-of-band completions

### DIFF
--- a/app/Console/Commands/RecalculatePartnerStatuses.php
+++ b/app/Console/Commands/RecalculatePartnerStatuses.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\UserType;
+use App\Models\Profile;
+use App\Services\BusinessPartnerStatusService;
+use Illuminate\Console\Command;
+
+class RecalculatePartnerStatuses extends Command
+{
+    protected $signature = 'app:recalculate-partner-statuses
+        {--profile= : Only recalculate this profile ID}
+        {--dry-run : Report resulting statuses without writing}';
+
+    protected $description = 'Recompute business partner_status from real collaboration history. '
+        .'Needed for businesses whose completed collaborations were written directly to the '
+        .'database (e.g. seeded test data) and never passed through the completion flow that '
+        .'normally triggers recalculation.';
+
+    public function handle(BusinessPartnerStatusService $service): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $profileId = $this->option('profile');
+
+        $query = Profile::query()->where('user_type', UserType::Business);
+
+        if ($profileId !== null) {
+            $query->where('id', $profileId);
+        }
+
+        $changed = 0;
+        $total = 0;
+
+        $query->chunkById(100, function ($chunk) use ($service, $dryRun, &$changed, &$total): void {
+            foreach ($chunk as $profile) {
+                $total++;
+                $previous = $service->statusFor($profile);
+                $new = $dryRun
+                    ? $this->previewStatus($service, $profile)
+                    : $service->recalculate($profile);
+
+                if ($new !== $previous) {
+                    $changed++;
+                    $this->line(sprintf(
+                        '%s[%s] %s: %s -> %s',
+                        $dryRun ? '[dry] ' : '',
+                        $profile->id,
+                        $profile->name ?? 'unnamed',
+                        $previous->value,
+                        $new->value,
+                    ));
+                }
+            }
+        });
+
+        $this->info(sprintf(
+            '%s %d business profile(s), %d status change(s).',
+            $dryRun ? 'Evaluated' : 'Recalculated',
+            $total,
+            $changed,
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Compute what the status would become without persisting, by running
+     * recalculate() inside a transaction that is always rolled back.
+     */
+    private function previewStatus(BusinessPartnerStatusService $service, Profile $profile): \App\Enums\PartnerStatusTier
+    {
+        $result = null;
+
+        try {
+            \Illuminate\Support\Facades\DB::transaction(function () use ($service, $profile, &$result): void {
+                $result = $service->recalculate($profile);
+                throw new PartnerStatusDryRunRollback;
+            });
+        } catch (PartnerStatusDryRunRollback) {
+            // Intentional rollback — nothing was persisted.
+        }
+
+        return $result;
+    }
+}
+
+/**
+ * Internal sentinel used to roll back a dry-run recalculation transaction.
+ */
+class PartnerStatusDryRunRollback extends \RuntimeException {}

--- a/tests/Feature/Console/RecalculatePartnerStatusesTest.php
+++ b/tests/Feature/Console/RecalculatePartnerStatusesTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Enums\CollaborationStatus;
+use App\Enums\PartnerStatusTier;
+use App\Models\BusinessPartnerStatus;
+use App\Models\Collaboration;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class RecalculatePartnerStatusesTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_recalculates_status_for_collaborations_that_bypassed_the_completion_flow(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        // Simulates completed collaborations written directly to the
+        // database (e.g. seeded test data) — recalculate() was never
+        // triggered, so no BusinessPartnerStatus row exists yet.
+        Collaboration::factory()
+            ->forCreator($business)
+            ->count(1)
+            ->create(['status' => CollaborationStatus::Completed]);
+
+        $this->assertDatabaseMissing('business_partner_statuses', [
+            'profile_id' => $business->id,
+        ]);
+
+        $this->artisan('app:recalculate-partner-statuses')->assertSuccessful();
+
+        $this->assertDatabaseHas('business_partner_statuses', [
+            'profile_id' => $business->id,
+            'status' => PartnerStatusTier::ActivePartner->value,
+            'completed_kolabs_count' => 1,
+        ]);
+    }
+
+    public function test_dry_run_reports_without_writing(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        Collaboration::factory()
+            ->forCreator($business)
+            ->count(1)
+            ->create(['status' => CollaborationStatus::Completed]);
+
+        $this->artisan('app:recalculate-partner-statuses --dry-run')->assertSuccessful();
+
+        $this->assertDatabaseMissing('business_partner_statuses', [
+            'profile_id' => $business->id,
+        ]);
+    }
+
+    public function test_profile_option_scopes_to_a_single_business(): void
+    {
+        $target = Profile::factory()->business()->create();
+        $other = Profile::factory()->business()->create();
+
+        Collaboration::factory()->forCreator($target)->count(1)->create([
+            'status' => CollaborationStatus::Completed,
+        ]);
+        Collaboration::factory()->forCreator($other)->count(1)->create([
+            'status' => CollaborationStatus::Completed,
+        ]);
+
+        $this->artisan("app:recalculate-partner-statuses --profile={$target->id}")->assertSuccessful();
+
+        $this->assertDatabaseHas('business_partner_statuses', ['profile_id' => $target->id]);
+        $this->assertDatabaseMissing('business_partner_statuses', ['profile_id' => $other->id]);
+    }
+
+    public function test_existing_stale_status_row_is_corrected(): void
+    {
+        $business = Profile::factory()->business()->create();
+
+        BusinessPartnerStatus::factory()->create([
+            'profile_id' => $business->id,
+            'status' => PartnerStatusTier::NewPartner,
+            'completed_kolabs_count' => 0,
+        ]);
+
+        Collaboration::factory()
+            ->forCreator($business)
+            ->count(1)
+            ->create(['status' => CollaborationStatus::Completed]);
+
+        $this->artisan('app:recalculate-partner-statuses')->assertSuccessful();
+
+        $this->assertDatabaseHas('business_partner_statuses', [
+            'profile_id' => $business->id,
+            'status' => PartnerStatusTier::ActivePartner->value,
+            'completed_kolabs_count' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- `partner_status` is only recalculated via `CollaborationService`'s completion flow. Collaborations written directly to the database (e.g. seeded test data) never trigger `BusinessPartnerStatusService::recalculate()`, so `partner_status` silently stays at `new_partner` regardless of real completed-kolab history.
- Surfaced live on the Eixample 46 test business account: it has 2 real completed collaborations, but `GET /me/dashboard` still returns `partner_status.status: "new_partner"` with `breakdown.completed_kolabs: 0`, because those collaborations were seeded via `psql` and never ran through the completion flow.
- Adds `app:recalculate-partner-statuses` — re-derives `partner_status` for all (or one, via `--profile=`) business profiles from real collaboration data. Supports `--dry-run` to preview changes without writing. Safe to run repeatedly (idempotent `updateOrCreate`).

## Test plan
- [x] `RecalculatePartnerStatusesTest.php` — 4 new tests (backfill for bypassed completions, dry-run, `--profile` scoping, correcting a stale existing row)
- [x] Regression: `DashboardTest.php`, `DashboardNextActionTest.php`, `DashboardMonthlyGoalTest.php`, `BusinessRepeatPartnerVisibilityTest.php` — all passing (37 tests, 174 assertions)
- [x] `vendor/bin/pint --dirty`

## After merge
Run once against prod to fix existing stale rows (e.g. Eixample 46):
```
php artisan app:recalculate-partner-statuses --dry-run   # preview
php artisan app:recalculate-partner-statuses             # apply
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)