### PR TITLE
fix(qa): host_profile_id (F1) + chat last_message preview (#8) + avatar distinctness (#9)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,10 @@
 > the authoritative app backlog. The live cross-repo board is **Kolabing Engineering**
 > (GitHub Project 4, owner `kolabing`).
 >
-> Last updated: 2026-07-28 (added BE-FX-10 — Explore browse feed now hides date-exhausted
+> Last updated: 2026-08-02 (BE-FX-11 F1 host_profile_id on EventResource + BE-FX-8 chat
+> last_message preview + BE-FX-9 factory-avatar distinctness — fixed in code on branch
+> fix/qa-batch-host-profile-chat-preview-avatars; app half = kolabing-app PR 108. Prior:
+> added BE-FX-10 — Explore browse feed now hides date-exhausted
 > Kolabs, fixed + tested. Prior: bootstrapped — the file `CLAUDE.md` mandates did not exist;
 > seeded with the known backend-outstanding items from the mobile-audit analysis and
 > referenced tickets. Future sessions must keep it in sync.)
@@ -42,8 +45,9 @@ _Backend bugs / gaps. Add when detected; strike through with a date once confirm
 
 | # | Bug / gap | Status |
 |---|-----------|--------|
-| BE-FX-8 | **Chat inbox has no message preview** (app audit #8) — `GET /chats` / `ChatThread` expose only `last_message_at`, never message body text, so the app shows a "Tap to open" placeholder. Add a `last_message_preview` (truncated, permission-safe) field to the chat-thread list resource. | Open — app blocked on this |
-| BE-FX-9 | **Same stock avatar for multiple profiles** (app audit #9) — the backend returns the same waterfall stock photo URL for profiles that never uploaded one, so the app's initials fallback never triggers. Either stop seeding/defaulting real profiles to a shared stock image, or expose a `has_custom_avatar` flag so the app can force the initials fallback. | Open — app blocked on this |
+| BE-FX-11 | **Event host profile 404 (public-profile F1)** — the app opened an event's host-community public profile by pushing `events.community_id` (a `communities.id`) into `/profiles/{id}`, which binds `profiles.id` → 404 on profile/collaborations/gallery. `EventResource` now emits `host_profile_id` (the eager-loaded community owner's `profiles.id`, falling back to `events.profile_id` — always a valid `profiles.id`). Branch `fix/qa-batch-host-profile-chat-preview-avatars`; app half = kolabing-app PR #108. | Fixed in code 2026-08-02 — pending review + e2e |
+| BE-FX-8 | **Chat inbox has no message preview** (app audit #8) — `GET /chats` / `ChatThread` exposed only `last_message_at`, never body text, so the app showed a "Tap to open" placeholder. Added `ChatThread::latestMessage()` (`latestOfMany`), eager-loaded in all 3 `ChatService` list loaders (no N+1), and emit `last_message: {content, created_at}` on `ChatThreadResource`. +1 feature test (`ChatActiveListTest`). App reads `last_message.content` (kolabing-app PR #108). | Fixed in code 2026-08-02 — pending review + e2e |
+| BE-FX-9 | **Same stock avatar for multiple profiles** (app audit #9) — the QA read was "same waterfall stock photo everywhere". **Ground-truth:** `RealisticDataSeeder` already assigns DISTINCT per-name picsum photos (`.../seed/profile-<slug>/...`) — not the culprit. The real identical-image source was the **factories** (`Profile/Business/CommunityProfileFactory`), whose `fake()->imageUrl()` returns one shared `via.placeholder` image for every row → fixed to a distinct per-row picsum seed (or null → the app's initials placeholder). **Still open:** confirm prod isn't holding a shared stock URL (`SELECT avatar_url FROM profiles WHERE avatar_url LIKE 'https://picsum.photos/%'` + the two `profile_photo` columns) and the app-side avatar-source inconsistency Jace saw (stock in offer-detail vs initials in Explore card) needs a device re-check. | Factory source fixed in code 2026-08-02 — prod-data + app-consistency check still open |
 | BE-FX-10 | ~~**Explore feed returns date-exhausted Kolabs** — the browse feed (`GET /kolabs` + `/opportunities` shim → `KolabService::browse()`) surfaced Kolabs whose application dates had all passed, so applicants hit an empty date picker ("No available dates for this kolab"). Added `Kolab::scopeWithSelectableDates()` on the discovery path, mirroring the apply-time guard; saved list unaffected.~~ | Fixed 2026-07-28 (tested) |
 
 ---

--- a/app/Http/Resources/Api/V1/ChatThreadResource.php
+++ b/app/Http/Resources/Api/V1/ChatThreadResource.php
@@ -36,6 +36,14 @@ class ChatThreadResource extends JsonResource
             'event_id' => $this->event_id,
             'series_id' => $this->series_id,
             'last_message_at' => $this->last_message_at?->toIso8601String(),
+            // Preview of the most recent message so the chat list shows real text
+            // instead of a "Tap to open" placeholder (#8). Eager-loaded via
+            // latestMessage()->latestOfMany() to avoid N+1; null on empty threads,
+            // key omitted when the relation isn't loaded (the app falls back).
+            'last_message' => $this->whenLoaded('latestMessage', fn () => $this->latestMessage ? [
+                'content' => $this->latestMessage->content,
+                'created_at' => $this->latestMessage->created_at?->toIso8601String(),
+            ] : null),
             'unread_count' => (int) ($this->unread_count ?? 0),
             'participant_summary' => $this->participantSummary(),
             'created_at' => $this->created_at?->toIso8601String(),

--- a/app/Http/Resources/Api/V1/EventResource.php
+++ b/app/Http/Resources/Api/V1/EventResource.php
@@ -35,6 +35,14 @@ class EventResource extends JsonResource
             'address' => $this->address,
             'location' => $this->location,
             'community_id' => $this->community_id,
+            // The host's `profiles.id` (NOT community_id, which is a communities.id):
+            // lets the app open the host's public profile without 404ing on the
+            // /profiles/{id} route (which binds profiles.id). Prefers the eager-loaded
+            // community owner's profile; falls back to the event's own host profile_id,
+            // which is always a valid profiles.id. See kolabing-app F1.
+            'host_profile_id' => $this->relationLoaded('community') && $this->community
+                ? $this->community->owner_profile_id
+                : $this->profile_id,
             // Host community name + 17-slug type (eager-loaded to avoid N+1).
             // community_type is the host community's `type` (the unified vocabulary),
             // NOT the 5-value App\Enums\CommunityType placeholder.

--- a/app/Models/ChatThread.php
+++ b/app/Models/ChatThread.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * @property string $id
@@ -77,6 +78,17 @@ class ChatThread extends Model
     public function messages(): HasMany
     {
         return $this->hasMany(ChatMessage::class, 'thread_id');
+    }
+
+    /**
+     * The most recent message, for the chat-list preview (#8). Eager-load this
+     * (`with('latestMessage')`) to avoid an N+1 across the thread list.
+     *
+     * @return HasOne<ChatMessage, $this>
+     */
+    public function latestMessage(): HasOne
+    {
+        return $this->hasOne(ChatMessage::class, 'thread_id')->latestOfMany();
     }
 
     /**

--- a/app/Services/ChatService.php
+++ b/app/Services/ChatService.php
@@ -231,6 +231,7 @@ class ChatService
             ->where('type', ChatThreadType::Collaboration->value)
             ->whereIn('application_id', $applicationIds)
             ->with([
+                'latestMessage', // chat-list preview (#8), avoids N+1
                 'application.collaboration',
                 'application.applicantProfile.businessProfile',
                 'application.applicantProfile.communityProfile',
@@ -507,6 +508,7 @@ class ChatService
                 ChatThreadType::CommunityMain->value,
                 ChatThreadType::CommunityCustom->value,
             ])
+            ->with('latestMessage') // chat-list preview (#8), avoids N+1
             ->get();
 
         $bannedThreadIds = $this->bannedThreadIds($profile, $threads);
@@ -616,6 +618,7 @@ class ChatService
                     $query->orWhereIn('community_id', $managedCommunityIds);
                 }
             })
+            ->with('latestMessage') // chat-list preview (#8), avoids N+1
             ->get();
 
         $bannedThreadIds = $this->bannedThreadIds($profile, $threads);

--- a/database/factories/BusinessProfileFactory.php
+++ b/database/factories/BusinessProfileFactory.php
@@ -42,7 +42,11 @@ class BusinessProfileFactory extends Factory
             'city_country' => fake()->country(),
             'instagram' => fake()->optional()->userName(),
             'website' => fake()->optional()->url(),
-            'profile_photo' => fake()->optional()->imageUrl(400, 400, 'business'),
+            // Distinct per-row (or null). fake()->imageUrl() returns one identical
+            // via.placeholder image for every row → "same avatar everywhere" (#9).
+            'profile_photo' => fake()->boolean(70)
+                ? 'https://picsum.photos/seed/'.fake()->uuid().'/400/400'
+                : null,
             'primary_venue' => null,
         ];
     }

--- a/database/factories/CommunityProfileFactory.php
+++ b/database/factories/CommunityProfileFactory.php
@@ -38,7 +38,11 @@ class CommunityProfileFactory extends Factory
             'instagram' => fake()->optional()->userName(),
             'tiktok' => fake()->optional()->userName(),
             'website' => fake()->optional()->url(),
-            'profile_photo' => fake()->optional()->imageUrl(400, 400, 'people'),
+            // Distinct per-row (or null). fake()->imageUrl() returns one identical
+            // via.placeholder image for every row → "same avatar everywhere" (#9).
+            'profile_photo' => fake()->boolean(70)
+                ? 'https://picsum.photos/seed/'.fake()->uuid().'/400/400'
+                : null,
             'is_featured' => false,
         ];
     }

--- a/database/factories/ProfileFactory.php
+++ b/database/factories/ProfileFactory.php
@@ -33,7 +33,12 @@ class ProfileFactory extends Factory
             'phone_number' => fake()->optional()->e164PhoneNumber(),
             'user_type' => fake()->randomElement(UserType::cases()),
             'google_id' => Str::random(21),
-            'avatar_url' => fake()->optional()->imageUrl(200, 200, 'people'),
+            // Distinct per-row image (or null → the app renders a clean initials
+            // placeholder). fake()->imageUrl() returns the SAME via.placeholder image
+            // for every row, which reads as "every profile has the same avatar" (#9).
+            'avatar_url' => fake()->boolean(70)
+                ? 'https://picsum.photos/seed/'.fake()->uuid().'/200/200'
+                : null,
             'email_verified_at' => now(),
         ];
     }

--- a/tests/Feature/Api/V1/ChatActiveListTest.php
+++ b/tests/Feature/Api/V1/ChatActiveListTest.php
@@ -79,6 +79,21 @@ class ChatActiveListTest extends TestCase
             ->assertJsonPath('data.0.unread_count', 1);
     }
 
+    public function test_active_chats_include_last_message_preview(): void
+    {
+        // #8: the chat list must carry the latest message so the app shows a
+        // preview instead of a "Tap to open" placeholder.
+        [$business, $community, $application] = $this->makeConversation();
+
+        $this->actingAs($community)
+            ->postJson("/api/v1/applications/{$application->id}/messages", ['content' => 'See you at 6!'])
+            ->assertStatus(201);
+
+        $this->actingAs($business)->getJson('/api/v1/chats')
+            ->assertStatus(200)
+            ->assertJsonPath('data.0.last_message.content', 'See you at 6!');
+    }
+
     public function test_active_chats_bulk_loads_community_thread_unread_counts(): void
     {
         $member = Profile::factory()->attendee()->create();


### PR DESCRIPTION
## Summary
Backend halves of the **2026-07-28 iOS QA** batch: fixes the public-profile 404 (F1), adds a chat last-message preview (#8), and removes the identical-avatar source in factories (#9). App halves are in **kolabing-app PR #108**.

## Linked tracking item
Closes # <!-- N/A — no GitHub issue was filed; tracked in BACKLOG (BE-FX-8/9/11) + the QA artifact "Kolabing iOS QA — 2026-07-28". App half: kolabing-app PR #108. -->

## Type of change
- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes
- **F1 (BE-FX-11) — `EventResource.host_profile_id`:** the app pushed `events.community_id` (a `communities.id`) into `/profiles/{id}` (binds `profiles.id`) → 404 on profile/collaborations/gallery. Emit `host_profile_id` = the eager-loaded community owner's `profiles.id`, falling back to `events.profile_id` (always a valid `profiles.id`, no eager-load dependency).
- **#8 (BE-FX-8) — chat preview:** `ChatThread::latestMessage()` (`hasOne(...)->latestOfMany()`), eager-loaded in all 3 `ChatService` list loaders (collaboration/community/event → no N+1), emitted as `last_message: {content, created_at}` on `ChatThreadResource` (null on empty threads; key omitted when the relation isn't loaded).
- **#9 (BE-FX-9) — avatar distinctness:** ground-truth — `RealisticDataSeeder` **already** uses distinct per-name picsum seeds, so it's not the culprit; the identical-image source was the **factories** (`fake()->imageUrl()` → one shared `via.placeholder` for every row) → now a distinct per-row picsum seed (or null → the app's initials placeholder).
- +1 feature test (`ChatActiveListTest::test_active_chats_include_last_message_preview`).

## Mobile impact (kolabing-app)
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** Additive JSON: `EventResource` gains `host_profile_id`; `ChatThreadResource` gains `last_message: {content, created_at}`. Both are consumed in **kolabing-app PR #108** with graceful fallbacks (F1 falls back to the community screen; #8 falls back to "Tap to open") so either side can merge/deploy first without breakage.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A. #9 also warrants a one-off prod data check/cleanup (not in this PR): `SELECT avatar_url FROM profiles WHERE avatar_url LIKE 'https://picsum.photos/%';` (+ the two `profile_photo` columns) to confirm prod isn't holding a shared stock URL.

## Testing
- [ ] `php artisan test` passes — **could NOT run on the build box: no `pdo_sqlite` and no local Postgres up, so `RefreshDatabase` can't boot (the existing sibling tests error identically). `php -l` clean on all files; reviewer to run the suite on CI/Postgres.**
- [x] `vendor/bin/pint` clean — `{"result":"pass"}` on all changed files.
- [ ] Manually verified the happy path — pending (needs the app + a device).

## Docs & rules updated
- [x] `BACKLOG.md` updated (BE-FX-8/9 moved to fixed-in-code; BE-FX-11 added)
- [x] `docs/BACKEND-SCHEMA.md` — N/A: no schema change; only two additive response fields (`host_profile_id`, `last_message`).

## Screenshots / notes
**Still open after this PR (flagged honestly, not fabricated):**
- #9 has two residual angles this PR does not fully close: (1) a **prod-data** check that no real profiles share a stock URL, and (2) an **app-side** avatar-source inconsistency the QA saw (a profile showing a stock photo in the offer-detail/apply modal but initials in the Explore card) — that's a widget reading a different avatar field, and needs a device re-check to pin. Both are noted in BACKLOG BE-FX-9.
