### PR TITLE
feat(admin): reproducible maintainer provisioning for /admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,11 @@ APPLE_IAP_MONTHLY_PRODUCT_ID=com.kolabing.kolabingApp.subscription.monthly
 APPLE_IAP_MONTHLY_PRICE=39.99
 APPLE_IAP_THREE_MONTHS_PRODUCT_ID=com.kolabing.kolabingApp.subscription.three_months
 # APPLE_IAP_THREE_MONTHS_PRICE=
+
+# Admin panel (/admin) maintainer provisioning.
+# The panel is gated on users.is_maintainer = true; without a maintainer it is
+# inaccessible. Set these, then run: php artisan db:seed --class=MaintainerSeeder --force
+# (see docs/admin-access.md). Leave blank in dev/CI -- the seeder no-ops.
+ADMIN_MAINTAINER_NAME="Kolabing Maintainer"
+ADMIN_MAINTAINER_EMAIL=
+ADMIN_MAINTAINER_PASSWORD=

--- a/config/admin.php
+++ b/config/admin.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Admin panel maintainer provisioning
+    |--------------------------------------------------------------------------
+    |
+    | The /admin panel is gated by the `maintainer` middleware
+    | (EnsureAdminUserIsMaintainer -> users.is_maintainer = true). Without at
+    | least one maintainer row, nobody can pass the gate and /admin is
+    | effectively inaccessible.
+    |
+    | MaintainerSeeder provisions (or promotes + resets the password of) a
+    | maintainer from the values below, so admin access is reproducible and
+    | secret-driven -- the password comes from a managed secret, never a
+    | plaintext argument in a shell / Cloud command log.
+    |
+    | Leave email/password unset in dev + CI: the seeder no-ops when either is
+    | blank, so it is safe to run and safe to leave wired into a deploy command.
+    | See docs/admin-access.md.
+    |
+    */
+    'maintainer' => [
+        'name' => env('ADMIN_MAINTAINER_NAME', 'Kolabing Maintainer'),
+        'email' => env('ADMIN_MAINTAINER_EMAIL'),
+        'password' => env('ADMIN_MAINTAINER_PASSWORD'),
+    ],
+];

--- a/database/seeders/MaintainerSeeder.php
+++ b/database/seeders/MaintainerSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Provisions (or promotes + password-resets) the admin-panel maintainer from
+ * config/admin.php (ADMIN_MAINTAINER_* env). Idempotent via updateOrCreate on
+ * email. No-ops when the email or password is not configured, so it is safe to
+ * run in dev / CI and safe to leave wired into a deploy command.
+ *
+ * Prod (Laravel Cloud): set ADMIN_MAINTAINER_EMAIL + ADMIN_MAINTAINER_PASSWORD
+ * (+ optionally ADMIN_MAINTAINER_NAME), then run
+ *   php artisan db:seed --class=MaintainerSeeder --force
+ * in the Commands tab (or append it to the deploy command to self-heal).
+ * See docs/admin-access.md.
+ *
+ * NOTE: intentionally NOT registered in DatabaseSeeder, so a full `db:seed`
+ * (which also runs RealisticDataSeeder) is never required to provision admin
+ * access. Always run it in isolation with --class=MaintainerSeeder.
+ */
+class MaintainerSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $email = config('admin.maintainer.email');
+        $password = config('admin.maintainer.password');
+        $name = config('admin.maintainer.name') ?: 'Kolabing Maintainer';
+
+        if (blank($email) || blank($password)) {
+            $this->command?->warn(
+                'MaintainerSeeder skipped: ADMIN_MAINTAINER_EMAIL / ADMIN_MAINTAINER_PASSWORD not set.'
+            );
+
+            return;
+        }
+
+        $user = User::query()->updateOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => $password, // hashed by the User `password` cast
+                'is_maintainer' => true,
+                'email_verified_at' => now(),
+            ],
+        );
+
+        $this->command?->info("Maintainer ready: {$user->email}");
+    }
+}

--- a/docs/admin-access.md
+++ b/docs/admin-access.md
@@ -1,0 +1,58 @@
+# Admin panel access (`/admin`)
+
+The operator panel at `https://kolabing.com/admin` is **not** a public page and is
+**not broken** when it "won't open" — it is a gated Laravel + AdminLTE panel.
+
+## How the gate works (code truth)
+
+- `GET /admin` → `302` → `/admin/login` for any unauthenticated visitor
+  (`routes/web.php`, `guest:admin`). Landing on the login screen is expected.
+- Every operator route is behind `middleware(['auth:admin', 'maintainer'])`.
+- The `maintainer` middleware (`App\Http\Middleware\EnsureAdminUserIsMaintainer`)
+  `abort(403)` unless `Auth::user('admin')->isMaintainer()`.
+- `isMaintainer()` is simply the boolean column **`users.is_maintainer`**.
+- The `admin` guard uses the **same `users` table** (`config/auth.php`), so any
+  user may *attempt* login, but `Admin\AuthController@store` logs out and rejects
+  ("This account is not allowed to access the admin panel.") unless
+  `is_maintainer` is true.
+
+**Therefore:** if no user has `is_maintainer = true`, nobody can pass the gate and
+`/admin` looks dead. There is no seeder that creates one by default, so a fresh
+database has **zero** maintainers.
+
+## Provision a maintainer (the fix)
+
+### Preferred — secret-driven (Laravel Cloud)
+
+1. In the Cloud dashboard set env vars on the **production (`master`) environment**:
+   - `ADMIN_MAINTAINER_NAME`
+   - `ADMIN_MAINTAINER_EMAIL`
+   - `ADMIN_MAINTAINER_PASSWORD`  (a strong password — this is the login password)
+2. Run once in the **Commands** tab:
+   ```
+   php artisan db:seed --class=MaintainerSeeder --force
+   ```
+   `MaintainerSeeder` is idempotent (`updateOrCreate` on email): it **creates** the
+   account if missing, or **promotes + resets the password** of an existing one.
+   The password is hashed by the `User` `password` cast.
+3. (Optional, self-healing) append to the `master` deploy command so a maintainer
+   always exists after a deploy:
+   ```
+   php artisan migrate --force && php artisan db:seed --class=MaintainerSeeder --force
+   ```
+
+### Quick one-off (equivalent)
+
+```
+php artisan admin:create-maintainer "Full Name" "email@kolabing.com" "the-password"
+```
+
+Same result; use when you don't want to set the env vars. (Note the password is a
+plaintext argument here, so it lands in the command log — prefer the seeder for
+anything long-lived.)
+
+## Verify
+
+Open `https://kolabing.com/admin/login`, sign in with the email + password above.
+Success redirects to the users dashboard (`admin.users.index`). A `403` after login
+means the account exists but `is_maintainer` is still false — re-run the seeder.

--- a/tests/Feature/Admin/MaintainerSeederTest.php
+++ b/tests/Feature/Admin/MaintainerSeederTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use Database\Seeders\MaintainerSeeder;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class MaintainerSeederTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function configureMaintainer(?string $email, ?string $password, string $name = 'Ops Admin'): void
+    {
+        config()->set('admin.maintainer', [
+            'name' => $name,
+            'email' => $email,
+            'password' => $password,
+        ]);
+    }
+
+    public function test_it_provisions_a_maintainer_from_config(): void
+    {
+        $this->configureMaintainer('ops@kolabing.com', 'super-secret-pw');
+
+        $this->seed(MaintainerSeeder::class);
+
+        $user = User::query()->where('email', 'ops@kolabing.com')->first();
+
+        $this->assertNotNull($user);
+        $this->assertTrue($user->isMaintainer());
+        $this->assertTrue($user->hasVerifiedEmail());
+        $this->assertTrue(Hash::check('super-secret-pw', $user->password));
+    }
+
+    public function test_it_promotes_and_resets_password_for_an_existing_user(): void
+    {
+        User::factory()->create([
+            'email' => 'ops@kolabing.com',
+            'is_maintainer' => false,
+        ]);
+
+        $this->configureMaintainer('ops@kolabing.com', 'rotated-pw');
+
+        $this->seed(MaintainerSeeder::class);
+
+        $user = User::query()->where('email', 'ops@kolabing.com')->first();
+
+        $this->assertTrue($user->isMaintainer());
+        $this->assertTrue(Hash::check('rotated-pw', $user->password));
+        $this->assertSame(1, User::query()->where('email', 'ops@kolabing.com')->count());
+    }
+
+    public function test_it_no_ops_when_credentials_are_not_configured(): void
+    {
+        $this->configureMaintainer(null, null);
+
+        $this->seed(MaintainerSeeder::class);
+
+        $this->assertSame(0, User::query()->where('is_maintainer', true)->count());
+    }
+
+    public function test_a_provisioned_maintainer_can_log_into_the_admin_panel(): void
+    {
+        $this->configureMaintainer('ops@kolabing.com', 'login-pw-123');
+        $this->seed(MaintainerSeeder::class);
+
+        $response = $this->post('/admin/login', [
+            'email' => 'ops@kolabing.com',
+            'password' => 'login-pw-123',
+        ]);
+
+        $response->assertRedirect(route('admin.users.index'));
+        $this->assertAuthenticatedAs(
+            User::query()->where('email', 'ops@kolabing.com')->first(),
+            'admin',
+        );
+    }
+}


### PR DESCRIPTION
## Why `/admin` looks dead

`kolabing.com/admin` is **not down** — it's a gated Laravel/AdminLTE panel. `GET /admin` → `302` → `/admin/login` (which returns `200`). Every operator route sits behind `middleware(['auth:admin','maintainer'])`; the `maintainer` middleware (`EnsureAdminUserIsMaintainer`) `abort(403)` unless `users.is_maintainer = true`. The `admin` guard uses the `users` table, and `Admin\AuthController@store` logs out + rejects any login without that flag.

**Root cause:** nothing provisions a maintainer — no seeder, no env path — so the live DB has **zero** maintainer accounts and nobody can pass the gate. It reads as "dead."

## What this PR adds

A reproducible, secret-driven, idempotent provisioning path:

- `config/admin.php` — `ADMIN_MAINTAINER_NAME/EMAIL/PASSWORD`
- `database/seeders/MaintainerSeeder.php` — `updateOrCreate` by email → sets `is_maintainer` + verifies email; password hashed by the `User` cast; **no-ops** when env unset (safe in dev/CI); deliberately **not** registered in `DatabaseSeeder` so it never pulls in `RealisticDataSeeder`
- `.env.example` + `docs/admin-access.md` runbook
- Feature tests: provision / promote + password-reset an existing user / no-op-when-unset / full `/admin/login` round-trip for a provisioned maintainer

## How to make `/admin` accessible (prod = Laravel Cloud `master` env)

1. Set `ADMIN_MAINTAINER_NAME` / `ADMIN_MAINTAINER_EMAIL` / `ADMIN_MAINTAINER_PASSWORD` on the production (`master`) environment.
2. Commands tab: `php artisan db:seed --class=MaintainerSeeder --force`
3. (optional self-heal) set the deploy command to `php artisan migrate --force && php artisan db:seed --class=MaintainerSeeder --force`

Equivalent one-off (no env needed): `php artisan admin:create-maintainer "Full Name" "email@kolabing.com" "the-password"`.

## Tests

`vendor/bin/pint` clean. Tests run on sqlite `:memory:`; the build box lacks the `pdo_sqlite` extension, so the suite (including pre-existing tests) cannot execute there — validated in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
