### PR TITLE
Move partner-status recalc schedule to 14:20 UTC

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -35,4 +35,4 @@ Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
 // collaborations written directly to the database (e.g. seeded test data)
 // that bypass CollaborationService's completion flow and never trigger
 // recalculation. Idempotent (updateOrCreate) — safe to run daily.
-Schedule::command('app:recalculate-partner-statuses')->dailyAt('14:05');
+Schedule::command('app:recalculate-partner-statuses')->dailyAt('14:20');

--- a/routes/console.php
+++ b/routes/console.php
@@ -35,4 +35,4 @@ Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
 // collaborations written directly to the database (e.g. seeded test data)
 // that bypass CollaborationService's completion flow and never trigger
 // recalculation. Idempotent (updateOrCreate) — safe to run daily.
-Schedule::command('app:recalculate-partner-statuses')->dailyAt('15:15');
+Schedule::command('app:recalculate-partner-statuses')->dailyAt('14:05');


### PR DESCRIPTION
## Summary
Bumps the run time forward again (14:05 UTC didn't leave enough buffer for CI + merge + deploy). Same idempotent command, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)