### PR TITLE
Move partner-status recalc schedule to 15:15 UTC (temporary)

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -35,4 +35,4 @@ Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
 // collaborations written directly to the database (e.g. seeded test data)
 // that bypass CollaborationService's completion flow and never trigger
 // recalculation. Idempotent (updateOrCreate) — safe to run daily.
-Schedule::command('app:recalculate-partner-statuses')->dailyAt('04:00');
+Schedule::command('app:recalculate-partner-statuses')->dailyAt('15:15');


### PR DESCRIPTION
## Summary
- Bumps `app:recalculate-partner-statuses` from `04:00` to `15:15` UTC so it runs today for verification against the Eixample 46 stale-status case, instead of waiting until tonight.
- No code change to the command itself — just the scheduled time.

## Follow-up
Once confirmed working, move this back to a quiet nighttime slot (e.g. `04:00`, alongside the other nightly jobs) in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)