### PR TITLE
feat: wire lifecycle transactional emails via the notification funnel

### DIFF
--- a/app/Enums/NotificationType.php
+++ b/app/Enums/NotificationType.php
@@ -39,6 +39,7 @@ enum NotificationType: string
     case SecondOfferPrompt = 'second_offer_prompt';
     case PartnerStatusUpgraded = 'partner_status_upgraded';
     case ReactivationPrompt = 'reactivation_prompt';
+    case TierPromoted = 'tier_promoted';
 
     /**
      * @return array<string>

--- a/app/Services/BadgeService.php
+++ b/app/Services/BadgeService.php
@@ -60,6 +60,7 @@ class BadgeService
                     replace: ['badge' => $badge->name],
                     targetId: $badge->id,
                     targetType: 'badge',
+                    emailModel: ['badge_name' => $badge->name],
                 );
             }
         }

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -11,15 +11,42 @@ use App\Models\Application;
 use App\Models\ChallengeCompletion;
 use App\Models\ChatMessage;
 use App\Models\Collaboration;
+use App\Models\CommunityMember;
+use App\Models\CommunityTier;
 use App\Models\Kolab;
 use App\Models\Notification;
 use App\Models\Profile;
 use App\Models\RewardClaim;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class NotificationService
 {
+    /**
+     * Notification types that also send a transactional email, mapped to their
+     * Postmark template alias + preference category. Every notification flows
+     * through {@see createNotification()}; a type present here gets an email
+     * side-effect there, gated by the recipient's preferences. Types absent
+     * from this map are push/in-app only.
+     *
+     * @var array<string, array{0: string, 1: string}>
+     */
+    private const EMAIL_MAP = [
+        'application_received' => ['application-received', EmailService::CATEGORY_APPLICATION],
+        'application_accepted' => ['application-accepted', EmailService::CATEGORY_COLLABORATION],
+        'application_declined' => ['application-declined', EmailService::CATEGORY_COLLABORATION],
+        'collaboration_created' => ['collab-confirmed', EmailService::CATEGORY_COLLABORATION],
+        'collab_followup_reminder' => ['feedback-request', EmailService::CATEGORY_COLLABORATION],
+        'badge_awarded' => ['badge-earned', EmailService::CATEGORY_GAMIFICATION],
+        'reward_won' => ['reward-won', EmailService::CATEGORY_GAMIFICATION],
+        'tier_promoted' => ['tier-promotion', EmailService::CATEGORY_GAMIFICATION],
+    ];
+
+    public function __construct(
+        private readonly EmailService $emailService,
+    ) {}
+
     /**
      * Get paginated notifications for a profile.
      *
@@ -68,6 +95,11 @@ class NotificationService
 
     /**
      * Create a notification record and dispatch a push notification for the recipient.
+     * If the type is in {@see EMAIL_MAP}, also queues a transactional email
+     * (gated + isolated) using the merge vars in $emailModel.
+     *
+     * @param  array<string, mixed>  $pushOptions
+     * @param  array<string, mixed>  $emailModel  template-specific merge vars ({{first_name}} is added automatically)
      */
     public function createNotification(
         Profile $recipient,
@@ -78,6 +110,7 @@ class NotificationService
         ?string $targetId = null,
         ?string $targetType = null,
         array $pushOptions = [],
+        array $emailModel = [],
     ): Notification {
         $notification = Notification::create([
             'profile_id' => $recipient->id,
@@ -91,7 +124,50 @@ class NotificationService
 
         SendPushNotification::dispatch($recipient, $title, $body, $type, $targetId, $pushOptions);
 
+        $this->sendEmailSideEffect($recipient, $type, $emailModel);
+
         return $notification;
+    }
+
+    /**
+     * Optional transactional-email side-effect of a notification, isolated from
+     * the push path so an email failure never affects the in-app notification.
+     *
+     * @param  array<string, mixed>  $emailModel
+     */
+    private function sendEmailSideEffect(Profile $recipient, NotificationType $type, array $emailModel): void
+    {
+        $mapping = self::EMAIL_MAP[$type->value] ?? null;
+
+        if ($mapping === null) {
+            return;
+        }
+
+        [$alias, $category] = $mapping;
+
+        try {
+            $this->emailService->send(
+                $recipient,
+                $alias,
+                ['first_name' => $this->recipientFirstName($recipient)] + $emailModel,
+                $category,
+            );
+        } catch (\Throwable $e) {
+            Log::warning('Notification email side-effect failed', [
+                'profile_id' => $recipient->id,
+                'type' => $type->value,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Greeting name for a recipient: the business/community name for those
+     * types, the person's name for attendees (mirrors the drip's convention).
+     */
+    private function recipientFirstName(Profile $recipient): ?string
+    {
+        return $recipient->getExtendedProfile()?->name ?? $recipient->name;
     }
 
     /**
@@ -102,6 +178,7 @@ class NotificationService
      *
      * @param  array<string, string|int>  $replace
      * @param  array<string, mixed>  $pushOptions
+     * @param  array<string, mixed>  $emailModel  template-specific merge vars ({{first_name}} is added automatically)
      */
     public function createLocalizedNotification(
         Profile $recipient,
@@ -113,6 +190,7 @@ class NotificationService
         ?string $targetId = null,
         ?string $targetType = null,
         array $pushOptions = [],
+        array $emailModel = [],
     ): Notification {
         $locale = $recipient->preferred_locale ?? config('app.fallback_locale');
 
@@ -128,6 +206,7 @@ class NotificationService
             targetId: $targetId,
             targetType: $targetType,
             pushOptions: $pushOptions,
+            emailModel: $emailModel,
         );
     }
 
@@ -271,6 +350,7 @@ class NotificationService
             actor: $actor,
             targetId: $application->id,
             targetType: 'application',
+            emailModel: ['applicant_name' => $actorName, 'opportunity_title' => $opportunityTitle],
         );
     }
 
@@ -293,6 +373,7 @@ class NotificationService
         $recipient = $application->applicantProfile;
         $actor = $opportunity->creatorProfile;
         $opportunityTitle = $opportunity->title;
+        $partnerName = $actor?->getExtendedProfile()?->name ?? 'your partner';
 
         $this->createLocalizedNotification(
             recipient: $recipient,
@@ -303,6 +384,7 @@ class NotificationService
             actor: $actor,
             targetId: $application->id,
             targetType: 'application',
+            emailModel: ['partner_name' => $partnerName, 'opportunity_title' => $opportunityTitle],
         );
     }
 
@@ -325,6 +407,7 @@ class NotificationService
         $recipient = $application->applicantProfile;
         $actor = $opportunity->creatorProfile;
         $opportunityTitle = $opportunity->title;
+        $partnerName = $actor?->getExtendedProfile()?->name ?? 'your partner';
 
         $this->createLocalizedNotification(
             recipient: $recipient,
@@ -335,6 +418,7 @@ class NotificationService
             actor: $actor,
             targetId: $application->id,
             targetType: 'application',
+            emailModel: ['partner_name' => $partnerName, 'opportunity_title' => $opportunityTitle],
         );
     }
 
@@ -445,6 +529,11 @@ class NotificationService
             if ($this->reminderAlreadySent($profile->id, NotificationType::CollabFollowUpReminder, $collaboration->id)) {
                 continue;
             }
+
+            $counterpart = $profile->id === $collaboration->creatorProfile?->id
+                ? $collaboration->applicantProfile
+                : $collaboration->creatorProfile;
+
             $this->createLocalizedNotification(
                 recipient: $profile,
                 type: NotificationType::CollabFollowUpReminder,
@@ -452,6 +541,7 @@ class NotificationService
                 bodyKey: 'notifications.collab.follow_up_reminder.body',
                 targetId: $collaboration->id,
                 targetType: 'collaboration',
+                emailModel: ['partner_name' => $counterpart?->getExtendedProfile()?->name ?? 'your partner'],
             );
         }
     }
@@ -616,6 +706,10 @@ class NotificationService
                 ?? $counterpartBodyKey
                 ?? $actorBodyKey;
 
+            $counterpart = $profile->id === $collaboration->creatorProfile?->id
+                ? $collaboration->applicantProfile
+                : $collaboration->creatorProfile;
+
             $this->createLocalizedNotification(
                 recipient: $profile,
                 type: $type,
@@ -625,6 +719,10 @@ class NotificationService
                 actor: $actor,
                 targetId: $collaboration->id,
                 targetType: 'collaboration',
+                emailModel: [
+                    'partner_name' => $counterpart?->getExtendedProfile()?->name ?? 'your partner',
+                    'scheduled_date' => $collaboration->scheduled_date?->format('l, j M Y') ?? 'soon',
+                ],
             );
         }
     }
@@ -727,6 +825,32 @@ class NotificationService
             replace: ['reward' => $claim->eventReward->name],
             targetId: $claim->id,
             targetType: 'reward_claim',
+            emailModel: ['reward_name' => $claim->eventReward->name],
+        );
+    }
+
+    /**
+     * Notify a community member they were promoted to a new tier. System event
+     * (no actor). Also queues the `tier-promotion` email via the funnel.
+     */
+    public function notifyTierPromoted(CommunityMember $member, CommunityTier $tier): void
+    {
+        $member->loadMissing('profile');
+
+        $recipient = $member->profile;
+
+        if ($recipient === null) {
+            return;
+        }
+
+        $this->createNotification(
+            recipient: $recipient,
+            type: NotificationType::TierPromoted,
+            title: "You've reached {$tier->name}",
+            body: "Your activity in the community earned you the {$tier->name} tier.",
+            targetId: $member->id,
+            targetType: 'community_member',
+            emailModel: ['tier_name' => $tier->name],
         );
     }
 }

--- a/app/Services/TierAssignmentService.php
+++ b/app/Services/TierAssignmentService.php
@@ -21,6 +21,10 @@ use App\Models\PointLedger;
  */
 class TierAssignmentService
 {
+    public function __construct(
+        private readonly NotificationService $notificationService,
+    ) {}
+
     /**
      * Re-evaluate a single member and promote if a higher auto tier is earned.
      */
@@ -49,6 +53,8 @@ class TierAssignmentService
                 'tier_id' => $earned->id,
                 'tier_assigned_at' => now(),
             ])->save();
+
+            $this->notificationService->notifyTierPromoted($member, $earned);
         }
     }
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # Kolabing — Pre-launch Backlog
 
-**Last updated:** 2026-07-27 (§1: onboarding drip wired into registration (`AuthService::startOnboardingDrip`) + scheduled hourly; `business-welcome-01`/`community-welcome-01` moved into `templates.php` (22 aliases now); drip state machine hardened — welcome always sends, row-locked sends, honest sent-tracking, `now()` anchor, idempotent enrolment. Prior: 2026-07-21 §1: corrected the stale "email not wired" note — the Postmark pipeline has existed since `b50c378` (2026-06-04); it's built and live-send verified but has no production caller yet. Added the onboarding drip command/service, built and not scheduled, pending Daniel's sign-off on the offsets. Prior: 2026-07-15 legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
+**Last updated:** 2026-07-28 (§1: lifecycle transactional emails wired as a notification-funnel side-effect (`NotificationService` EMAIL_MAP) — application received/accepted/declined, collab-confirmed, feedback-request, badge-earned, reward-won, tier-promotion (new `tier_promoted` type). Prior: 2026-07-27 §1: onboarding drip wired into registration (`AuthService::startOnboardingDrip`) + scheduled hourly; `business-welcome-01`/`community-welcome-01` moved into `templates.php` (22 aliases now); drip state machine hardened — welcome always sends, row-locked sends, honest sent-tracking, `now()` anchor, idempotent enrolment. Prior: 2026-07-21 §1: corrected the stale "email not wired" note — the Postmark pipeline has existed since `b50c378` (2026-06-04); it's built and live-send verified but has no production caller yet. Added the onboarding drip command/service, built and not scheduled, pending Daniel's sign-off on the offsets. Prior: 2026-07-15 legal: company/legal details + agreement version now admin-editable at `/admin/company-settings` (`company_settings` table); legal pages render live values — §4. Prior: bilingual Terms/Privacy (EN + `/es`) + mobile consent tracking — §4. Prior: query-audit N+1 sweep — §12)
 **Sync note:** This file is duplicated in both repos (`kolabing-app` and `kolabing-v2`). Keep the two copies identical.
 
 A consolidated punch list of everything we've identified but haven't shipped. Items are tagged by **owner** (`backend` = kolabing-v2, `app` = kolabing-app, `cross` = both, `infra` = hosting) and **priority** (`P0` = blocker for launch, `P1` = needed soon after, `P2` = nice-to-have).
@@ -42,10 +42,12 @@ flow yet. Password reset still uses Laravel's Password broker default, not the P
   to the `password-reset` Postmark template).
 
 **What's missing:**
-- Registration now triggers email via the onboarding drip (welcome at T+0), but the remaining
-  lifecycle seams still don't call `EmailService::send()`: application accept/decline, collab
-  confirmed, feedback-request, badge/reward/tier events — see
-  `docs/plans/2026-06-04-transactional-email-system.md` Phase 2 for the full seam-by-seam map.
+- Lifecycle emails are now wired as a side-effect of the notification funnel
+  (`NotificationService::createNotification` → `EMAIL_MAP`): application received/accepted/declined,
+  collab-confirmed, feedback-request (rides the follow-up reminder), badge-earned, reward-won,
+  tier-promotion (new `tier_promoted` notification). Still NOT wired: password reset/changed swap to
+  Postmark templates, first-message (#11), and withdrawal-processed (#21) — see
+  `docs/plans/2026-06-04-transactional-email-system.md` Phase 2 for the remaining seams.
 - Default mailer (`config/mail.php:17`) is still `'log'`, not `postmark`, in local/default env.
 - No `MustVerifyEmail` on the `Profile` model — email confirmation on signup is not enforced.
   (Google OAuth manually sets `email_verified_at = now()` per `AuthService:168` so OAuth users skip
@@ -53,9 +55,10 @@ flow yet. Password reset still uses Laravel's Password broker default, not the P
   (plan doc Phase 5).
 
 **P0 — must ship before launch:**
-- [ ] Wire `EmailService::send()` into the real trigger seams (welcome on register, password
-  reset/changed, application lifecycle, collab-confirmed, feedback-request) per the plan doc's
-  Phase 2 table. Owner: **backend**.
+- [x] Wire `EmailService::send()` into the real trigger seams — welcome on register (drip) +
+  application lifecycle / collab-confirmed / feedback-request / badge / reward / tier promotion
+  (notification-funnel side-effect). Remaining: password reset/changed template swap, first-message,
+  withdrawal-processed. Owner: **backend**.
 - [ ] Wire Postmark: `MAIL_MAILER=postmark` in production env (config already supports it). Owner: **infra**.
 
 **P1 — customer success flows:**

--- a/tests/Feature/Notifications/LifecycleEmailTest.php
+++ b/tests/Feature/Notifications/LifecycleEmailTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\UserType;
+use App\Jobs\SendTransactionalEmail;
+use App\Models\Application;
+use App\Models\AttendeeProfile;
+use App\Models\BusinessProfile;
+use App\Models\Collaboration;
+use App\Models\Community;
+use App\Models\CommunityMember;
+use App\Models\CommunityProfile;
+use App\Models\CommunityTier;
+use App\Models\EventReward;
+use App\Models\Kolab;
+use App\Models\NotificationPreference;
+use App\Models\PointLedger;
+use App\Models\Profile;
+use App\Models\RewardClaim;
+use App\Services\BadgeService;
+use App\Services\NotificationService;
+use App\Services\TierAssignmentService;
+use Database\Seeders\BadgeSeeder;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * The transactional-email side-effect wired into the notification funnel
+ * (NotificationService::createNotification -> EMAIL_MAP). Each lifecycle seam
+ * should queue the right Postmark template to the right recipient with the
+ * right merge vars, and respect the recipient's preferences.
+ */
+class LifecycleEmailTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function business(string $name): Profile
+    {
+        $profile = Profile::factory()->business()->create();
+        BusinessProfile::factory()->create(['profile_id' => $profile->id, 'name' => $name]);
+
+        return $profile->refresh();
+    }
+
+    private function community(string $name): Profile
+    {
+        $profile = Profile::factory()->community()->create();
+        CommunityProfile::factory()->create(['profile_id' => $profile->id, 'name' => $name]);
+
+        return $profile->refresh();
+    }
+
+    /**
+     * @param  array<string, mixed>  $model
+     */
+    private function assertEmailQueued(string $toEmail, string $alias, array $model): void
+    {
+        Bus::assertDispatched(SendTransactionalEmail::class, function (SendTransactionalEmail $job) use ($toEmail, $alias, $model): bool {
+            if ($job->to !== $toEmail || $job->data['alias'] !== $alias) {
+                return false;
+            }
+
+            foreach ($model as $key => $value) {
+                if (($job->data['model'][$key] ?? null) !== $value) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+    }
+
+    private function assertNoEmail(string $alias): void
+    {
+        Bus::assertNotDispatched(
+            SendTransactionalEmail::class,
+            fn (SendTransactionalEmail $job): bool => $job->data['alias'] === $alias,
+        );
+    }
+
+    public function test_application_received_emails_the_business(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Summer Popup']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(NotificationService::class)->notifyApplicationReceived($application);
+
+        $this->assertEmailQueued($business->email, 'application-received', [
+            'first_name' => 'Joe Cafe',
+            'applicant_name' => 'Run Club',
+            'opportunity_title' => 'Summer Popup',
+        ]);
+    }
+
+    public function test_application_accepted_emails_the_applicant(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Summer Popup']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(NotificationService::class)->notifyApplicationAccepted($application);
+
+        $this->assertEmailQueued($community->email, 'application-accepted', [
+            'first_name' => 'Run Club',
+            'partner_name' => 'Joe Cafe',
+            'opportunity_title' => 'Summer Popup',
+        ]);
+    }
+
+    public function test_application_declined_emails_the_applicant(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Winter Market']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(NotificationService::class)->notifyApplicationDeclined($application);
+
+        $this->assertEmailQueued($community->email, 'application-declined', [
+            'first_name' => 'Run Club',
+            'partner_name' => 'Joe Cafe',
+            'opportunity_title' => 'Winter Market',
+        ]);
+    }
+
+    public function test_collaboration_confirmed_emails_both_parties_with_counterpart_names(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Summer Popup']);
+        $date = Carbon::parse('2026-08-15');
+        $collaboration = Collaboration::factory()->create([
+            'kolab_id' => $kolab->id,
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+            'scheduled_date' => $date,
+        ]);
+
+        app(NotificationService::class)->notifyCollaborationCreated($collaboration);
+
+        $expectedDate = $date->format('l, j M Y');
+
+        // Business hears their partner is the community.
+        $this->assertEmailQueued($business->email, 'collab-confirmed', [
+            'first_name' => 'Joe Cafe',
+            'partner_name' => 'Run Club',
+            'scheduled_date' => $expectedDate,
+        ]);
+        // Community hears their partner is the business.
+        $this->assertEmailQueued($community->email, 'collab-confirmed', [
+            'first_name' => 'Run Club',
+            'partner_name' => 'Joe Cafe',
+            'scheduled_date' => $expectedDate,
+        ]);
+    }
+
+    public function test_feedback_request_emails_both_parties(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        $collaboration = Collaboration::factory()->create([
+            'creator_profile_id' => $business->id,
+            'applicant_profile_id' => $community->id,
+        ]);
+
+        app(NotificationService::class)->notifyCollabFollowUpReminder($collaboration);
+
+        $this->assertEmailQueued($business->email, 'feedback-request', ['partner_name' => 'Run Club']);
+        $this->assertEmailQueued($community->email, 'feedback-request', ['partner_name' => 'Joe Cafe']);
+    }
+
+    public function test_reward_won_emails_the_winner(): void
+    {
+        Bus::fake();
+
+        $attendee = Profile::factory()->attendee()->create(['name' => 'Dana']);
+        $reward = EventReward::factory()->create(['name' => 'Free Coffee']);
+        $claim = RewardClaim::factory()->create([
+            'profile_id' => $attendee->id,
+            'event_reward_id' => $reward->id,
+        ]);
+
+        app(NotificationService::class)->notifyRewardWon($claim);
+
+        $this->assertEmailQueued($attendee->email, 'reward-won', [
+            'first_name' => 'Dana',
+            'reward_name' => 'Free Coffee',
+        ]);
+    }
+
+    public function test_badge_earned_emails_the_attendee(): void
+    {
+        Bus::fake();
+        $this->seed(BadgeSeeder::class);
+
+        $attendee = Profile::factory()->attendee()->create(['name' => 'Dana']);
+        AttendeeProfile::factory()->create(['profile_id' => $attendee->id, 'total_events_attended' => 1]);
+
+        app(BadgeService::class)->checkAndAwardBadges($attendee->refresh());
+
+        Bus::assertDispatched(SendTransactionalEmail::class, function (SendTransactionalEmail $job) use ($attendee): bool {
+            return $job->to === $attendee->email
+                && $job->data['alias'] === 'badge-earned'
+                && $job->data['model']['first_name'] === 'Dana'
+                && ! empty($job->data['model']['badge_name']);
+        });
+    }
+
+    public function test_tier_promotion_emails_the_member(): void
+    {
+        Bus::fake();
+
+        $community = Community::factory()->create();
+        CommunityTier::factory()->defaultTier()->forCommunity($community)->create();
+        CommunityTier::factory()->xpThreshold(500)->forCommunity($community)->create(['rank' => 2, 'name' => 'Gold']);
+
+        $profile = Profile::factory()->attendee()->create(['name' => 'Dana']);
+        PointLedger::factory()->create(['profile_id' => $profile->id, 'points' => 500]);
+        $member = CommunityMember::factory()->forCommunity($community)->create(['profile_id' => $profile->id]);
+
+        app(TierAssignmentService::class)->evaluateMember($member);
+
+        $this->assertEmailQueued($profile->email, 'tier-promotion', [
+            'first_name' => 'Dana',
+            'tier_name' => 'Gold',
+        ]);
+    }
+
+    public function test_lifecycle_email_respects_master_opt_out(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        NotificationPreference::factory()->allDisabled()->create(['profile_id' => $community->id]);
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Summer Popup']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(NotificationService::class)->notifyApplicationAccepted($application);
+
+        $this->assertNoEmail('application-accepted');
+    }
+
+    public function test_application_received_respects_the_application_alerts_flag(): void
+    {
+        Bus::fake();
+
+        $business = $this->business('Joe Cafe');
+        $community = $this->community('Run Club');
+        NotificationPreference::factory()->create([
+            'profile_id' => $business->id,
+            'email_notifications' => true,
+            'new_application_alerts' => false,
+        ]);
+        $kolab = Kolab::factory()->published()->create(['creator_profile_id' => $business->id, 'title' => 'Summer Popup']);
+        $application = Application::factory()->create([
+            'kolab_id' => $kolab->id,
+            'applicant_profile_id' => $community->id,
+            'applicant_profile_type' => UserType::Community,
+        ]);
+
+        app(NotificationService::class)->notifyApplicationReceived($application);
+
+        $this->assertNoEmail('application-received');
+    }
+}


### PR DESCRIPTION
## Summary
Wires the remaining Phase-2 transactional emails (application received/accepted/declined, collaboration confirmed, feedback request, badge earned, reward won, tier promotion) as a **gated, isolated side-effect of the existing notification funnel** — one dispatch point, not scattered `EmailService::send()` calls — matching the transactional-email plan (§1.4).

## Linked tracking item
Closes #
<!-- No GitHub Projects item exists yet; this continues the external Jace handoff `15450189` (Kolabing onboarding/lifecycle emails) and the merged PR #106. @olucvolkan: please create/link a Projects item before merge to satisfy the repo rule. -->

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [x] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes
- **Funnel hook**: `NotificationService::createNotification()` now sends an optional transactional email after the push, driven by a `NotificationType → (alias, category)` map (`EMAIL_MAP`). `EmailService` is injected; email dispatch is wrapped so a failure never affects the push/in-app path.
- **`$emailModel` threading**: `createNotification` / `createLocalizedNotification` / `notifyBothParties` accept per-recipient merge vars; each emailing `notify*` method supplies them (`{{first_name}}` is derived from the recipient automatically).
- **Seams wired** (each rides its existing notification, gated by the shown flag):
  - `application-received` → creator — `new_application_alerts`
  - `application-accepted` / `application-declined` → applicant — `collaboration_updates`
  - `collab-confirmed` → both parties, per-side `partner_name` + `scheduled_date` — `collaboration_updates`
  - `feedback-request` → both parties on the follow-up reminder — `collaboration_updates`
  - `badge-earned` → attendee — `email_notifications` master (gamification)
  - `reward-won` → winner — gamification
  - `tier-promotion` → promoted member — gamification
- **New `NotificationType::TierPromoted`** + `NotificationService::notifyTierPromoted()`, fired from `TierAssignmentService::evaluateMember()` on an actual promotion. This also adds the previously-missing tier **push/in-app** notification (tier promotions were silent before).

## Mobile impact (kolabing-app)
- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** This PR adds a **new notification type enum value `tier_promoted`**, which now appears in the `GET /notifications` payload (`type` field) and in the push payload for promoted community members. Existing types are unchanged and no payload shape changed. The app should map `tier_promoted` like other types (icon + deep-link, e.g. to the community/tier screen); until then it will fall back to whatever the app does for unknown types (title/body are server-provided, so it still renders). **Needs a `kolabing-app` ticket** to handle the new type — not yet created (⚠️ please link before merge). No other contract changes; the lifecycle emails themselves are server-side Postmark and invisible to the app.

## Database / migrations
- [x] No schema changes
- [ ] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change (explain rollback below)

**Migration notes:** N/A. `notifications.type` is a plain `string` column (no DB enum/CHECK constraint), so the new `tier_promoted` value needs no migration.

## Testing
- [x] `php artisan test` passes — paste counts: **1392 passed (6484 assertions)**, 0 failures. New: `tests/Feature/Notifications/LifecycleEmailTest.php` (10) — asserts each seam's alias + merge vars + both preference gates (master opt-out and the per-flag `new_application_alerts` gate).
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — jobs reroute to the DB queue under `sync` (no network in tests), same as the drip.

## Docs & rules updated
- [x] `BACKLOG.md` updated (bumped date; §1 lifecycle emails moved from "missing" to wired; P0 seam-wiring item ticked with the remaining items called out: password reset/changed swap, first-message, withdrawal-processed)
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` — N/A, not a role/paywall/feed/onboarding-permission surface
- [ ] `docs/BACKEND-SCHEMA.md` — N/A, file does not exist in this repo; no schema change here anyway
- [ ] No docs impact

## Screenshots / notes
- Design choice: emails are a side-effect of the **notification funnel**, so any future `NotificationType` becomes emailable by adding one line to `EMAIL_MAP` — no per-service plumbing.
- Category gating follows the plan's locked selection: application-received rides `new_application_alerts`; accepted/declined/collab-confirmed/feedback-request ride `collaboration_updates`; badge/reward/tier ride the `email_notifications` master switch.
- Out of scope (still in BACKLOG): password-reset/changed template swap, first-message (#11, needs first-in-thread detection), withdrawal-processed (#21).
