### PR TITLE
Schedule app:recalculate-partner-statuses to run daily

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -30,3 +30,9 @@ Schedule::command('app:evaluate-community-tiers')->dailyAt('02:00');
 // Nudge subscribed but inactive businesses back to the platform.
 // Dedup is done via the notifications table so re-runs are safe.
 Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
+
+// Recompute business partner_status from real collaboration history. Catches
+// collaborations written directly to the database (e.g. seeded test data)
+// that bypass CollaborationService's completion flow and never trigger
+// recalculation. Idempotent (updateOrCreate) — safe to run daily.
+Schedule::command('app:recalculate-partner-statuses')->dailyAt('04:00');


### PR DESCRIPTION
## Summary
- Adds `Schedule::command('app:recalculate-partner-statuses')->dailyAt('04:00')` to `routes/console.php`, alongside the other nightly recalculation jobs (tiers at 02:00, auto-complete at 03:00).
- Automatically catches businesses whose `partner_status` is stale because their collaborations were written directly to the database (seeded data, admin fixes, etc.) and never went through `CollaborationService`'s completion flow — no manual one-off run needed going forward.
- Command is idempotent (`updateOrCreate`), so daily re-runs are safe and cheap.

## Test plan
- [x] `RecalculatePartnerStatusesTest.php` — 4 tests, still green
- [x] `vendor/bin/pint --dirty`
- N/A automated test for schedule registration — no existing pattern for asserting `routes/console.php` entries in this repo (checked: only individual command tests exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)