### PR TITLE
fix(subscriptions): set reference monthly price to EUR 49

### DIFF
--- a/config/subscriptions.php
+++ b/config/subscriptions.php
@@ -4,7 +4,7 @@ return [
     'business' => [
         'apple' => [
             'monthly' => [
-                'price' => 39.99,
+                'price' => 49,
                 'apple_product_id' => env('APPLE_IAP_MONTHLY_PRODUCT_ID', 'com.kolabing.kolabingApp.subscription.monthly'),
             ],
             'three_months' => [


### PR DESCRIPTION
## Summary
Aligns the backend reference monthly subscription price with the confirmed EUR 49/month plan (was 39.99).

## Linked tracking item
Closes # <!-- N/A: no pre-existing issue; part of the EUR 49 pricing alignment requested 2026-08-05. -->

## Type of change
- [x] Bug fix

## Changes
- `config/subscriptions.php`: `business.apple.monthly.price` 39.99 -> 49

## Mobile impact (kolabing-app)
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** The user-visible EUR 39.99 strings in the app (paywall Android fallback, status screen, subscribe button l10n) are updated in a companion kolabing-app PR. The **actual charged price is the App Store Connect subscription tier**, which the Account Holder must set to the EUR 49 tier — no code can change that.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A

## Testing
- [x] `php artisan test` passes — N/A behaviour change; `php -l` clean. This `price` value is a reference field (only `apple_product_id` is read at runtime by `AppleSubscriptionProducts`), so no test asserts on it.
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (config value only)

## Docs & rules updated
- [x] No docs impact

## Screenshots / notes
The real price users are charged is the ASC subscription product tier. **Production need:** set the `com.kolabing.kolabingApp.subscription.monthly` product to the EUR 49.00 tier in App Store Connect (Account Holder), then resubmit.
