### PR TITLE
fix(apply): reject applications to closed/date-exhausted Kolabs (audit #4)

### DIFF
--- a/app/Models/Kolab.php
+++ b/app/Models/Kolab.php
@@ -250,4 +250,76 @@ class Kolab extends Model
     {
         return $this->status === KolabStatus::Closed;
     }
+
+    /**
+     * Whether $date falls inside this kolab's availability window and, for a
+     * recurring kolab, matches one of its recurring weekdays (ISO 1..7).
+     *
+     * Single source of truth for date validity — mirrors the app's
+     * buildSelectableApplicationDates logic and the accept-time window check.
+     */
+    public function isDateWithinAvailability(\Carbon\CarbonInterface $date): bool
+    {
+        $day = $date->copy()->startOfDay();
+
+        $start = $this->availability_start?->copy()->startOfDay();
+        if ($start !== null && $day->lt($start)) {
+            return false;
+        }
+
+        $end = $this->availability_end?->copy()->startOfDay();
+        if ($end !== null && $day->gt($end)) {
+            return false;
+        }
+
+        if ($this->availability_mode !== 'recurring') {
+            return true;
+        }
+
+        $recurringDays = collect($this->recurring_days ?? [])
+            ->filter(fn (mixed $d): bool => is_numeric($d))
+            ->map(fn (mixed $d): int => (int) $d)
+            ->values()
+            ->all();
+
+        if ($recurringDays === []) {
+            return true;
+        }
+
+        return in_array($day->dayOfWeekIso, $recurringDays, true);
+    }
+
+    /**
+     * Whether at least one application date is still selectable from $from
+     * onward (today, in practice). Used to close applications on
+     * date-exhausted kolabs at apply time, matching accept-time validation.
+     */
+    public function hasSelectableDatesFrom(\Carbon\CarbonInterface $from): bool
+    {
+        $fromDay = $from->copy()->startOfDay();
+
+        $cursor = $this->availability_start?->copy()->startOfDay() ?? $fromDay;
+        if ($cursor->lt($fromDay)) {
+            $cursor = $fromDay;
+        }
+
+        $end = $this->availability_end?->copy()->startOfDay();
+        if ($end !== null && $cursor->gt($end)) {
+            return false;
+        }
+
+        // Scan day-by-day within the window (bounded by its length). For an
+        // open-ended window cap the look-ahead so this can never loop away.
+        $scanEnd = $end ?? $cursor->copy()->addDays(90);
+
+        $day = $cursor->copy();
+        while ($day->lte($scanEnd)) {
+            if ($this->isDateWithinAvailability($day)) {
+                return true;
+            }
+            $day = $day->addDay();
+        }
+
+        return false;
+    }
 }

--- a/app/Services/ApplicationService.php
+++ b/app/Services/ApplicationService.php
@@ -366,6 +366,15 @@ class ApplicationService
             );
         }
 
+        // Applications close once no valid date remains in the availability
+        // window (mirrors the accept-time window/recurring-day check). Guards
+        // against a direct API apply to a date-exhausted opportunity.
+        if (! $opportunity->hasSelectableDatesFrom(now()->startOfDay())) {
+            throw new InvalidArgumentException(
+                'Applications for this opportunity are closed — no available dates remain.'
+            );
+        }
+
         if (is_string($opportunity->recipient_community_id)
             && $opportunity->recipient_community_id !== ''
             && $opportunity->recipient_community_id !== $applicant->id) {

--- a/tests/Feature/Api/V1/ApplyDateAvailabilityTest.php
+++ b/tests/Feature/Api/V1/ApplyDateAvailabilityTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\KolabStatus;
+use App\Models\BusinessProfile;
+use App\Models\CommunityProfile;
+use App\Models\Kolab;
+use App\Models\Profile;
+use App\Services\ApplicationService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+/**
+ * Guards the apply-time date-availability check (audit #4): a community must
+ * not be able to apply to a date-exhausted / closed Kolab, mirroring the
+ * accept-time window validation.
+ */
+class ApplyDateAvailabilityTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private ApplicationService $service;
+
+    private Profile $creator;
+
+    private Profile $applicant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = app(ApplicationService::class);
+
+        $this->creator = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $this->creator->id]);
+
+        // Communities are never paywalled when applying — simplest applicant.
+        $this->applicant = Profile::factory()->community()->create();
+        CommunityProfile::factory()->create(['profile_id' => $this->applicant->id]);
+    }
+
+    private function kolab(array $overrides): Kolab
+    {
+        return Kolab::factory()->create(array_merge([
+            'creator_profile_id' => $this->creator->id,
+            'status' => KolabStatus::Published,
+            'availability_mode' => 'flexible',
+        ], $overrides));
+    }
+
+    /**
+     * @return array{message: string, availability: string}
+     */
+    private function payload(): array
+    {
+        return [
+            'message' => 'We would love to collaborate on this with our community.',
+            'availability' => 'Available on weekday evenings and most weekends this month.',
+        ];
+    }
+
+    public function test_apply_is_rejected_when_the_availability_window_is_in_the_past(): void
+    {
+        $kolab = $this->kolab([
+            'availability_start' => now()->subMonths(2),
+            'availability_end' => now()->subMonth(),
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Applications for this opportunity are closed');
+
+        $this->service->apply($this->applicant, $kolab, $this->payload());
+    }
+
+    public function test_apply_is_rejected_when_no_recurring_day_remains_in_the_window(): void
+    {
+        // Window Tue..Sun but only Mondays allowed — no selectable date.
+        $tuesday = now()->next(2); // ISO 2 = Tuesday
+        $kolab = $this->kolab([
+            'availability_mode' => 'recurring',
+            'availability_start' => $tuesday,
+            'availability_end' => $tuesday->copy()->addDays(4), // Sat
+            'recurring_days' => [1], // Monday only
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Applications for this opportunity are closed');
+
+        $this->service->apply($this->applicant, $kolab, $this->payload());
+    }
+
+    public function test_apply_succeeds_when_a_future_date_is_still_available(): void
+    {
+        $kolab = $this->kolab([
+            'availability_start' => now()->addDays(3),
+            'availability_end' => now()->addMonth(),
+        ]);
+
+        $application = $this->service->apply($this->applicant, $kolab, $this->payload());
+
+        $this->assertNotNull($application->id);
+        $this->assertDatabaseHas('applications', [
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $this->applicant->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
Reject applications to a date-exhausted (or closed) Kolab at apply time, mirroring the window/recurring-day check that already exists at accept time. Closes the hole where a direct API call could submit an application to a fully-expired opportunity. Backend half of the P0 apply-flow audit block (app half: kolabing-app #83).

## Linked tracking item
Closes #107

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes
- `Kolab::isDateWithinAvailability(CarbonInterface)` — single-date validity (window + ISO recurring weekdays), the shared source of truth mirroring the app logic and the accept-time check.
- `Kolab::hasSelectableDatesFrom(CarbonInterface)` — whether ≥1 selectable date remains from a given day onward (bounded scan; 90-day cap for open-ended windows).
- `ApplicationService::validateCanApply()` — after the existing published check, reject when no selectable date remains from today → `InvalidArgumentException` → HTTP **400** + message (matches the endpoint's existing error mapping; no new error-code contract).
- No change to the apply request payload.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** No contract change (same 400 + `message` shape already handled by the app). The app also gates client-side in kolabing-app #83, so this backend guard is defense-in-depth against direct/stale API calls.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A

## Testing
- [x] `php artisan test` passes — `ApplyDateAvailabilityTest` 3 passed (6 assertions); regression check `RealUserKolabFlowTest` + `NotificationReminderTest` 4 passed (47 assertions).
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (future-dated apply still succeeds; expired + recurring-exhausted rejected)

## Docs & rules updated
- [x] `BACKLOG.md` updated (tracked as FX-34 in kolabing-app BACKLOG, which is the maintained backlog)
- [x] No docs impact (no schema/role/payload change)

## Screenshots / notes
No UI (backend-only). Note: `KolabStatus` has no `Completed` case (completion lives on the collaboration) and `validateCanApply` already rejects non-published Kolabs, so the guard added here is purely the date-availability check. The free-text `availability` → structured `selected_dates` refactor is intentionally out of scope (follow-up).
