### PR TITLE
docs(legal): zero-tolerance clause in Terms §7 (App Review 1.2)

### DIFF
--- a/resources/views/pages/es/terms.blade.php
+++ b/resources/views/pages/es/terms.blade.php
@@ -73,6 +73,7 @@
                 <li>Eludir cualquier medida de seguridad, muro de pago de suscripción o control de acceso.</li>
                 <li>Usar el Servicio con fines fraudulentos o engañosos.</li>
             </ul>
+            <p><strong>Tolerancia cero.</strong> Kolabing tiene tolerancia cero con el contenido objetable y los usuarios abusivos. No se permite el contenido ofensivo, amenazante, acosador, de odio, sexualmente explícito o de cualquier otro modo objetable, ni los usuarios que se comporten de forma abusiva. Puedes denunciar contenido objetable y bloquear a usuarios abusivos directamente en la aplicación; el contenido denunciado se revisa y podemos eliminarlo y suspender o cancelar las cuentas responsables (véase la Sección 10).</p>
 
             <h2>8. Propiedad intelectual</h2>
             <p>El Servicio, incluidos su software, diseño, textos, gráficos, logotipos y marcas (pero excluyendo el Contenido del Usuario), es propiedad de Kolabing o de sus licenciantes y está protegido por las leyes de propiedad intelectual. Te concedemos una licencia limitada, personal, intransferible y revocable para usar el Servicio según su finalidad prevista. No puedes copiar, modificar, distribuir, vender ni crear obras derivadas de ninguna parte del Servicio sin nuestro consentimiento previo por escrito.</p>

--- a/resources/views/pages/terms.blade.php
+++ b/resources/views/pages/terms.blade.php
@@ -73,6 +73,7 @@
                 <li>Circumvent any security, subscription paywall, or access control.</li>
                 <li>Use the Service for any fraudulent or misleading purpose.</li>
             </ul>
+            <p><strong>Zero tolerance.</strong> Kolabing has zero tolerance for objectionable content and abusive users. Content that is offensive, threatening, harassing, hateful, sexually explicit or otherwise objectionable — and users who behave abusively — are not permitted. You can flag objectionable content and block abusive users directly in the app; reported content is reviewed and we may remove it and suspend or terminate the responsible accounts (see Section 10).</p>
 
             <h2>8. Intellectual Property</h2>
             <p>The Service, including its software, design, text, graphics, logos and trademarks (but excluding User Content), is owned by Kolabing or its licensors and is protected by intellectual property laws. We grant you a limited, personal, non-transferable, revocable licence to use the Service for its intended purpose. You may not copy, modify, distribute, sell or create derivative works from any part of the Service without our prior written consent.</p>


### PR DESCRIPTION
## Summary
Adds an explicit **zero-tolerance for objectionable content & abusive users** clause to Section 7 of the public Terms (en + es), with an in-app report/block reference and content-removal statement — the EULA requirement for App Review Guideline 1.2. Pairs with the in-app moderation shipped in kolabing-app #99 (report/block + in-app no-tolerance notice).

## Linked tracking item
Closes #117

## Type of change
- [x] 📝 Docs

## Changes
- `resources/views/pages/terms.blade.php` — new paragraph after §7 list.
- `resources/views/pages/es/terms.blade.php` — Spanish equivalent.

## Mobile impact (kolabing-app)
- [x] No mobile changes required — the app links to /terms (and /es/terms); content-only.

## Database / migrations
- [x] No schema changes

## Testing
- [x] `php artisan test` — N/A (Blade content only)
- [x] `vendor/bin/pint` — N/A (no PHP changed)
- [x] Manually verified the clause renders in §7 (en + es).

## Docs & rules updated
- [x] No docs impact beyond the Terms pages

## Screenshots / notes
Content addition only. Linked from the app's sign-up consent + ReconsentGate via LegalLinks.
