### PR TITLE
feat: onboarding email drip (T+0/T+2/T+5/T+10) + template copy export

### DIFF
--- a/app/Console/Commands/SendOnboardingDrip.php
+++ b/app/Console/Commands/SendOnboardingDrip.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\UserType;
+use App\Models\Profile;
+use App\Services\OnboardingDripService;
+use Illuminate\Console\Command;
+
+/**
+ * Onboarding email drip: T+0 welcome -> T+2 complete-profile nudge (if still
+ * incomplete) -> T+5 activation nudge (if no first action) -> T+10 inactive
+ * nudge (if still no first action). Cadence from config('onboarding_drip.cadence_hours').
+ *
+ * NOT LIVE. Built and registered so it's discoverable/testable
+ * (`php artisan app:send-onboarding-drip`), but intentionally left OUT of
+ * routes/console.php's scheduler — see the commented-out entry there.
+ * Daniel has not signed off on the N-day offsets going live yet. Do not add
+ * a Schedule::command(...) line for this without that sign-off.
+ */
+class SendOnboardingDrip extends Command
+{
+    protected $signature = 'app:send-onboarding-drip
+        {--dry-run : Log what would happen without sending or writing state}
+        {--sync-new : Also start drip state for profiles that signed up but have no state row yet}';
+
+    protected $description = 'Send the T+0/T+2/T+5/T+10 onboarding email drip (NOT scheduled live yet, see routes/console.php)';
+
+    public function handle(OnboardingDripService $drip): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($this->option('sync-new')) {
+            $this->syncNewProfiles($drip, $dryRun);
+        }
+
+        if ($dryRun) {
+            $this->info('[dry-run] Skipping send pass (state would be evaluated + advanced on a real run).');
+
+            return self::SUCCESS;
+        }
+
+        $sentCount = $drip->sendDue();
+
+        $this->info("Onboarding drip emails sent: {$sentCount}.");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Backfill drip state for any profile that doesn't have one yet. In
+     * steady state this would run from the registration seam
+     * (AuthService::register*()); until that hook is added, --sync-new lets
+     * this command pick up existing/new profiles on its own.
+     */
+    private function syncNewProfiles(OnboardingDripService $drip, bool $dryRun): void
+    {
+        $candidates = Profile::query()
+            ->whereIn('user_type', UserType::values())
+            ->whereDoesntHave('onboardingDripState')
+            ->get();
+
+        $this->info("Profiles without drip state: {$candidates->count()}.");
+
+        foreach ($candidates as $profile) {
+            if ($dryRun) {
+                $this->line("  [dry-run] Would start onboarding drip for profile {$profile->id}");
+
+                continue;
+            }
+
+            $drip->startForProfile($profile);
+        }
+    }
+}

--- a/app/Console/Commands/SendOnboardingDrip.php
+++ b/app/Console/Commands/SendOnboardingDrip.php
@@ -50,10 +50,10 @@ class SendOnboardingDrip extends Command
     }
 
     /**
-     * Backfill drip state for any profile that doesn't have one yet. In
-     * steady state this would run from the registration seam
-     * (AuthService::register*()); until that hook is added, --sync-new lets
-     * this command pick up existing/new profiles on its own.
+     * Backfill drip state for any profile that doesn't have one yet. In steady
+     * state new signups are enrolled at the registration seam
+     * (AuthService::startOnboardingDrip()); --sync-new is the one-off backfill
+     * for profiles created before that hook existed.
      */
     private function syncNewProfiles(OnboardingDripService $drip, bool $dryRun): void
     {

--- a/app/Models/OnboardingDripState.php
+++ b/app/Models/OnboardingDripState.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Per-recipient state for the T+0/T+2/T+5/T+10 onboarding email drip.
+ *
+ * One row per profile (unique on profile_id). Mirrors the shape of
+ * {@see NotificationReminder}: an anchor timestamp, a cadence position
+ * (next_sequence), and a scheduled_for the drip's sender polls. Cancelling
+ * (cancelled_at) stops the drip cleanly when the underlying condition the
+ * step exists for resolves (e.g. profile completed, first action taken).
+ *
+ * @property string $id
+ * @property string $profile_id
+ * @property \Illuminate\Support\Carbon $anchor_at
+ * @property int $next_sequence
+ * @property int|null $last_sent_sequence
+ * @property \Illuminate\Support\Carbon|null $scheduled_for
+ * @property \Illuminate\Support\Carbon|null $sent_at
+ * @property \Illuminate\Support\Carbon|null $cancelled_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Profile $profile
+ */
+class OnboardingDripState extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'profile_id',
+        'anchor_at',
+        'next_sequence',
+        'last_sent_sequence',
+        'scheduled_for',
+        'sent_at',
+        'cancelled_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'anchor_at' => 'datetime',
+            'scheduled_for' => 'datetime',
+            'sent_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -201,6 +201,16 @@ class Profile extends Authenticatable
     }
 
     /**
+     * Get the onboarding email drip state for this profile.
+     *
+     * @return HasOne<OnboardingDripState, $this>
+     */
+    public function onboardingDripState(): HasOne
+    {
+        return $this->hasOne(OnboardingDripState::class);
+    }
+
+    /**
      * Get applications submitted by this profile.
      *
      * @return HasMany<Application, $this>

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -16,6 +16,7 @@ use App\Models\Profile;
 use App\Support\ApiDebugLogger;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
 use InvalidArgumentException;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -88,6 +89,7 @@ class AuthService
         private readonly BusinessVenueService $businessVenueService,
         private readonly FileUploadService $fileUploadService,
         private readonly OnboardingService $onboardingService,
+        private readonly OnboardingDripService $onboardingDripService,
         private readonly \App\Services\Admin\CompanySettingService $companySettings,
     ) {}
 
@@ -199,6 +201,8 @@ class AuthService
         });
 
         $this->loadProfileRelationships($profile);
+
+        $this->startOnboardingDrip($profile);
 
         return [
             'profile' => $profile,
@@ -324,6 +328,8 @@ class AuthService
         // Load relationships
         $this->loadProfileRelationships($profile);
 
+        $this->startOnboardingDrip($profile);
+
         return [
             'profile' => $profile,
             'is_new_user' => true,
@@ -342,6 +348,27 @@ class AuthService
             $profile->load(['attendeeProfile']);
         } else {
             $profile->load(['communityProfile.city']);
+        }
+    }
+
+    /**
+     * Enrol a freshly-registered profile into the onboarding email drip.
+     *
+     * Runs after the registration transaction has committed and is fully
+     * isolated: the drip is a peripheral concern, so a failure to seed its
+     * state must never propagate into (and roll back) account creation. Mirrors
+     * the "email failures never break the triggering request" rule in
+     * {@see \App\Jobs\SendTransactionalEmail}.
+     */
+    private function startOnboardingDrip(Profile $profile): void
+    {
+        try {
+            $this->onboardingDripService->startForProfile($profile);
+        } catch (\Throwable $e) {
+            Log::warning('Failed to start onboarding drip for new profile', [
+                'profile_id' => $profile->id,
+                'exception' => $e->getMessage(),
+            ]);
         }
     }
 
@@ -475,6 +502,8 @@ class AuthService
         // Load relationships
         $this->loadProfileRelationships($profile);
 
+        $this->startOnboardingDrip($profile);
+
         return [
             'profile' => $profile,
             'is_new_user' => true,
@@ -569,6 +598,8 @@ class AuthService
         // Load relationships
         $this->loadProfileRelationships($profile);
 
+        $this->startOnboardingDrip($profile);
+
         return [
             'profile' => $profile,
             'is_new_user' => true,
@@ -600,6 +631,8 @@ class AuthService
         });
 
         $this->loadProfileRelationships($profile);
+
+        $this->startOnboardingDrip($profile);
 
         return [
             'profile' => $profile,

--- a/app/Services/EmailService.php
+++ b/app/Services/EmailService.php
@@ -41,11 +41,13 @@ class EmailService
      * Send a Postmark template email to a profile, respecting preferences.
      *
      * @param  array<string, mixed>  $model
+     * @return bool Whether an email was actually queued (false = suppressed by
+     *              the recipient's preferences).
      */
-    public function send(Profile $recipient, string $templateAlias, array $model, string $category): void
+    public function send(Profile $recipient, string $templateAlias, array $model, string $category): bool
     {
         if (! $this->shouldSend($recipient, $category)) {
-            return;
+            return false;
         }
 
         dispatch(SendTransactionalEmail::template(
@@ -54,6 +56,8 @@ class EmailService
             model: $model,
             toName: $this->recipientName($recipient),
         ));
+
+        return true;
     }
 
     /**

--- a/app/Services/OnboardingDripService.php
+++ b/app/Services/OnboardingDripService.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\ApplicationStatus;
+use App\Enums\KolabStatus;
+use App\Enums\UserType;
+use App\Models\OnboardingDripState;
+use App\Models\Profile;
+
+/**
+ * Drives the T+0/T+2/T+5/T+10 onboarding email drip.
+ *
+ * Same architectural shape as {@see NotificationReminderService}: a per-recipient
+ * state row (here {@see OnboardingDripState}, one per profile), a cadence-hours
+ * offset table, and a due-polling sender that re-checks eligibility at send time
+ * so a step is skipped/cancelled cleanly the moment its underlying condition
+ * resolves (profile completed, first action taken).
+ *
+ * Cadence (config('onboarding_drip.cadence_hours'), recommended by Jace,
+ * pending Daniel's sign-off — see config/onboarding_drip.php):
+ *   0. T+0  Welcome                     — always
+ *   1. T+2  Complete-profile nudge      — only if profile still incomplete
+ *   2. T+5  Activation nudge            — only if no first action taken yet
+ *   3. T+10 Inactive nudge              — only if still no first action taken
+ *
+ * Steps whose condition is no longer met when they come due are skipped (not
+ * cancelled outright) so a later step can still fire; the whole drip is
+ * cancelled once the profile is fully activated (see cancelIfActivated()).
+ */
+class OnboardingDripService
+{
+    private const STEP_WELCOME = 0;
+
+    private const STEP_COMPLETE_PROFILE = 1;
+
+    private const STEP_ACTIVATION = 2;
+
+    private const STEP_INACTIVE_NUDGE = 3;
+
+    public function __construct(
+        private readonly EmailService $emailService,
+    ) {}
+
+    /**
+     * Start (or resync) the drip for a freshly signed-up profile. Idempotent:
+     * calling this again for a profile that already has a state row is a no-op
+     * unless that row was previously cancelled and the profile re-qualifies.
+     */
+    public function startForProfile(Profile $profile): void
+    {
+        $state = OnboardingDripState::query()->firstOrNew(['profile_id' => $profile->id]);
+
+        if ($state->exists && $state->cancelled_at === null) {
+            return;
+        }
+
+        $cadenceHours = $this->cadenceHours();
+        $anchor = $profile->created_at ?? now();
+
+        $state->fill([
+            'anchor_at' => $anchor,
+            'next_sequence' => 0,
+            'last_sent_sequence' => null,
+            'scheduled_for' => $anchor->copy()->addHours($cadenceHours[0]),
+            'sent_at' => null,
+            'cancelled_at' => null,
+        ])->save();
+    }
+
+    /**
+     * Cancel the drip outright (e.g. profile deleted/banned). Distinct from a
+     * single step being skipped for no longer being eligible.
+     */
+    public function cancelForProfile(Profile $profile): void
+    {
+        OnboardingDripState::query()
+            ->where('profile_id', $profile->id)
+            ->whereNull('cancelled_at')
+            ->update(['cancelled_at' => now(), 'scheduled_for' => null]);
+    }
+
+    /**
+     * Process every due drip step across all profiles. Returns the count of
+     * emails actually dispatched (skipped/ineligible steps are advanced past,
+     * not counted).
+     */
+    public function sendDue(int $limit = 200): int
+    {
+        $sentCount = 0;
+
+        OnboardingDripState::query()
+            ->whereNull('cancelled_at')
+            ->whereNotNull('scheduled_for')
+            ->where('scheduled_for', '<=', now())
+            ->orderBy('scheduled_for')
+            ->limit($limit)
+            ->with('profile.businessProfile', 'profile.communityProfile', 'profile.attendeeProfile')
+            ->get()
+            ->each(function (OnboardingDripState $state) use (&$sentCount): void {
+                $profile = $state->profile;
+
+                if ($profile === null) {
+                    $this->cancel($state);
+
+                    return;
+                }
+
+                if ($this->isFullyActivated($profile)) {
+                    $this->cancel($state);
+
+                    return;
+                }
+
+                if ($this->dispatchStep($profile, $state->next_sequence)) {
+                    $sentCount++;
+                }
+
+                $this->advance($state);
+            });
+
+        return $sentCount;
+    }
+
+    /**
+     * Send the given step's email if still eligible. Returns whether an email
+     * was actually dispatched (false = step skipped, condition no longer met).
+     */
+    private function dispatchStep(Profile $profile, int $sequence): bool
+    {
+        return match ($sequence) {
+            self::STEP_WELCOME => $this->sendWelcome($profile),
+            self::STEP_COMPLETE_PROFILE => $this->sendCompleteProfileNudge($profile),
+            self::STEP_ACTIVATION => $this->sendActivationNudge($profile),
+            self::STEP_INACTIVE_NUDGE => $this->sendInactiveNudge($profile),
+            default => false,
+        };
+    }
+
+    private function sendWelcome(Profile $profile): bool
+    {
+        $alias = match ($profile->user_type) {
+            UserType::Business => 'business-welcome-01',
+            UserType::Community => 'community-welcome-01',
+            UserType::Attendee => 'attendee-welcome-01',
+        };
+
+        $this->emailService->send($profile, $alias, [
+            'first_name' => $this->displayName($profile),
+        ], EmailService::CATEGORY_NUDGE);
+
+        return true;
+    }
+
+    private function sendCompleteProfileNudge(Profile $profile): bool
+    {
+        if ($profile->onboardingCompleted()) {
+            return false;
+        }
+
+        // Attendee onboarding is completed at signup time (name/handle/city/interests
+        // captured then) and has no dedicated "complete profile" template; only
+        // business/community have a two-step (signup -> flesh out profile) flow.
+        $alias = match ($profile->user_type) {
+            UserType::Business => 'complete-profile-business',
+            UserType::Community => 'complete-profile-community',
+            UserType::Attendee => null,
+        };
+
+        if ($alias === null) {
+            return false;
+        }
+
+        $this->emailService->send($profile, $alias, [
+            'first_name' => $this->displayName($profile),
+        ], EmailService::CATEGORY_NUDGE);
+
+        return true;
+    }
+
+    private function sendActivationNudge(Profile $profile): bool
+    {
+        if ($this->hasTakenFirstAction($profile)) {
+            return false;
+        }
+
+        $alias = match ($profile->user_type) {
+            UserType::Business => 'activation-business',
+            UserType::Community => 'activation-community',
+            UserType::Attendee => 'attendee-activation-01',
+        };
+
+        $this->emailService->send($profile, $alias, [
+            'first_name' => $this->displayName($profile),
+        ], EmailService::CATEGORY_NUDGE);
+
+        return true;
+    }
+
+    private function sendInactiveNudge(Profile $profile): bool
+    {
+        if ($this->hasTakenFirstAction($profile)) {
+            return false;
+        }
+
+        $this->emailService->send($profile, 'inactive-nudge', [
+            'first_name' => $this->displayName($profile),
+        ], EmailService::CATEGORY_NUDGE);
+
+        return true;
+    }
+
+    /**
+     * "First action" per user type, mirrors the plan doc's activation-nudge
+     * trigger (docs/plans/2026-06-04-transactional-email-system.md, catalog B):
+     * business = published a Kolab; community = submitted an application;
+     * attendee = joined a community.
+     */
+    private function hasTakenFirstAction(Profile $profile): bool
+    {
+        return match ($profile->user_type) {
+            UserType::Business => $profile->kolabs()->where('status', KolabStatus::Published)->exists(),
+            UserType::Community => $profile->applications()->where('status', '!=', ApplicationStatus::Withdrawn)->exists(),
+            UserType::Attendee => $profile->communityMemberships()->exists(),
+        };
+    }
+
+    private function isFullyActivated(Profile $profile): bool
+    {
+        return $profile->onboardingCompleted() && $this->hasTakenFirstAction($profile);
+    }
+
+    private function cancel(OnboardingDripState $state): void
+    {
+        $state->update(['scheduled_for' => null, 'cancelled_at' => now()]);
+    }
+
+    private function advance(OnboardingDripState $state): void
+    {
+        $cadenceHours = $this->cadenceHours();
+        $currentSequence = $state->next_sequence;
+        $nextSequence = $currentSequence + 1;
+        $now = now();
+
+        while ($nextSequence < count($cadenceHours)
+            && $state->anchor_at->copy()->addHours($cadenceHours[$nextSequence])->lte($now)) {
+            $nextSequence++;
+        }
+
+        $state->update([
+            'last_sent_sequence' => $currentSequence,
+            'next_sequence' => $nextSequence,
+            'scheduled_for' => $nextSequence < count($cadenceHours)
+                ? $state->anchor_at->copy()->addHours($cadenceHours[$nextSequence])
+                : null,
+            'sent_at' => $now,
+            'cancelled_at' => $nextSequence < count($cadenceHours) ? null : $now,
+        ]);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function cadenceHours(): array
+    {
+        return config('onboarding_drip.cadence_hours');
+    }
+
+    private function displayName(Profile $profile): ?string
+    {
+        return match ($profile->user_type) {
+            UserType::Business => $profile->businessProfile?->name,
+            UserType::Community => $profile->communityProfile?->name,
+            UserType::Attendee => $profile->name,
+        };
+    }
+}

--- a/app/Services/OnboardingDripService.php
+++ b/app/Services/OnboardingDripService.php
@@ -9,6 +9,7 @@ use App\Enums\KolabStatus;
 use App\Enums\UserType;
 use App\Models\OnboardingDripState;
 use App\Models\Profile;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Drives the T+0/T+2/T+5/T+10 onboarding email drip.
@@ -27,8 +28,9 @@ use App\Models\Profile;
  *   3. T+10 Inactive nudge              — only if still no first action taken
  *
  * Steps whose condition is no longer met when they come due are skipped (not
- * cancelled outright) so a later step can still fire; the whole drip is
- * cancelled once the profile is fully activated (see cancelIfActivated()).
+ * cancelled outright) so a later step can still fire. The welcome (step 0)
+ * always sends; from step 1 on, the whole drip is cancelled the moment the
+ * profile is fully activated (see sendDue()/processDueRow()).
  */
 class OnboardingDripService
 {
@@ -45,20 +47,26 @@ class OnboardingDripService
     ) {}
 
     /**
-     * Start (or resync) the drip for a freshly signed-up profile. Idempotent:
-     * calling this again for a profile that already has a state row is a no-op
-     * unless that row was previously cancelled and the profile re-qualifies.
+     * Enrol a profile into the drip. One-shot and idempotent: once a profile
+     * has a state row — running, completed, or cancelled — this is a no-op.
+     * Onboarding happens once; resurrecting a finished drip would re-send the
+     * welcome.
+     *
+     * The cadence is anchored on enrolment time (now()), not the profile's
+     * created_at, so a profile backfilled via --sync-new well after signup
+     * still receives the full T+0..T+10 sequence from the backfill moment
+     * rather than having every past-due step collapsed away by advance().
      */
     public function startForProfile(Profile $profile): void
     {
         $state = OnboardingDripState::query()->firstOrNew(['profile_id' => $profile->id]);
 
-        if ($state->exists && $state->cancelled_at === null) {
+        if ($state->exists) {
             return;
         }
 
         $cadenceHours = $this->cadenceHours();
-        $anchor = $profile->created_at ?? now();
+        $anchor = now();
 
         $state->fill([
             'anchor_at' => $anchor,
@@ -89,39 +97,69 @@ class OnboardingDripService
      */
     public function sendDue(int $limit = 200): int
     {
-        $sentCount = 0;
-
-        OnboardingDripState::query()
+        $dueIds = OnboardingDripState::query()
             ->whereNull('cancelled_at')
             ->whereNotNull('scheduled_for')
             ->where('scheduled_for', '<=', now())
             ->orderBy('scheduled_for')
             ->limit($limit)
-            ->with('profile.businessProfile', 'profile.communityProfile', 'profile.attendeeProfile')
-            ->get()
-            ->each(function (OnboardingDripState $state) use (&$sentCount): void {
-                $profile = $state->profile;
+            ->pluck('id');
 
-                if ($profile === null) {
-                    $this->cancel($state);
+        $sentCount = 0;
 
-                    return;
-                }
-
-                if ($this->isFullyActivated($profile)) {
-                    $this->cancel($state);
-
-                    return;
-                }
-
-                if ($this->dispatchStep($profile, $state->next_sequence)) {
-                    $sentCount++;
-                }
-
-                $this->advance($state);
-            });
+        foreach ($dueIds as $id) {
+            $sentCount += $this->processDueRow($id);
+        }
 
         return $sentCount;
+    }
+
+    /**
+     * Process a single due drip row under a row lock so two overlapping runs
+     * (or a retried job) can never dispatch the same step twice: the row is
+     * re-read + re-checked inside the transaction, and a concurrent pass that
+     * already advanced it sees a future/null scheduled_for and bails.
+     *
+     * @return int 1 if an email was dispatched, 0 otherwise.
+     */
+    private function processDueRow(string $id): int
+    {
+        return DB::transaction(function () use ($id): int {
+            $state = OnboardingDripState::query()
+                ->whereKey($id)
+                ->lockForUpdate()
+                ->with('profile.businessProfile', 'profile.communityProfile', 'profile.attendeeProfile')
+                ->first();
+
+            if ($state === null
+                || $state->cancelled_at !== null
+                || $state->scheduled_for === null
+                || $state->scheduled_for->gt(now())) {
+                return 0;
+            }
+
+            $profile = $state->profile;
+
+            if ($profile === null) {
+                $this->cancel($state);
+
+                return 0;
+            }
+
+            // Stop nudging a fully-activated user — but the T+0 welcome always
+            // sends; only the later nudge steps are short-circuited.
+            if ($state->next_sequence > self::STEP_WELCOME && $this->isFullyActivated($profile)) {
+                $this->cancel($state);
+
+                return 0;
+            }
+
+            $dispatched = $this->dispatchStep($profile, $state->next_sequence);
+
+            $this->advance($state, $dispatched);
+
+            return $dispatched ? 1 : 0;
+        });
     }
 
     /**
@@ -147,11 +185,9 @@ class OnboardingDripService
             UserType::Attendee => 'attendee-welcome-01',
         };
 
-        $this->emailService->send($profile, $alias, [
+        return $this->emailService->send($profile, $alias, [
             'first_name' => $this->displayName($profile),
         ], EmailService::CATEGORY_NUDGE);
-
-        return true;
     }
 
     private function sendCompleteProfileNudge(Profile $profile): bool
@@ -173,11 +209,9 @@ class OnboardingDripService
             return false;
         }
 
-        $this->emailService->send($profile, $alias, [
+        return $this->emailService->send($profile, $alias, [
             'first_name' => $this->displayName($profile),
         ], EmailService::CATEGORY_NUDGE);
-
-        return true;
     }
 
     private function sendActivationNudge(Profile $profile): bool
@@ -192,11 +226,9 @@ class OnboardingDripService
             UserType::Attendee => 'attendee-activation-01',
         };
 
-        $this->emailService->send($profile, $alias, [
+        return $this->emailService->send($profile, $alias, [
             'first_name' => $this->displayName($profile),
         ], EmailService::CATEGORY_NUDGE);
-
-        return true;
     }
 
     private function sendInactiveNudge(Profile $profile): bool
@@ -205,11 +237,9 @@ class OnboardingDripService
             return false;
         }
 
-        $this->emailService->send($profile, 'inactive-nudge', [
+        return $this->emailService->send($profile, 'inactive-nudge', [
             'first_name' => $this->displayName($profile),
         ], EmailService::CATEGORY_NUDGE);
-
-        return true;
     }
 
     /**
@@ -237,7 +267,15 @@ class OnboardingDripService
         $state->update(['scheduled_for' => null, 'cancelled_at' => now()]);
     }
 
-    private function advance(OnboardingDripState $state): void
+    /**
+     * Advance the state past the step just processed. sent_at and
+     * last_sent_sequence are only touched when an email was actually
+     * dispatched ($dispatched), so a skipped/ineligible step never records a
+     * phantom "sent". Steps whose scheduled time is already in the past (a
+     * scheduler outage / backfill catch-up) are skipped over so only the most
+     * relevant current step fires, not a burst of stale ones.
+     */
+    private function advance(OnboardingDripState $state, bool $dispatched): void
     {
         $cadenceHours = $this->cadenceHours();
         $currentSequence = $state->next_sequence;
@@ -250,12 +288,12 @@ class OnboardingDripService
         }
 
         $state->update([
-            'last_sent_sequence' => $currentSequence,
+            'last_sent_sequence' => $dispatched ? $currentSequence : $state->last_sent_sequence,
             'next_sequence' => $nextSequence,
             'scheduled_for' => $nextSequence < count($cadenceHours)
                 ? $state->anchor_at->copy()->addHours($cadenceHours[$nextSequence])
                 : null,
-            'sent_at' => $now,
+            'sent_at' => $dispatched ? $now : $state->sent_at,
             'cancelled_at' => $nextSequence < count($cadenceHours) ? null : $now,
         ]);
     }

--- a/config/onboarding_drip.php
+++ b/config/onboarding_drip.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------
+    | Onboarding drip cadence (hours since signup)
+    |--------------------------------------------------------------------
+    |
+    | Recommended cadence from Jace (Serra CMO), vault deliverable
+    | _deliverables/to-review/jace/2026-07-20 - kolabing-launch-emails-and-onboarding.md,
+    | task 1a: T+0 welcome -> T+2 complete-profile nudge (if incomplete) ->
+    | T+5 activation nudge (if no first action) -> T+10 inactive nudge.
+    |
+    | NOT YET APPROVED BY DANIEL. Built and ready; do not enable the
+    | scheduled command in routes/console.php until the offsets below are
+    | signed off. See app/Console/Commands/SendOnboardingDrip.php.
+    |
+    */
+    'cadence_hours' => [0, 48, 120, 240],
+
+];

--- a/database/migrations/2026_07_21_080951_create_onboarding_drip_states_table.php
+++ b/database/migrations/2026_07_21_080951_create_onboarding_drip_states_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('onboarding_drip_states', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('profile_id');
+            $table->timestamp('anchor_at');
+            $table->unsignedTinyInteger('next_sequence')->default(0);
+            $table->unsignedTinyInteger('last_sent_sequence')->nullable();
+            $table->timestamp('scheduled_for')->nullable();
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('profile_id')
+                ->references('id')
+                ->on('profiles')
+                ->onDelete('cascade');
+
+            $table->unique('profile_id', 'onboarding_drip_states_profile_unique');
+            $table->index(['scheduled_for', 'cancelled_at'], 'onboarding_drip_states_schedule_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('onboarding_drip_states');
+    }
+};

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-15 (legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
+**Last updated:** 2026-07-21 (§1: corrected the stale "email not wired" note — the Postmark pipeline has existed since `b50c378` (2026-06-04); it's built and live-send verified but has no production caller yet. Added the onboarding drip command/service, built and not scheduled, pending Daniel's sign-off on the offsets. Prior: 2026-07-15 legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -11,39 +11,63 @@ Each item lists what exists now, what's missing, and any open decisions. See ref
 
 ## 1. Email infrastructure (Postmark)
 
-**Status:** Not wired. Only password reset uses Laravel's Password broker default.
+**Status (corrected 2026-07-21 — the previous "not wired" note here was stale; the pipeline has
+existed since commit `b50c378`, 2026-06-04):** the transactional email **pipeline is built and
+live-send verified**, but has **no production caller** — `EmailService::send()` is only ever
+invoked from the manual `email:sync-templates --test=` / `email:test` CLI smoke-test commands. No
+app code path (registration, application lifecycle, gamification, etc.) calls it in the request
+flow yet. Password reset still uses Laravel's Password broker default, not the Postmark template.
 
 **What exists:**
-- `config/services.php:17-19` declares Postmark with `POSTMARK_API_KEY` env.
-- `config/mail.php:17` default mailer is `'log'` (not Postmark).
-- `AuthService:566` sends password reset via `Password::broker()->sendResetLink()`.
+- `app/Services/PostmarkClient.php` — Postmark HTTP client (`sendTemplate` + `sendRaw` + template CRUD).
+- `app/Services/EmailService.php` — preference-gated dispatch (`account`/`security` always send;
+  `application`/`collaboration` respect their dedicated flags; `gamification`/`nudge` respect only
+  the `email_notifications` master switch; `marketing` respects `marketing_tips`).
+- `app/Jobs/SendTransactionalEmail.php` — queued delivery, mirrors `SendPushNotification`.
+- `resources/postmark/templates.php` — 19 seeded template definitions (+ 2 pre-existing aliases,
+  `business-welcome-01`/`community-welcome-01`, live in Postmark only) + `app/Console/Commands/SyncPostmarkTemplates.php`
+  to push them. See `docs/TEMPLATE_COPY_EXPORT.md` for the full copy export.
+- `app/Console/Commands/SendOnboardingDrip.php` + `app/Models/OnboardingDripState.php` +
+  `app/Services/OnboardingDripService.php` (added 2026-07-21) — the T+0/T+2/T+5/T+10 onboarding
+  drip (welcome / complete-profile / activation / inactive-nudge), same per-recipient-state-row +
+  cadence-hours shape as `NotificationReminderService`. **Built, not scheduled** — see
+  `routes/console.php` (commented out) and `config/onboarding_drip.php`. Do not uncomment the
+  `Schedule::command('app:send-onboarding-drip')` line until Daniel approves the cadence.
+- `config/services.php:17-19` declares Postmark with `POSTMARK_API_KEY` env; `POSTMARK_API_KEY` /
+  `POSTMARK_MESSAGE_STREAM_ID` documented in `.env.example`.
+- `AuthService:566` sends password reset via `Password::broker()->sendResetLink()` (not yet swapped
+  to the `password-reset` Postmark template).
 
 **What's missing:**
-- No `app/Mail/` Mailables at all. No `app/Notifications/` mail-channel classes. No `resources/views/mail/` templates.
-- No `POSTMARK_API_KEY` in `.env.example`.
-- Default mailer never flipped to `postmark`.
-- No `MustVerifyEmail` on the `Profile` model — email confirmation on signup is not enforced. (Google OAuth manually sets `email_verified_at = now()` per `AuthService:168` so OAuth users skip verification anyway.)
+- No app code calls `EmailService::send()` from a real trigger seam yet (registration, application
+  accept/decline, collab confirmed, badge/reward/tier events, etc.) — see
+  `docs/plans/2026-06-04-transactional-email-system.md` Phase 2 for the full seam-by-seam map.
+- Default mailer (`config/mail.php:17`) is still `'log'`, not `postmark`, in local/default env.
+- No `MustVerifyEmail` on the `Profile` model — email confirmation on signup is not enforced.
+  (Google OAuth manually sets `email_verified_at = now()` per `AuthService:168` so OAuth users skip
+  verification anyway.) Verification stays OFF by design until Daniel approves the welcome template
+  (plan doc Phase 5).
 
 **P0 — must ship before launch:**
-- [ ] `Mail/EmailVerification` Mailable + send on registration (email/password path). Owner: **backend**.
-- [ ] `Mail/PasswordReset` Mailable to replace Laravel's default reset email (custom branding). Owner: **backend**.
-- [ ] `Mail/WelcomeBusiness`, `Mail/WelcomeCommunity` post-onboarding. Owner: **backend**.
-- [ ] Wire Postmark: `POSTMARK_API_KEY` to `.env.example`, `MAIL_MAILER=postmark` in production env. Owner: **infra**.
-- [ ] Email-style branding template (`emails/layouts/master.blade.php`) so all subsequent Mailables share a header/footer. Owner: **backend**.
+- [ ] Wire `EmailService::send()` into the real trigger seams (welcome on register, password
+  reset/changed, application lifecycle, collab-confirmed, feedback-request) per the plan doc's
+  Phase 2 table. Owner: **backend**.
+- [ ] Wire Postmark: `MAIL_MAILER=postmark` in production env (config already supports it). Owner: **infra**.
 
 **P1 — customer success flows:**
-- [ ] "Create your first kolab" nudge — business with no published kolab after N days. Trigger: scheduled command. Owner: **backend**.
-- [ ] "Your first application is in" — business gets an email when they receive their first community application. Owner: **backend**.
+- [x] Onboarding drip (welcome / complete-profile / activation / inactive-nudge) — command +
+  service built 2026-07-21, **awaiting Daniel's sign-off on the offsets before scheduling live**.
+  Owner: **backend**.
 - [ ] Collab-day + follow-up reminders also as email fallback (push exists already). Owner: **backend**.
 - [ ] Subscription receipts on activation / cancellation / past_due (gated on §3 Stripe ship). Owner: **backend**.
 
 **P2 — lifecycle marketing:**
-- [ ] Re-engagement after N days inactive — email path complementing push. Owner: **backend**.
 - [ ] Monthly "your Kolabing impact" summary for businesses (revenue from feedback, attendance, reviews). Owner: **backend**.
 
 **Open decisions:**
 - Single Postmark stream or one stream per type (transactional vs broadcast)?
 - Do we mirror every push as an email, or push for time-sensitive + email for value-add?
+- Onboarding drip cadence (T+0/T+2/T+5/T+10, `config/onboarding_drip.php`) — pending Daniel approval.
 
 ---
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-21 (§1: corrected the stale "email not wired" note — the Postmark pipeline has existed since `b50c378` (2026-06-04); it's built and live-send verified but has no production caller yet. Added the onboarding drip command/service, built and not scheduled, pending Daniel's sign-off on the offsets. Prior: 2026-07-15 legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
+**Last updated:** 2026-07-27 (§1: onboarding drip wired into registration (`AuthService::startOnboardingDrip`) + scheduled hourly; `business-welcome-01`/`community-welcome-01` moved into `templates.php` (22 aliases now); drip state machine hardened — welcome always sends, row-locked sends, honest sent-tracking, `now()` anchor, idempotent enrolment. Prior: 2026-07-21 §1: corrected the stale "email not wired" note — the Postmark pipeline has existed since `b50c378` (2026-06-04); it's built and live-send verified but has no production caller yet. Added the onboarding drip command/service, built and not scheduled, pending Daniel's sign-off on the offsets. Prior: 2026-07-15 legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -24,23 +24,27 @@ flow yet. Password reset still uses Laravel's Password broker default, not the P
   `application`/`collaboration` respect their dedicated flags; `gamification`/`nudge` respect only
   the `email_notifications` master switch; `marketing` respects `marketing_tips`).
 - `app/Jobs/SendTransactionalEmail.php` — queued delivery, mirrors `SendPushNotification`.
-- `resources/postmark/templates.php` — 19 seeded template definitions (+ 2 pre-existing aliases,
-  `business-welcome-01`/`community-welcome-01`, live in Postmark only) + `app/Console/Commands/SyncPostmarkTemplates.php`
-  to push them. See `docs/TEMPLATE_COPY_EXPORT.md` for the full copy export.
+- `resources/postmark/templates.php` — 22 seeded template definitions (now including
+  `business-welcome-01`/`community-welcome-01`, moved in from Postmark-only so a fresh env is
+  self-sufficient) + `app/Console/Commands/SyncPostmarkTemplates.php` to push them. See
+  `docs/TEMPLATE_COPY_EXPORT.md` for the full copy export.
 - `app/Console/Commands/SendOnboardingDrip.php` + `app/Models/OnboardingDripState.php` +
   `app/Services/OnboardingDripService.php` (added 2026-07-21) — the T+0/T+2/T+5/T+10 onboarding
   drip (welcome / complete-profile / activation / inactive-nudge), same per-recipient-state-row +
-  cadence-hours shape as `NotificationReminderService`. **Built, not scheduled** — see
-  `routes/console.php` (commented out) and `config/onboarding_drip.php`. Do not uncomment the
-  `Schedule::command('app:send-onboarding-drip')` line until Daniel approves the cadence.
+  cadence-hours shape as `NotificationReminderService`. **Wired + scheduled (2026-07-27):** new
+  signups are enrolled at registration (`AuthService::startOnboardingDrip`) and
+  `Schedule::command('app:send-onboarding-drip')->hourly()->withoutOverlapping()` runs in
+  `routes/console.php`. Note: the cadence offsets in `config/onboarding_drip.php` were activated
+  ahead of Daniel's formal sign-off — confirm before/at launch.
 - `config/services.php:17-19` declares Postmark with `POSTMARK_API_KEY` env; `POSTMARK_API_KEY` /
   `POSTMARK_MESSAGE_STREAM_ID` documented in `.env.example`.
 - `AuthService:566` sends password reset via `Password::broker()->sendResetLink()` (not yet swapped
   to the `password-reset` Postmark template).
 
 **What's missing:**
-- No app code calls `EmailService::send()` from a real trigger seam yet (registration, application
-  accept/decline, collab confirmed, badge/reward/tier events, etc.) — see
+- Registration now triggers email via the onboarding drip (welcome at T+0), but the remaining
+  lifecycle seams still don't call `EmailService::send()`: application accept/decline, collab
+  confirmed, feedback-request, badge/reward/tier events — see
   `docs/plans/2026-06-04-transactional-email-system.md` Phase 2 for the full seam-by-seam map.
 - Default mailer (`config/mail.php:17`) is still `'log'`, not `postmark`, in local/default env.
 - No `MustVerifyEmail` on the `Profile` model — email confirmation on signup is not enforced.
@@ -55,8 +59,9 @@ flow yet. Password reset still uses Laravel's Password broker default, not the P
 - [ ] Wire Postmark: `MAIL_MAILER=postmark` in production env (config already supports it). Owner: **infra**.
 
 **P1 — customer success flows:**
-- [x] Onboarding drip (welcome / complete-profile / activation / inactive-nudge) — command +
-  service built 2026-07-21, **awaiting Daniel's sign-off on the offsets before scheduling live**.
+- [x] Onboarding drip (welcome / complete-profile / activation / inactive-nudge) — built 2026-07-21;
+  wired into registration + scheduled hourly 2026-07-27. Cadence offsets activated ahead of
+  Daniel's formal sign-off — **confirm the T+0/T+2/T+5/T+10 offsets before/at launch**.
   Owner: **backend**.
 - [ ] Collab-day + follow-up reminders also as email fallback (push exists already). Owner: **backend**.
 - [ ] Subscription receipts on activation / cancellation / past_due (gated on §3 Stripe ship). Owner: **backend**.

--- a/docs/TEMPLATE_COPY_EXPORT.md
+++ b/docs/TEMPLATE_COPY_EXPORT.md
@@ -4,20 +4,17 @@
 brand-voice audit. This is an **extraction**, not a rewrite — nothing below has been reworded.
 
 **Source files:**
-- [`resources/postmark/templates.php`](../resources/postmark/templates.php) — 19 template
+- [`resources/postmark/templates.php`](../resources/postmark/templates.php) — 22 template
   definitions (structured content blocks; this is the seed `email:sync-templates` pushes to Postmark).
 - [`docs/plans/2026-06-04-transactional-email-system.md`](plans/2026-06-04-transactional-email-system.md)
   — the copy-slot catalog and gating rules for the full onboarding/lifecycle plan.
 
-**Count note:** the repo defines **19** template aliases in `templates.php`. Two more aliases
-(`business-welcome-01`, `community-welcome-01`) are referenced throughout the codebase and plan
-doc as already **live in Postmark** but are deliberately **excluded from this file** (see the
-file's own header comment: "Existing/approved templates are intentionally NOT redefined here so
-the sync never clobbers them"). Their copy is **not in the repo** — it lives only in the Postmark
-dashboard, so it cannot be exported from here; audit it directly in Postmark if needed.
-That's **21 total live/defined aliases** today. The wider plan doc catalogs up to ~30 email
-*concepts* across all phases (A–G), but the remaining ones (billing/digest, Phase 3–4) have no
-template file yet — they're design notes, not copy. This export covers the 19 that exist as copy.
+**Count note:** the repo now defines **22** template aliases in `templates.php`, all exported
+below. `business-welcome-01` / `community-welcome-01` (the onboarding drip's T+0 welcome) were
+previously authored only in the Postmark dashboard; they are now checked into `templates.php` so a
+fresh environment is self-sufficient, and their copy is exported here (see the *Onboarding drip*
+section). The wider plan doc catalogs up to ~30 email *concepts* across all phases (A–G), but the
+remaining ones (billing/digest, Phase 3–4) have no template file yet — they're design notes, not copy.
 
 **Rendering note:** every template shares one HTML scaffold (logo header, 600px content column,
 footer) built by `SyncPostmarkTemplates::renderHtml()`. The `content` blocks below are rendered in
@@ -331,20 +328,75 @@ Each template's dynamic variables are also listed in the index at the bottom of 
 
 ---
 
-## Referenced but NOT in this repo (live in Postmark dashboard only)
+## Onboarding drip
 
-These two aliases are used by the codebase (`AuthService::registerBusiness()` /
-`registerCommunity()`) and confirmed live in Postmark as of 2026-06-04, but their copy was
-authored directly in Postmark and was never checked into `templates.php` — this repo has no
-source text to export for them.
+The T+0/T+2/T+5/T+10 drip (`OnboardingDripService`). The welcome (T+0) fires for every new signup;
+`inactive-nudge` (T+10) only if no first action was taken. `business-welcome-01` /
+`community-welcome-01` were previously Postmark-only and are now checked into `templates.php`, so
+their copy is exported here for the first time. (The T+2 complete-profile and T+5 activation
+nudges are exported above under *Onboarding / activation nudges*.)
 
-| Alias | Subject (from plan doc) | Model |
-|---|---|---|
-| `business-welcome-01` | "Your first match is 10 minutes away" | `{ first_name }` (= business name) |
-| `community-welcome-01` | "Your first Kolab is 10 minutes away" | `{ first_name }` (= community name) |
+### `business-welcome-01` — Welcome (business)
+**Subject:** `Welcome to Kolabing`
+**Sample model:** `{ first_name: "Joe's Cafe" }` (= business name)
 
-Neither has a `verify_url` slot today (see plan doc — deferred to Phase 5, email verification is
-off).
+> Hi {{first_name}},
+>
+> Welcome to Kolabing. You're here to partner with local communities, run clubs, art collectives,
+> wellness groups, food crews, and get your venue in front of the people who'll fill it.
+>
+> **How it works:**
+> 1. Finish your profile so communities can find you.
+> 2. Post a Kolab: what you're offering (a venue, a discount, a private space) and what you'd like back.
+> 3. Review the applications and pick the communities that fit.
+>
+> You can post your first Kolab in about 3 minutes.
+>
+> **[Button: Open Kolabing → app]**
+>
+> *(signature)*
+
+---
+
+### `community-welcome-01` — Welcome (community)
+**Subject:** `Welcome to Kolabing`
+**Sample model:** `{ first_name: "Barcelona Run Club" }` (= community name)
+
+> Hi {{first_name}},
+>
+> Welcome to Kolabing. You're here to find local businesses to partner with, venues, discounts,
+> private spaces, and perks for your members.
+>
+> **How it works:**
+> 1. Finish your community profile so businesses can find you.
+> 2. Browse the open Kolabs and apply to the ones that fit your members.
+> 3. Team up, run the event, and build your reputation for the next one.
+>
+> You can apply to your first Kolab in about 2 minutes.
+>
+> **[Button: Browse Kolabs → app]**
+>
+> *(signature)*
+
+---
+
+### `inactive-nudge` — Inactive nudge
+**Subject:** `Still worth a look, new collabs near you`
+**Sample model:** `{ first_name: "Daniel" }`
+
+> Hi {{first_name}},
+>
+> You joined Kolabing but haven't started a collab yet. No pressure.
+>
+> There are new opportunities posted since you signed up that match what you're after. It takes
+> two minutes to apply to the first one.
+>
+> **[Button: See what's open → app]**
+>
+> *(signature)*
+
+Neither welcome has a `verify_url` slot today (see plan doc — deferred to Phase 5, email
+verification is off).
 
 ---
 
@@ -379,3 +431,7 @@ Postmark mustache placeholders (`{{name}}`) with the same variable names if rena
 *Generated by Clark from `resources/postmark/templates.php` (commit `b50c378`) and
 `docs/plans/2026-06-04-transactional-email-system.md`, 2026-07-21, for Jace's brand-voice audit
 (handoff `15450189-3f75-48e5-94f7-d338c94574be`). No copy has been altered in this export.*
+
+*Updated 2026-07-27: `business-welcome-01` / `community-welcome-01` were checked into
+`templates.php` (previously Postmark-only) and their copy exported; the unused `first-collab-tips`
+draft was removed. Counts and the onboarding-drip section reflect the 22 current aliases.*

--- a/docs/TEMPLATE_COPY_EXPORT.md
+++ b/docs/TEMPLATE_COPY_EXPORT.md
@@ -1,0 +1,381 @@
+# Postmark Template Copy Export
+
+**Purpose:** faithful, verbatim export of the transactional email copy in this repo, for Jace's
+brand-voice audit. This is an **extraction**, not a rewrite — nothing below has been reworded.
+
+**Source files:**
+- [`resources/postmark/templates.php`](../resources/postmark/templates.php) — 19 template
+  definitions (structured content blocks; this is the seed `email:sync-templates` pushes to Postmark).
+- [`docs/plans/2026-06-04-transactional-email-system.md`](plans/2026-06-04-transactional-email-system.md)
+  — the copy-slot catalog and gating rules for the full onboarding/lifecycle plan.
+
+**Count note:** the repo defines **19** template aliases in `templates.php`. Two more aliases
+(`business-welcome-01`, `community-welcome-01`) are referenced throughout the codebase and plan
+doc as already **live in Postmark** but are deliberately **excluded from this file** (see the
+file's own header comment: "Existing/approved templates are intentionally NOT redefined here so
+the sync never clobbers them"). Their copy is **not in the repo** — it lives only in the Postmark
+dashboard, so it cannot be exported from here; audit it directly in Postmark if needed.
+That's **21 total live/defined aliases** today. The wider plan doc catalogs up to ~30 email
+*concepts* across all phases (A–G), but the remaining ones (billing/digest, Phase 3–4) have no
+template file yet — they're design notes, not copy. This export covers the 19 that exist as copy.
+
+**Rendering note:** every template shares one HTML scaffold (logo header, 600px content column,
+footer) built by `SyncPostmarkTemplates::renderHtml()`. The `content` blocks below are rendered in
+order into that scaffold. Block types: `para` (paragraph), `head` (bold subheading), `list`
+(ordered/unordered), `button` (label + URL), `signature` (fixed "Maria, Co-founder, Kolabing"),
+`ps` (postscript, rendered with a top border). All body text runs through `htmlspecialchars()` on
+render; the copy below is the pre-escaped source text.
+
+**Merge variable syntax:** Postmark mustache, `{{variable_name}}`. Every `{{...}}` token below is
+**dynamic** (filled at send time from the `model` array); everything else is **static** copy.
+Each template's dynamic variables are also listed in the index at the bottom of this doc.
+
+---
+
+## Account & security (always sends — never opt-outable)
+
+### `attendee-welcome-01` — Welcome (attendee)
+**Subject:** `Your first points are one event away`
+**Sample model:** `{ first_name: "Daniel" }`
+
+> Hi {{first_name}},
+>
+> Welcome to Kolabing. You're here for the events, the challenges, and the rewards you earn just for showing up.
+>
+> **How it works (2 min):**
+> 1. Open the app and join a community you're into. Run clubs, art collectives, wellness groups, food crews. New ones are added every week in Barcelona.
+> 2. Find an event or challenge, show up, and snap your proof.
+> 3. Earn points. Every challenge and event earns points that unlock badges and move you up the community leaderboard.
+>
+> **This week:**
+> Join one community and complete one challenge. That's it. The first one is the hardest; after that it's a habit.
+>
+> [Signature: Maria, Co-founder]
+>
+> P.S. Not sure which community fits you? Reply with what you're into (running, art, food, wellness...) and I'll point you to the most active ones tonight.
+
+---
+
+### `password-reset` — Password reset
+**Subject:** `Reset your Kolabing password`
+**Sample model:** `{ first_name: "Daniel", reset_url: "https://kolabing.com/reset-password?token=sample", expires_minutes: "60" }`
+
+> Hi {{first_name}},
+>
+> We got a request to reset your Kolabing password. Tap the button below to choose a new one. This link expires in {{expires_minutes}} minutes.
+>
+> **[Button: Reset password → {{reset_url}}]**
+>
+> If you didn't request this, you can ignore this email, your password won't change.
+
+---
+
+### `password-changed` — Password changed
+**Subject:** `Your Kolabing password was changed`
+**Sample model:** `{ first_name: "Daniel", support_email: "info@kolabing.com" }`
+
+> Hi {{first_name}},
+>
+> This is a confirmation that your Kolabing password was just changed. For security, you've been signed out on all devices.
+>
+> If this was you, you're all set. If it wasn't, reset your password right away and email us at {{support_email}}.
+
+---
+
+## Onboarding / activation nudges
+
+### `complete-profile-business` — Complete profile (business)
+**Subject:** `Your profile is almost ready`
+**Sample model:** `{ first_name: "Joe's Cafe" }`
+
+> Hi {{first_name}},
+>
+> You signed up but your business profile isn't finished yet, and communities can't find you until it is.
+>
+> **Two minutes to go live:**
+> 1. Add 3 photos of your venue.
+> 2. Pick your category and write one specific line about your place.
+> 3. Add one thing you can offer a community.
+>
+> Done. You'll start showing up in front of communities looking for partners.
+>
+> [Signature: Maria, Co-founder]
+
+---
+
+### `complete-profile-community` — Complete profile (community)
+**Subject:** `Your community profile is almost ready`
+**Sample model:** `{ first_name: "Barcelona Run Club" }`
+
+> Hi {{first_name}},
+>
+> You signed up but your community profile isn't finished, and businesses can't find you until it is.
+>
+> **Two minutes to go live:**
+> 1. Add your logo and a couple of photos.
+> 2. Pick your community type and write one line about who you are.
+> 3. Add your city and socials.
+>
+> Done. You'll start showing up to businesses looking to collaborate.
+>
+> [Signature: Maria, Co-founder]
+
+---
+
+### `activation-business` — Activation nudge (business)
+**Subject:** `Post your first Kolab`
+**Sample model:** `{ first_name: "Joe's Cafe" }`
+
+> Hi {{first_name}},
+>
+> Your profile's ready. Now post your first Kolab so communities can apply.
+>
+> A Kolab is just what you're offering and what you'd like back. A discount night for a shoutout. A private space for an event. It takes 3 minutes.
+>
+> **[Button: Post a Kolab → app]**
+>
+> [Signature: Maria, Co-founder]
+
+---
+
+### `activation-community` — Activation nudge (community)
+**Subject:** `Apply to your first Kolab`
+**Sample model:** `{ first_name: "Barcelona Run Club" }`
+
+> Hi {{first_name}},
+>
+> Your profile's ready. Now browse what businesses are offering and apply to your first Kolab.
+>
+> Venues, discounts, private spaces, sponsored slots, there's a lot up for grabs for your members. It takes 2 minutes to apply.
+>
+> **[Button: Browse Kolabs → app]**
+>
+> [Signature: Maria, Co-founder]
+
+---
+
+### `attendee-activation-01` — Activation nudge (attendee)
+**Subject:** `Your first challenge is waiting`
+**Sample model:** `{ first_name: "Daniel" }`
+
+> Hi {{first_name}},
+>
+> You're in, but you haven't joined a community yet. That's where the events, challenges, and points are.
+>
+> Pick one community, complete one challenge. The first one is the hardest; after that it's a habit.
+>
+> **[Button: Find a community → app]**
+>
+> [Signature: Maria, Co-founder]
+
+---
+
+## Collaboration lifecycle
+
+### `application-received` — Application received
+**Subject:** `New application for {{opportunity_title}}`
+**Sample model:** `{ first_name: "Joe's Cafe", applicant_name: "Barcelona Run Club", opportunity_title: "Saturday morning coffee partner" }`
+
+> Hi {{first_name}},
+>
+> {{applicant_name}} just applied to your Kolab "{{opportunity_title}}".
+>
+> Take a look and accept if it's a fit. The sooner you reply, the more likely it happens.
+>
+> **[Button: Review application → app]**
+
+---
+
+### `application-accepted` — Application accepted
+**Subject:** `You're in. {{opportunity_title}} is a match`
+**Sample model:** `{ first_name: "Barcelona Run Club", partner_name: "Joe's Cafe", opportunity_title: "Saturday morning coffee partner" }`
+
+> Hi {{first_name}},
+>
+> Good news, {{partner_name}} accepted your application for "{{opportunity_title}}".
+>
+> Open the app to agree on a date and sort the details in chat.
+>
+> **[Button: Open the collaboration → app]**
+
+---
+
+### `application-declined` — Application declined
+**Subject:** `About your application for {{opportunity_title}}`
+**Sample model:** `{ first_name: "Barcelona Run Club", partner_name: "Joe's Cafe", opportunity_title: "Saturday morning coffee partner" }`
+
+> Hi {{first_name}},
+>
+> {{partner_name}} won't be moving forward with your application for "{{opportunity_title}}" this time.
+>
+> It happens, fit matters. There are more Kolabs posted every week, and the next one might be a better match.
+>
+> **[Button: Browse Kolabs → app]**
+
+---
+
+### `first-message` — First message
+**Subject:** `{{sender_name}} sent you a message`
+**Sample model:** `{ first_name: "Joe's Cafe", sender_name: "Barcelona Run Club" }`
+**Trigger note (from plan doc):** fires only on a thread's first message; every later message in the same thread is push-only, no email.
+
+> Hi {{first_name}},
+>
+> {{sender_name}} started a conversation with you on Kolabing. Open the app to reply and keep things moving.
+>
+> **[Button: Open chat → app]**
+
+---
+
+### `collab-confirmed` — Collaboration confirmed
+**Subject:** `Your collaboration with {{partner_name}} is confirmed`
+**Sample model:** `{ first_name: "Joe's Cafe", partner_name: "Barcelona Run Club", scheduled_date: "Saturday, 14 June" }`
+
+> Hi {{first_name}},
+>
+> It's official, your collaboration with {{partner_name}} is confirmed for {{scheduled_date}}.
+>
+> **Before the day:**
+> - Agree on the final details in chat.
+> - Make sure everyone knows where and when.
+>
+> We'll remind you the day it happens.
+>
+> **[Button: View collaboration → app]**
+
+---
+
+### `feedback-request` — Feedback request
+**Subject:** `How did it go with {{partner_name}}?`
+**Sample model:** `{ first_name: "Joe's Cafe", partner_name: "Barcelona Run Club" }`
+
+> Hi {{first_name}},
+>
+> Your collaboration with {{partner_name}} should be done by now. Tell us how it went, it takes a minute and helps both sides build trust for the next one.
+>
+> **[Button: Give feedback → app]**
+>
+> Your feedback (including any revenue it drove) stays private and helps us match you better next time.
+
+---
+
+## Gamification
+
+### `badge-earned` — Badge earned
+**Subject:** `You earned the {{badge_name}} badge`
+**Sample model:** `{ first_name: "Daniel", badge_name: "Early Bird" }`
+
+> Hi {{first_name}},
+>
+> Nice work, you just earned the {{badge_name}} badge on Kolabing.
+>
+> Keep showing up to climb the leaderboard and unlock the next one.
+>
+> **[Button: See your badges → app]**
+
+---
+
+### `reward-won` — Reward won (community leader)
+**Subject:** `You won {{reward_name}}`
+**Sample model:** `{ first_name: "Barcelona Run Club", reward_name: "a 50 EUR bonus" }`
+
+> Hi {{first_name}},
+>
+> Congratulations, you just won {{reward_name}}.
+>
+> Open the app to see the details and claim it.
+>
+> **[Button: Claim your reward → app]**
+
+---
+
+### `withdrawal-processed` — Withdrawal processed (community leader)
+**Subject:** `Your cash-out of {{amount_eur}} is on its way`
+**Sample model:** `{ first_name: "Barcelona Run Club", amount_eur: "€75.00" }`
+
+> Hi {{first_name}},
+>
+> Your withdrawal of {{amount_eur}} has been processed and is on its way to your account.
+>
+> Thanks for being an active part of Kolabing.
+
+---
+
+### `tier-promotion` — Tier promotion
+**Subject:** `You've reached {{tier_name}}`
+**Sample model:** `{ first_name: "Barcelona Run Club", tier_name: "Gold" }`
+
+> Hi {{first_name}},
+>
+> You've been promoted to {{tier_name}}. Your activity on Kolabing is paying off.
+>
+> Higher tiers mean more visibility and more perks. Keep it up.
+>
+> **[Button: See your status → app]**
+
+---
+
+## Attendee gamification
+
+### `attendee-challenge-verified` — Challenge verified (attendee)
+**Subject:** `Challenge complete, +{{points}} points`
+**Sample model:** `{ first_name: "Daniel", challenge_name: "5K Morning Run", points: "50" }`
+
+> Hi {{first_name}},
+>
+> Your "{{challenge_name}}" challenge was verified. You just earned {{points}} points.
+>
+> Keep going to unlock badges and climb your community leaderboard.
+>
+> **[Button: See your points → app]**
+
+---
+
+## Referenced but NOT in this repo (live in Postmark dashboard only)
+
+These two aliases are used by the codebase (`AuthService::registerBusiness()` /
+`registerCommunity()`) and confirmed live in Postmark as of 2026-06-04, but their copy was
+authored directly in Postmark and was never checked into `templates.php` — this repo has no
+source text to export for them.
+
+| Alias | Subject (from plan doc) | Model |
+|---|---|---|
+| `business-welcome-01` | "Your first match is 10 minutes away" | `{ first_name }` (= business name) |
+| `community-welcome-01` | "Your first Kolab is 10 minutes away" | `{ first_name }` (= community name) |
+
+Neither has a `verify_url` slot today (see plan doc — deferred to Phase 5, email verification is
+off).
+
+---
+
+## Dynamic variable index (all `{{...}}` merge tokens used above)
+
+| Variable | Used in | Notes |
+|---|---|---|
+| `{{first_name}}` | nearly every template | Greeting name. **Caveat:** the schema has no personal contact-name field for business/community accounts — `first_name` is populated from `business_profiles.name` / `community_profiles.name` (i.e. the business/community's own name, not a person's), so copy reads "Hi Joe's Cafe," not "Hi Joe,". Attendees do have a real name. |
+| `{{reset_url}}` | `password-reset` | Full password-reset link with token. |
+| `{{expires_minutes}}` | `password-reset` | Link TTL in minutes (currently 60). |
+| `{{support_email}}` | `password-changed` | Support contact address. |
+| `{{opportunity_title}}` | `application-received`, `application-accepted`, `application-declined` | The Kolab/opportunity title, also appears in the subject line for `application-received`/`application-declined`. |
+| `{{applicant_name}}` | `application-received` | Name of the applying community. |
+| `{{partner_name}}` | `application-accepted`, `application-declined`, `collab-confirmed`, `feedback-request` | Name of the counterparty business/community. |
+| `{{sender_name}}` | `first-message` | Name of whoever sent the first message; also in the subject line. |
+| `{{scheduled_date}}` | `collab-confirmed` | Human-readable collab date. |
+| `{{badge_name}}` | `badge-earned` | Also appears in the subject line. |
+| `{{reward_name}}` | `reward-won` | Also appears in the subject line. |
+| `{{amount_eur}}` | `withdrawal-processed` | Pre-formatted currency string (e.g. `€75.00`); also in the subject line. |
+| `{{tier_name}}` | `tier-promotion` | Also appears in the subject line. |
+| `{{challenge_name}}` | `attendee-challenge-verified` | Challenge name. |
+| `{{points}}` | `attendee-challenge-verified` | Points earned; also appears in the subject line. |
+
+Everything else in the copy above (headings, list items, button labels, the signature block,
+the P.S., the footer, and all subject lines minus the tokens listed) is **static** text as
+authored — safe to brand-voice-audit and rewrite directly; the merge tokens must stay as
+Postmark mustache placeholders (`{{name}}`) with the same variable names if renamed, or the
+`model` array passed from `EmailService::send()` in the calling code must be updated to match.
+
+---
+
+*Generated by Clark from `resources/postmark/templates.php` (commit `b50c378`) and
+`docs/plans/2026-06-04-transactional-email-system.md`, 2026-07-21, for Jace's brand-voice audit
+(handoff `15450189-3f75-48e5-94f7-d338c94574be`). No copy has been altered in this export.*

--- a/resources/postmark/templates.php
+++ b/resources/postmark/templates.php
@@ -312,4 +312,42 @@ return [
         ],
     ],
 
+    // ───────────────────────── Onboarding drip (new, 2026-07-21) ─────────────────────────
+    // Copy drafted by Jace (Serra CMO), vault deliverable
+    // _deliverables/to-review/jace/2026-07-20 - kolabing-launch-emails-and-onboarding.md.
+    // Content verbatim from that draft; not yet brand-voice-audited/approved by Daniel.
+
+    [
+        'alias' => 'first-collab-tips',
+        'name' => 'First collab tips',
+        'subject' => 'Three ways to land your first collab on Kolabing',
+        'sample' => ['first_name' => 'Daniel'],
+        'content' => [
+            ['type' => 'para', 'text' => 'Hi {{first_name}},'],
+            ['type' => 'para', 'text' => "You're in. Here's how the people who get picked fastest do it:"],
+            ['type' => 'list', 'ordered' => true, 'items' => [
+                'Complete your profile. A photo and one line on what you do doubles your reply rate.',
+                "Apply to two or three collabs that fit, not ten that don't. A short, specific note beats a copy-paste.",
+                'Reply fast when a business messages you. The first to answer usually gets the collab.',
+            ]],
+            ['type' => 'para', 'text' => 'Want to browse what\'s open now?'],
+            ['type' => 'button', 'label' => 'Open Kolabing', 'url' => $app],
+            ['type' => 'signature'],
+        ],
+    ],
+
+    [
+        'alias' => 'inactive-nudge',
+        'name' => 'Inactive nudge',
+        'subject' => 'Still worth a look, new collabs near you',
+        'sample' => ['first_name' => 'Daniel'],
+        'content' => [
+            ['type' => 'para', 'text' => 'Hi {{first_name}},'],
+            ['type' => 'para', 'text' => "You joined Kolabing but haven't started a collab yet. No pressure."],
+            ['type' => 'para', 'text' => 'There are new opportunities posted since you signed up that match what you\'re after. It takes two minutes to apply to the first one.'],
+            ['type' => 'button', 'label' => 'See what\'s open', 'url' => $app],
+            ['type' => 'signature'],
+        ],
+    ],
+
 ];

--- a/resources/postmark/templates.php
+++ b/resources/postmark/templates.php
@@ -23,8 +23,10 @@ declare(strict_types=1);
  *
  * 'sample' supplies merge values for --test sends.
  *
- * Existing/approved templates (business-welcome-01, community-welcome-01) are
- * intentionally NOT redefined here so the sync never clobbers them.
+ * business-welcome-01 / community-welcome-01 are defined here so a fresh
+ * environment is self-sufficient (the onboarding drip's T+0 welcome depends on
+ * them). Sync without --force only creates missing aliases, so this never
+ * clobbers copy already edited in the Postmark dashboard.
  */
 $app = 'https://kolabing.com';
 
@@ -50,6 +52,46 @@ return [
             ['type' => 'para', 'text' => "Join one community and complete one challenge. That's it. The first one is the hardest; after that it's a habit."],
             ['type' => 'signature'],
             ['type' => 'ps', 'text' => "Not sure which community fits you? Reply with what you're into (running, art, food, wellness...) and I'll point you to the most active ones tonight."],
+        ],
+    ],
+
+    [
+        'alias' => 'business-welcome-01',
+        'name' => 'Welcome (business)',
+        'subject' => 'Welcome to Kolabing',
+        'sample' => ['first_name' => "Joe's Cafe"],
+        'content' => [
+            ['type' => 'para', 'text' => 'Hi {{first_name}},'],
+            ['type' => 'para', 'text' => "Welcome to Kolabing. You're here to partner with local communities, run clubs, art collectives, wellness groups, food crews, and get your venue in front of the people who'll fill it."],
+            ['type' => 'head', 'text' => 'How it works:'],
+            ['type' => 'list', 'ordered' => true, 'items' => [
+                'Finish your profile so communities can find you.',
+                "Post a Kolab: what you're offering (a venue, a discount, a private space) and what you'd like back.",
+                'Review the applications and pick the communities that fit.',
+            ]],
+            ['type' => 'para', 'text' => 'You can post your first Kolab in about 3 minutes.'],
+            ['type' => 'button', 'label' => 'Open Kolabing', 'url' => $app],
+            ['type' => 'signature'],
+        ],
+    ],
+
+    [
+        'alias' => 'community-welcome-01',
+        'name' => 'Welcome (community)',
+        'subject' => 'Welcome to Kolabing',
+        'sample' => ['first_name' => 'Barcelona Run Club'],
+        'content' => [
+            ['type' => 'para', 'text' => 'Hi {{first_name}},'],
+            ['type' => 'para', 'text' => "Welcome to Kolabing. You're here to find local businesses to partner with, venues, discounts, private spaces, and perks for your members."],
+            ['type' => 'head', 'text' => 'How it works:'],
+            ['type' => 'list', 'ordered' => true, 'items' => [
+                'Finish your community profile so businesses can find you.',
+                'Browse the open Kolabs and apply to the ones that fit your members.',
+                'Team up, run the event, and build your reputation for the next one.',
+            ]],
+            ['type' => 'para', 'text' => 'You can apply to your first Kolab in about 2 minutes.'],
+            ['type' => 'button', 'label' => 'Browse Kolabs', 'url' => $app],
+            ['type' => 'signature'],
         ],
     ],
 
@@ -316,25 +358,6 @@ return [
     // Copy drafted by Jace (Serra CMO), vault deliverable
     // _deliverables/to-review/jace/2026-07-20 - kolabing-launch-emails-and-onboarding.md.
     // Content verbatim from that draft; not yet brand-voice-audited/approved by Daniel.
-
-    [
-        'alias' => 'first-collab-tips',
-        'name' => 'First collab tips',
-        'subject' => 'Three ways to land your first collab on Kolabing',
-        'sample' => ['first_name' => 'Daniel'],
-        'content' => [
-            ['type' => 'para', 'text' => 'Hi {{first_name}},'],
-            ['type' => 'para', 'text' => "You're in. Here's how the people who get picked fastest do it:"],
-            ['type' => 'list', 'ordered' => true, 'items' => [
-                'Complete your profile. A photo and one line on what you do doubles your reply rate.',
-                "Apply to two or three collabs that fit, not ten that don't. A short, specific note beats a copy-paste.",
-                'Reply fast when a business messages you. The first to answer usually gets the collab.',
-            ]],
-            ['type' => 'para', 'text' => 'Want to browse what\'s open now?'],
-            ['type' => 'button', 'label' => 'Open Kolabing', 'url' => $app],
-            ['type' => 'signature'],
-        ],
-    ],
 
     [
         'alias' => 'inactive-nudge',

--- a/routes/console.php
+++ b/routes/console.php
@@ -36,3 +36,10 @@ Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
 // that bypass CollaborationService's completion flow and never trigger
 // recalculation. Idempotent (updateOrCreate) — safe to run daily.
 Schedule::command('app:recalculate-partner-statuses')->dailyAt('14:20');
+
+// Onboarding email drip (T+0 welcome / T+2 complete-profile / T+5 activation /
+// T+10 inactive-nudge, see config/onboarding_drip.php). Command is built and
+// tested (`php artisan app:send-onboarding-drip`) but INTENTIONALLY NOT
+// scheduled — Daniel has not signed off on the N-day offsets going live yet.
+// Uncomment only after that approval:
+// Schedule::command('app:send-onboarding-drip')->hourly();

--- a/routes/console.php
+++ b/routes/console.php
@@ -38,8 +38,10 @@ Schedule::command('app:send-business-reactivation-reminders')->dailyAt('09:00');
 Schedule::command('app:recalculate-partner-statuses')->dailyAt('14:20');
 
 // Onboarding email drip (T+0 welcome / T+2 complete-profile / T+5 activation /
-// T+10 inactive-nudge, see config/onboarding_drip.php). Command is built and
-// tested (`php artisan app:send-onboarding-drip`) but INTENTIONALLY NOT
-// scheduled — Daniel has not signed off on the N-day offsets going live yet.
-// Uncomment only after that approval:
-// Schedule::command('app:send-onboarding-drip')->hourly();
+// T+10 inactive-nudge, see config/onboarding_drip.php). Polls due drip-state
+// rows hourly; each step re-checks eligibility at send time. New signups are
+// enrolled at registration (AuthService::startOnboardingDrip); run the command
+// once with --sync-new to backfill profiles created before that hook existed.
+Schedule::command('app:send-onboarding-drip')
+    ->hourly()
+    ->withoutOverlapping();

--- a/tests/Feature/Api/V1/OnboardingDripEnrolmentTest.php
+++ b/tests/Feature/Api/V1/OnboardingDripEnrolmentTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\UserType;
+use App\Models\City;
+use App\Models\Profile;
+use App\Services\AppleAuthService;
+use App\Services\GoogleAuthService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+/**
+ * Every registration seam must enrol the new profile into the onboarding drip
+ * (AuthService::startOnboardingDrip -> OnboardingDripService::startForProfile),
+ * so the scheduled `app:send-onboarding-drip` command has state to act on
+ * without the one-off --sync-new backfill.
+ */
+class OnboardingDripEnrolmentTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function assertEnrolledAtStepZero(string $email): void
+    {
+        $profile = Profile::query()->where('email', $email)->firstOrFail();
+
+        $this->assertDatabaseHas('onboarding_drip_states', [
+            'profile_id' => $profile->id,
+            'next_sequence' => 0,
+            'cancelled_at' => null,
+        ]);
+    }
+
+    public function test_business_email_registration_enrols_in_drip(): void
+    {
+        $city = City::factory()->create();
+
+        $this->postJson('/api/v1/auth/register/business', [
+            'accepted_terms' => true,
+            'email' => 'drip-business@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'name' => 'Drip Business',
+            'business_type' => 'cafe',
+            'city_id' => $city->id,
+            'primary_venue' => [
+                'name' => 'Drip Rooftop',
+                'venue_type' => 'cafe',
+                'capacity' => 50,
+                'formatted_address' => 'Carrer de Mallorca 1, Barcelona',
+                'city' => $city->name,
+                'country' => $city->country,
+                'photos' => [],
+            ],
+        ])->assertStatus(201);
+
+        $this->assertEnrolledAtStepZero('drip-business@example.com');
+    }
+
+    public function test_community_email_registration_enrols_in_drip(): void
+    {
+        $city = City::factory()->create();
+
+        $this->postJson('/api/v1/auth/register/community', [
+            'accepted_terms' => true,
+            'email' => 'drip-community@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'name' => 'Drip Community',
+            'community_type' => 'run_club',
+            'city_id' => $city->id,
+        ])->assertStatus(201);
+
+        $this->assertEnrolledAtStepZero('drip-community@example.com');
+    }
+
+    public function test_attendee_email_registration_enrols_in_drip(): void
+    {
+        $this->postJson('/api/v1/auth/register/attendee', [
+            'email' => 'drip-attendee@example.com',
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'accepted_terms' => true,
+        ])->assertStatus(201);
+
+        $this->assertEnrolledAtStepZero('drip-attendee@example.com');
+    }
+
+    public function test_google_registration_enrols_in_drip(): void
+    {
+        $this->mock(GoogleAuthService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('verifyIdToken')
+                ->once()
+                ->andReturn([
+                    'google_id' => 'google-drip-1',
+                    'email' => 'drip-google@example.com',
+                    'avatar_url' => null,
+                    'email_verified' => true,
+                ]);
+        });
+
+        $this->postJson('/api/v1/auth/google', [
+            'id_token' => 'valid-token',
+            'user_type' => 'business',
+        ])->assertStatus(200);
+
+        $this->assertEnrolledAtStepZero('drip-google@example.com');
+    }
+
+    public function test_apple_registration_enrols_in_drip(): void
+    {
+        $this->mock(AppleAuthService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('verifyIdentityToken')
+                ->once()
+                ->andReturn([
+                    'apple_id' => 'apple-drip-1',
+                    'email' => 'drip-apple@example.com',
+                ]);
+        });
+
+        $this->postJson('/api/v1/auth/apple', [
+            'identity_token' => 'valid-token',
+            'name' => 'Ada Lovelace',
+            'user_type' => 'attendee',
+        ])->assertStatus(200);
+
+        $this->assertEnrolledAtStepZero('drip-apple@example.com');
+    }
+
+    public function test_drip_enrolment_failure_does_not_break_registration(): void
+    {
+        $this->mock(GoogleAuthService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('verifyIdToken')
+                ->once()
+                ->andReturn([
+                    'google_id' => 'google-drip-2',
+                    'email' => 'drip-resilient@example.com',
+                    'avatar_url' => null,
+                    'email_verified' => true,
+                ]);
+        });
+
+        $this->mock(\App\Services\OnboardingDripService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('startForProfile')
+                ->once()
+                ->andThrow(new \RuntimeException('drip write failed'));
+        });
+
+        $this->postJson('/api/v1/auth/google', [
+            'id_token' => 'valid-token',
+            'user_type' => 'community',
+        ])->assertStatus(200)
+            ->assertJsonPath('data.is_new_user', true);
+
+        $this->assertDatabaseHas('profiles', [
+            'email' => 'drip-resilient@example.com',
+            'user_type' => UserType::Community->value,
+        ]);
+    }
+}

--- a/tests/Feature/Console/SendOnboardingDripTest.php
+++ b/tests/Feature/Console/SendOnboardingDripTest.php
@@ -154,4 +154,105 @@ class SendOnboardingDripTest extends TestCase
         $state->refresh();
         $this->assertNotNull($state->cancelled_at, 'drip should be fully cancelled after the last step');
     }
+
+    public function test_welcome_sends_even_when_profile_already_fully_activated(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->attendee()->create([
+            'name' => 'Dana',
+            'handle' => 'dana',
+            'city_id' => null,
+            'interests' => ['running'],
+        ]);
+        CommunityMember::factory()->create(['profile_id' => $profile->id]);
+
+        app(OnboardingDripService::class)->startForProfile($profile);
+        $state = OnboardingDripState::query()->where('profile_id', $profile->id)->firstOrFail();
+        $this->backdateSchedule($state, 0);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->data['alias'] === 'attendee-welcome-01');
+
+        $state->refresh();
+        $this->assertSame(1, $state->next_sequence);
+        $this->assertNull($state->cancelled_at, 'the welcome step must not cancel the drip');
+    }
+
+    public function test_start_for_profile_is_idempotent_and_does_not_resurrect_a_finished_drip(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        $service = app(OnboardingDripService::class);
+
+        $service->startForProfile($profile);
+        $state = OnboardingDripState::query()->where('profile_id', $profile->id)->firstOrFail();
+        $state->update(['cancelled_at' => now(), 'scheduled_for' => null, 'next_sequence' => 4]);
+
+        $service->startForProfile($profile);
+
+        $state->refresh();
+        $this->assertNotNull($state->cancelled_at, 'a finished/cancelled drip must not be re-enrolled');
+        $this->assertSame(4, $state->next_sequence);
+        $this->assertSame(1, OnboardingDripState::query()->where('profile_id', $profile->id)->count());
+    }
+
+    public function test_start_for_profile_anchors_on_enrolment_time_not_created_at(): void
+    {
+        $profile = Profile::factory()->business()->create();
+        DB::table('profiles')->where('id', $profile->id)->update(['created_at' => now()->subDays(30)]);
+        $profile->refresh();
+
+        app(OnboardingDripService::class)->startForProfile($profile);
+
+        $state = OnboardingDripState::query()->where('profile_id', $profile->id)->firstOrFail();
+        $this->assertTrue(
+            $state->anchor_at->greaterThan(now()->subDay()),
+            'drip is anchored on enrolment time, not the 30-day-old created_at'
+        );
+        $this->assertSame(0, $state->next_sequence);
+    }
+
+    public function test_skipped_step_does_not_record_a_phantom_sent(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create([
+            'profile_id' => $profile->id,
+            'name' => 'Complete Cafe',
+            'business_type' => 'cafe',
+        ]);
+        $state = OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(48),
+            'next_sequence' => 1,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        $state->refresh();
+        $this->assertNull($state->sent_at, 'a skipped step must not stamp sent_at');
+        $this->assertNull($state->last_sent_sequence, 'a skipped step must not record last_sent_sequence');
+        $this->assertSame(2, $state->next_sequence);
+    }
+
+    public function test_a_second_pass_does_not_resend_the_same_step(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->community()->create();
+        OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(120),
+            'next_sequence' => 2,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertDispatchedTimes(SendTransactionalEmail::class, 1);
+    }
 }

--- a/tests/Feature/Console/SendOnboardingDripTest.php
+++ b/tests/Feature/Console/SendOnboardingDripTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Jobs\SendTransactionalEmail;
+use App\Models\BusinessProfile;
+use App\Models\CommunityMember;
+use App\Models\OnboardingDripState;
+use App\Models\Profile;
+use App\Services\OnboardingDripService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SendOnboardingDripTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Backdate a drip state's scheduled_for/anchor_at directly — Eloquent mass
+     * assignment guards timestamps via the model's casts but the point here is
+     * to simulate time having passed, same technique as
+     * SendBusinessReactivationRemindersTest::backdateActivity().
+     */
+    private function backdateSchedule(OnboardingDripState $state, int $hoursAgo): void
+    {
+        DB::table('onboarding_drip_states')->where('id', $state->id)->update([
+            'anchor_at' => now()->subHours($hoursAgo),
+            'scheduled_for' => now()->subHour(),
+        ]);
+    }
+
+    public function test_start_for_profile_creates_state_scheduled_at_step_zero(): void
+    {
+        $profile = Profile::factory()->business()->create();
+
+        app(OnboardingDripService::class)->startForProfile($profile);
+
+        $this->assertDatabaseHas('onboarding_drip_states', [
+            'profile_id' => $profile->id,
+            'next_sequence' => 0,
+        ]);
+    }
+
+    public function test_sends_welcome_email_at_step_zero(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id]);
+        app(OnboardingDripService::class)->startForProfile($profile);
+        $state = OnboardingDripState::query()->where('profile_id', $profile->id)->firstOrFail();
+        $this->backdateSchedule($state, 0);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->to === $profile->email
+            && $job->data['alias'] === 'business-welcome-01');
+
+        $state->refresh();
+        $this->assertSame(1, $state->next_sequence);
+    }
+
+    public function test_skips_complete_profile_nudge_when_profile_already_complete(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create([
+            'profile_id' => $profile->id,
+            'name' => 'Complete Cafe',
+            'business_type' => 'cafe',
+        ]);
+        $state = OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(48),
+            'next_sequence' => 1,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertNotDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->data['alias'] === 'complete-profile-business');
+
+        $state->refresh();
+        $this->assertSame(2, $state->next_sequence, 'step should advance even when skipped');
+    }
+
+    public function test_sends_activation_nudge_when_no_first_action_taken(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->community()->create();
+        $state = OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(120),
+            'next_sequence' => 2,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->to === $profile->email
+            && $job->data['alias'] === 'activation-community');
+    }
+
+    public function test_cancels_drip_once_attendee_is_fully_activated(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->attendee()->create([
+            'name' => 'Dana',
+            'handle' => 'dana',
+            'city_id' => null,
+            'interests' => ['running'],
+        ]);
+        CommunityMember::factory()->create(['profile_id' => $profile->id]);
+
+        $state = OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(240),
+            'next_sequence' => 3,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertNotDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->data['alias'] === 'inactive-nudge');
+
+        $state->refresh();
+        $this->assertNotNull($state->cancelled_at);
+    }
+
+    public function test_sends_inactive_nudge_at_final_step_and_cancels_after(): void
+    {
+        Bus::fake();
+
+        $profile = Profile::factory()->attendee()->create();
+        $state = OnboardingDripState::query()->create([
+            'profile_id' => $profile->id,
+            'anchor_at' => now()->subHours(240),
+            'next_sequence' => 3,
+            'scheduled_for' => now()->subHour(),
+        ]);
+
+        $this->artisan('app:send-onboarding-drip')->assertSuccessful();
+
+        Bus::assertDispatched(SendTransactionalEmail::class, fn (SendTransactionalEmail $job): bool => $job->to === $profile->email
+            && $job->data['alias'] === 'inactive-nudge');
+
+        $state->refresh();
+        $this->assertNotNull($state->cancelled_at, 'drip should be fully cancelled after the last step');
+    }
+}


### PR DESCRIPTION
## Summary
Builds the T+0/T+2/T+5/T+10 onboarding email drip **and takes it live**: every new signup is enrolled at registration, the sender runs hourly, and the state machine has been hardened for correctness (idempotent enrolment, row-locked sends, honest send-tracking, always-on welcome). Also exports the template copy for Jace's brand-voice audit.

## Linked tracking item
Closes #
<!-- No GitHub Projects item / issue exists for this work yet — it originates from the external Jace handoff `15450189` (Kolabing onboarding emails). @olucvolkan: please create/link a Projects item before merge so the repo rule is satisfied. -->

## Type of change
- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [x] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes
- **Drip engine** (`OnboardingDripService` + `SendOnboardingDrip` command + `OnboardingDripState` model + migration): per-recipient state row + cadence-hours offsets, same shape as `NotificationReminderService`. Cadence in `config/onboarding_drip.php`.
- **Wired into registration**: `AuthService::startOnboardingDrip()` enrols new profiles across all five seams (Apple, Google, business, community, attendee), error-isolated so a drip-state write can never roll back / break account creation.
- **Live**: `Schedule::command('app:send-onboarding-drip')->hourly()->withoutOverlapping()` in `routes/console.php`.
- **State-machine hardening**:
  - Anchor on enrolment time (`now()`), not `created_at`, so `--sync-new` backfills receive the full cadence instead of being collapsed to welcome-only by the catch-up loop.
  - Each due row processed inside `DB::transaction` + `lockForUpdate` with a re-check → overlapping runs / job retries can't double-send.
  - `EmailService::send()` returns `bool`; `advance()` records `sent_at`/`last_sent_sequence` **only** on an actual dispatch (no phantom "sent" on skips/opt-outs).
  - Welcome (T+0) always sends; the fully-activated early-cancel applies from step 1 on.
  - `startForProfile()` is one-shot idempotent — an existing row (running/completed/cancelled) is never re-enrolled, so a finished drip can't resurrect and re-send welcome.
- **Templates**: moved `business-welcome-01` / `community-welcome-01` into `resources/postmark/templates.php` (were Postmark-only and un-syncable — the drip's welcome step depended on them existing); removed the unused `first-collab-tips` draft.
- **Docs**: synced `docs/BACKLOG.md` and `docs/TEMPLATE_COPY_EXPORT.md` (counts, wiring/scheduling status, welcome copy now exported).

## Mobile impact (kolabing-app)
- [x] No mobile changes required
- [ ] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** N/A — no API contract change. No request/response shape, endpoint, enum, auth, or error-code changes. The only observable behavior change is that new signups now receive onboarding emails (server-side Postmark), which the app does not consume or depend on. Deliberate choice, not an omission.

## Database / migrations
- [ ] No schema changes
- [x] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change (explain rollback below)

**Migration notes:** Adds `onboarding_drip_states` (one row per profile: anchor/sequence/scheduled_for/sent_at/cancelled_at, unique on `profile_id`, FK to `profiles` with `onDelete('cascade')`, `[scheduled_for, cancelled_at]` index). Purely additive; `down()` drops the table.

## Testing
- [x] `php artisan test` passes — paste counts: **1379 passed (6466 assertions)**, 0 failures. Drip-specific: `SendOnboardingDripTest` (11) + new `OnboardingDripEnrolmentTest` (6).
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — `php artisan schedule:list` shows the hourly entry registered.

## Docs & rules updated
- [x] `BACKLOG.md` updated (bumped date; corrected the "not wired / not scheduled / welcome-templates-Postmark-only" notes that this PR makes false)
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` — N/A, the drip is not a role/paywall/feed/onboarding-permission surface
- [ ] `docs/BACKEND-SCHEMA.md` (schema / payload / JSON keys) — N/A, that file does not exist in this repo; the migration + `OnboardingDripState` PHPDoc are the schema record. `docs/TEMPLATE_COPY_EXPORT.md` was updated for the new/removed template aliases.
- [ ] No docs impact

## Screenshots / notes
⚠️ **Cadence went live ahead of Daniel's formal sign-off.** The original PR intentionally left the command unscheduled pending approval of the T+0/T+2/T+5/T+10 offsets; this revision activates it at the maintainer's request. The offsets in `config/onboarding_drip.php` should still be confirmed before/at launch — flagged in `BACKLOG.md`.

Note: the drip only *sends* for profiles enrolled after this ships (new signups). Existing back-catalog profiles are not enrolled unless someone runs `php artisan app:send-onboarding-drip --sync-new` — which would send a welcome to the entire current userbase, so run deliberately.
