### PR TITLE
fix: trust Laravel Cloud's proxy so HTTPS/cookie detection works

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -28,6 +28,17 @@ return Application::configure(basePath: dirname(__DIR__))
         ['middleware' => ['auth:sanctum']],
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        // Trust Laravel Cloud's edge/compute network as a proxy so isSecure()/getScheme()
+        // (and everything downstream of it: the session/XSRF cookie Secure flag, CSRF checks,
+        // URL generation) correctly see the original client's HTTPS request instead of the
+        // plain-HTTP hop from Laravel Cloud's internal load balancer. `at: '*'` (not an IP
+        // allowlist) is safe here because the app is only ever reachable through Laravel
+        // Cloud's own edge + compute network, never directly from the public internet -- see
+        // https://laravel.com/cloud/docs/network ("Your applications run in private networks
+        // and are only made publicly accessible via the Cloud Edge Network"). Fixes
+        // intermittent 419 (Page Expired) on /admin/login, diagnosed in #104.
+        $middleware->trustProxies(at: '*');
+
         $middleware->append(AddSecurityHeaders::class);
 
         // Register middleware aliases


### PR DESCRIPTION
## Summary
Fixes intermittent 419 ("Page Expired") failures on `/admin/login` that read as a "timeout" to the reporting user. `bootstrap/app.php` never configured `trustProxies`, so Laravel's HTTPS/secure-cookie auto-detection was unreliable behind Laravel Cloud's edge + load-balanced compute network.

## Linked tracking item
Closes #104

## Type of change
- [x] 🐛 Bug fix

## Changes
- `bootstrap/app.php`: add `$middleware->trustProxies(at: '*')` in the `withMiddleware()` closure, with an inline comment explaining why `'*'` (not an IP allowlist) is the correct scope for this deployment.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A

## Testing
- [ ] `php artisan test` passes — paste counts: **could not fully run** — this box is missing the `pdo_sqlite` PHP extension (`php -m` confirms `pdo_sqlite` absent), a pre-existing environment gap unrelated to this change; the 99 tests that don't touch the DB connection passed, the remaining 1263 failed uniformly with `could not find driver`, not from anything this diff touches. Recommend CI (which presumably has the extension) confirm green before merge.
- [x] `vendor/bin/pint` clean — `{"result":"pass"}` on `bootstrap/app.php`.
- [x] Manually verified the happy path — `php -l` clean; booted the app directly (`require bootstrap/app.php`) post-change, no error; `php artisan route:list --path=admin/login` still resolves both `GET` and `POST /admin/login` to `Admin\AuthController@create`/`store` correctly with the new middleware registered.

## Docs & rules updated
- [x] No docs impact

## Screenshots / notes
Full diagnosis (Laravel Cloud API logs/metrics used to rule out an actual timeout, resource pressure, or multi-instance session issue, then trace to the missing `trustProxies` call) is in issue #104. Could not add #104 to the "Kolabing Engineering" project board — the CI token used to open it lacks the `read:project` GraphQL scope; flagging as a manual follow-up for whoever has board access.
