### PR TITLE
feat(blog): blog engine + SEO/GEO for kolabing.com

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@
 > the authoritative app backlog. The live cross-repo board is **Kolabing Engineering**
 > (GitHub Project 4, owner `kolabing`).
 >
-> Last updated: 2026-08-02 (BE-FX-11 F1 host_profile_id on EventResource + BE-FX-8 chat
+> Last updated: 2026-08-15 (BE-NF-16 blog engine + SEO/GEO built, branch feat/blog-engine-seo-geo: public /blog + admin /admin/blog CRUD + Article/Organization/WebSite/FAQPage JSON-LD + homepage meta/OG + sitemap/llms now include posts. Prior 2026-08-02: BE-FX-11 F1 host_profile_id on EventResource + BE-FX-8 chat
 > last_message preview + BE-FX-9 factory-avatar distinctness — fixed in code on branch
 > fix/qa-batch-host-profile-chat-preview-avatars; app half = kolabing-app PR 108. Prior:
 > added BE-FX-10 — Explore browse feed now hides date-exhausted
@@ -38,6 +38,7 @@ _Started or partially shipped; not yet fully working end-to-end._
 | BE-IF-18 | **Real-time chat — Reverb Part A (ops)** | Code exists (event + channel auth + broadcasting route); the Flutter client (app IF-18) is dormant until the backend returns `REVERB_APP_KEY`. **MISSING:** env config + self-hosted Reverb daemon + queue worker + nginx/TLS. No code change on handoff — app flips live once the key is served. Ticket: `docs/tickets/2026-06-09-reverb-realtime-chat-PART-A-ops.md`. | Code ready — ops/deploy pending |
 | BE-IF-47 | **Legacy `collab_opportunities` → Kolab consolidation** | PR #32 removed table-level legacy code (archive table), but the app still routes System-A edits to legacy rows and the split persists conceptually. Full data migration + route/model consolidation remains open-ended (needs a migration plan). App audit item #47. | Partial — migration plan needed |
 | BE-IF-48 | **Landing-page newsletter + book-a-call pop-up** | ✅ BUILT: `newsletter_subscribers` table + `NewsletterSubscriber` model + `NewsletterAudience` enum + `NewsletterSubscribeRequest` (email + optional community/business audience + honeypot) + `NewsletterController@store` (idempotent per email) + `POST /newsletter` (throttle 10/min) + pop-up UI in `welcome.blade.php` (exit-intent/18s/45%-scroll, once per session, segmented audience, book-a-call CTA). 7 feature tests green, pint clean. **PENDING:** run migration on prod; set `KOLABING_BOOK_A_CALL_URL` env to the real Cal.com link (default is a placeholder). | Built — pending deploy + real Cal.com link |
+| BE-NF-16 | **Blog engine + SEO/GEO** | ✅ BUILT (branch `feat/blog-engine-seo-geo`): `blog_posts` table + `BlogPost` model/factory + public `/blog` + `/blog/{slug}` (Blade on the `marketing-page` layout, per-post canonical/OG) + admin `/admin/blog/*` CRUD (maintainer-gated, sidebar entry) + **Article/Organization/WebSite/FAQPage JSON-LD** + homepage `welcome.blade.php` meta/canonical/OG fix + `/sitemap.xml` & `/llms.txt` now include published posts. 2 feature test files (public + admin). Owned by Clark going forward (blog + SEO/GEO workstream). **PENDING:** merge (Volkan) + prod migrate (the `master` deploy runs `migrate --force`); then Phase 2 = first Community-Commerce articles + a Barcelona city page. | Built (PR) - pending merge/deploy + content |
 
 ---
 

--- a/app/Http/Controllers/Admin/BlogController.php
+++ b/app/Http/Controllers/Admin/BlogController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\StoreBlogPostRequest;
+use App\Http\Requests\Admin\UpdateBlogPostRequest;
+use App\Models\BlogPost;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+
+class BlogController extends Controller
+{
+    public function index(): View
+    {
+        return view('admin.blog.index', [
+            'posts' => BlogPost::query()
+                ->orderByRaw('published_at is null desc')
+                ->orderByDesc('published_at')
+                ->orderByDesc('created_at')
+                ->get(),
+        ]);
+    }
+
+    public function create(): View
+    {
+        return view('admin.blog.edit', [
+            'post' => new BlogPost(['locale' => 'en', 'author_name' => 'Kolabing Team']),
+        ]);
+    }
+
+    public function edit(BlogPost $post): View
+    {
+        return view('admin.blog.edit', ['post' => $post]);
+    }
+
+    public function store(StoreBlogPostRequest $request): RedirectResponse
+    {
+        BlogPost::query()->create($request->validated());
+
+        return redirect()->route('admin.blog.index')->with('status', 'Post created.');
+    }
+
+    public function update(UpdateBlogPostRequest $request, BlogPost $post): RedirectResponse
+    {
+        $post->update($request->validated());
+
+        return redirect()->route('admin.blog.index')->with('status', 'Post updated.');
+    }
+
+    public function destroy(BlogPost $post): RedirectResponse
+    {
+        $post->delete();
+
+        return redirect()->route('admin.blog.index')->with('status', 'Post deleted.');
+    }
+}

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\BlogPost;
+use Illuminate\Contracts\View\View;
+
+class BlogController extends Controller
+{
+    public function index(): View
+    {
+        return view('blog.index', [
+            'posts' => BlogPost::query()->published()->orderByDesc('published_at')->paginate(12),
+        ]);
+    }
+
+    public function show(BlogPost $post): View
+    {
+        abort_unless($post->isPublished(), 404);
+
+        return view('blog.show', [
+            'post' => $post,
+            'related' => BlogPost::query()->published()
+                ->whereKeyNot($post->getKey())
+                ->orderByDesc('published_at')
+                ->limit(3)
+                ->get(),
+        ]);
+    }
+}

--- a/app/Http/Requests/Admin/StoreBlogPostRequest.php
+++ b/app/Http/Requests/Admin/StoreBlogPostRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreBlogPostRequest extends FormRequest
+{
+    /**
+     * The /admin/blog routes are already behind the auth:admin + maintainer
+     * middleware, which is the authorization gate.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $id = $this->route('post')?->id;
+
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255', 'alpha_dash', Rule::unique('blog_posts', 'slug')->ignore($id)],
+            'description' => ['required', 'string', 'max:500'],
+            'body' => ['required', 'string'],
+            'author_name' => ['required', 'string', 'max:120'],
+            'author_title' => ['nullable', 'string', 'max:120'],
+            'cover_image_url' => ['nullable', 'url', 'max:2048'],
+            'locale' => ['required', 'string', 'max:8'],
+            'published_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/UpdateBlogPostRequest.php
+++ b/app/Http/Requests/Admin/UpdateBlogPostRequest.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+/**
+ * Same rules as store; the slug-uniqueness rule ignores the bound post's id.
+ */
+class UpdateBlogPostRequest extends StoreBlogPostRequest {}

--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * A public marketing / SEO blog post (Community Commerce content) served at
+ * /blog and /blog/{slug}. Route-bound by slug; only published posts are public
+ * (see scopePublished + isPublished). Draft = published_at null or in the future.
+ */
+class BlogPost extends Model
+{
+    /** @use HasFactory<\Database\Factories\BlogPostFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    protected $fillable = [
+        'slug', 'title', 'description', 'body',
+        'author_name', 'author_title', 'cover_image_url',
+        'locale', 'published_at',
+    ];
+
+    protected function casts(): array
+    {
+        return ['published_at' => 'datetime'];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function isPublished(): bool
+    {
+        return $this->published_at !== null && $this->published_at->isPast();
+    }
+
+    /**
+     * @param  Builder<BlogPost>  $query
+     * @return Builder<BlogPost>
+     */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->whereNotNull('published_at')->where('published_at', '<=', now());
+    }
+}

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -338,6 +338,12 @@ return [
             'icon' => 'fas fa-fw fa-star',
             'active' => ['admin/reviews', 'admin/reviews/*'],
         ],
+        [
+            'text' => 'Blog',
+            'route' => 'admin.blog.index',
+            'icon' => 'fas fa-fw fa-newspaper',
+            'active' => ['admin/blog', 'admin/blog/*'],
+        ],
         ['header' => 'INSIGHTS'],
         [
             'text' => 'Statistics',

--- a/database/factories/BlogPostFactory.php
+++ b/database/factories/BlogPostFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\BlogPost;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<BlogPost>
+ */
+class BlogPostFactory extends Factory
+{
+    protected $model = BlogPost::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $title = rtrim($this->faker->unique()->sentence(6), '.');
+
+        return [
+            'slug' => Str::slug($title).'-'.$this->faker->unique()->numberBetween(1, 99999),
+            'title' => $title,
+            'description' => $this->faker->sentence(18),
+            'body' => '<p>'.$this->faker->paragraphs(4, true).'</p>',
+            'author_name' => 'Kolabing Team',
+            'author_title' => null,
+            'cover_image_url' => null,
+            'locale' => 'en',
+            'published_at' => now()->subDays($this->faker->numberBetween(1, 30)),
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn (): array => ['published_at' => null]);
+    }
+
+    public function scheduled(): static
+    {
+        return $this->state(fn (): array => ['published_at' => now()->addWeek()]);
+    }
+}

--- a/database/migrations/2026_08_15_120000_create_blog_posts_table.php
+++ b/database/migrations/2026_08_15_120000_create_blog_posts_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Marketing / SEO blog posts, served server-side (Blade) at /blog and
+     * /blog/{slug} on the public marketing site and authored by maintainers via
+     * /admin/blog. `published_at` gates visibility (null or future = draft).
+     * `body` is trusted maintainer-authored HTML rendered in a prose container.
+     * Not linked to `profiles` — `author_name` / `author_title` are the free-text
+     * byline used for E-E-A-T authority in the Article schema.
+     */
+    public function up(): void
+    {
+        Schema::create('blog_posts', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('slug')->unique();
+            $table->string('title');
+            $table->string('description', 500);
+            $table->longText('body');
+            $table->string('author_name')->default('Kolabing Team');
+            $table->string('author_title')->nullable();
+            $table->string('cover_image_url')->nullable();
+            $table->string('locale', 8)->default('en');
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['locale', 'published_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_posts');
+    }
+};

--- a/resources/views/admin/blog/edit.blade.php
+++ b/resources/views/admin/blog/edit.blade.php
@@ -1,0 +1,54 @@
+@extends('admin.layout', ['title' => $post->exists ? 'Edit post' : 'New post'])
+
+@section('page_title', $post->exists ? 'Edit post' : 'New post')
+
+@section('admin_content')
+    <form method="POST" action="{{ $post->exists ? route('admin.blog.update', $post) : route('admin.blog.store') }}">
+        @csrf
+        @if ($post->exists) @method('PUT') @endif
+
+        <div class="card"><div class="card-body">
+            <div class="form-group">
+                <label>Title</label>
+                <input name="title" value="{{ old('title', $post->title) }}" class="form-control" required>
+            </div>
+            <div class="form-row">
+                <div class="form-group col-md-8">
+                    <label>Slug</label>
+                    <input name="slug" value="{{ old('slug', $post->slug) }}" class="form-control" placeholder="how-to-get-foot-traffic-without-paid-ads" required>
+                    <small class="form-text text-muted">Lowercase words separated by hyphens. This is the /blog/&lt;slug&gt; URL.</small>
+                </div>
+                <div class="form-group col-md-4">
+                    <label>Locale</label>
+                    <select name="locale" class="form-control">
+                        @foreach (['en' => 'English', 'es' => 'Spanish'] as $k => $l)
+                            <option value="{{ $k }}" @selected(old('locale', $post->locale ?? 'en') === $k)>{{ $l }}</option>
+                        @endforeach
+                    </select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label>Description (meta / excerpt, max 500)</label>
+                <textarea name="description" rows="2" class="form-control" maxlength="500" required>{{ old('description', $post->description) }}</textarea>
+            </div>
+            <div class="form-row">
+                <div class="form-group col-md-6"><label>Author name</label><input name="author_name" value="{{ old('author_name', $post->author_name ?? 'Kolabing Team') }}" class="form-control" required></div>
+                <div class="form-group col-md-6"><label>Author title (optional)</label><input name="author_title" value="{{ old('author_title', $post->author_title) }}" class="form-control" placeholder="Co-founder, Kolabing"></div>
+            </div>
+            <div class="form-row">
+                <div class="form-group col-md-8"><label>Cover image URL (optional)</label><input name="cover_image_url" value="{{ old('cover_image_url', $post->cover_image_url) }}" class="form-control" placeholder="https://..."></div>
+                <div class="form-group col-md-4"><label>Publish at (blank = draft)</label><input type="datetime-local" name="published_at" value="{{ old('published_at', $post->published_at?->format('Y-m-d\TH:i')) }}" class="form-control"></div>
+            </div>
+            <div class="form-group">
+                <label>Body (HTML)</label>
+                <textarea name="body" rows="18" class="form-control text-monospace" required>{{ old('body', $post->body) }}</textarea>
+                <small class="form-text text-muted">Trusted HTML, rendered in a prose container. Use &lt;h2&gt;, &lt;p&gt;, &lt;ul&gt;, &lt;a&gt;. Lead each section with a direct 40&ndash;60 word answer so answer-engines can extract it.</small>
+            </div>
+        </div></div>
+
+        <div class="d-flex justify-content-between">
+            <a href="{{ route('admin.blog.index') }}" class="btn btn-outline-secondary">Cancel</a>
+            <button class="btn btn-primary">{{ $post->exists ? 'Save' : 'Create' }}</button>
+        </div>
+    </form>
+@endsection

--- a/resources/views/admin/blog/index.blade.php
+++ b/resources/views/admin/blog/index.blade.php
@@ -1,0 +1,39 @@
+@extends('admin.layout', ['title' => 'Blog'])
+
+@section('page_title', 'Blog')
+@section('page_subtitle', 'Community Commerce articles published at /blog.')
+
+@section('page_actions')
+    <a href="{{ route('admin.blog.create') }}" class="btn btn-primary"><i class="fas fa-plus mr-1"></i> New post</a>
+@endsection
+
+@section('admin_content')
+    <div class="card">
+        <div class="card-body p-0">
+            <table class="table table-hover table-sm mb-0">
+                <thead>
+                    <tr><th style="width:120px">Status</th><th>Title</th><th>Author</th><th>Published</th><th class="text-right pr-3">Actions</th></tr>
+                </thead>
+                <tbody>
+                    @forelse ($posts as $post)
+                        @php $live = $post->isPublished(); $scheduled = $post->published_at && $post->published_at->isFuture(); @endphp
+                        <tr>
+                            <td>
+                                <span class="badge {{ $live ? 'badge-success' : ($scheduled ? 'badge-info' : 'badge-secondary') }}">{{ $live ? 'Published' : ($scheduled ? 'Scheduled' : 'Draft') }}</span>
+                            </td>
+                            <td class="font-weight-bold"><a href="{{ route('blog.show', $post) }}" target="_blank" rel="noopener">{{ $post->title }}</a></td>
+                            <td>{{ $post->author_name }}</td>
+                            <td>{{ $post->published_at?->format('d M Y') ?? '—' }}</td>
+                            <td class="text-right pr-3 text-nowrap">
+                                <a href="{{ route('admin.blog.edit', $post) }}" class="btn btn-sm btn-outline-primary">Edit</a>
+                                <form method="POST" action="{{ route('admin.blog.destroy', $post) }}" class="d-inline" onsubmit="return confirm('Delete post?');">@csrf @method('DELETE')<button class="btn btn-sm btn-outline-danger">&times;</button></form>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr><td colspan="5" class="text-center text-muted py-4">No posts yet. <a href="{{ route('admin.blog.create') }}">Write the first one</a>.</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,0 +1,35 @@
+<x-layouts.marketing-page
+    title="Blog"
+    description="Community Commerce insights for local businesses and communities: turn real-world partnerships into foot traffic, members, and repeat visits."
+    :canonical="route('blog.index')"
+>
+    <section class="mx-auto max-w-6xl px-6 py-16">
+        <header class="max-w-2xl">
+            <p class="font-montserrat text-sm font-bold uppercase tracking-widest text-off-black/50">Community Commerce</p>
+            <h1 class="mt-3 font-montserrat text-4xl font-black uppercase tracking-tight md:text-5xl">The Kolabing blog</h1>
+            <p class="mt-4 text-lg text-off-black/70">Real playbooks for local businesses and communities: foot traffic without paid ads, event marketing that actually works, and how the two sides grow together.</p>
+        </header>
+
+        @if ($posts->isEmpty())
+            <p class="mt-16 text-off-black/60">New articles are on the way. Check back soon.</p>
+        @else
+            <div class="mt-12 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                @foreach ($posts as $post)
+                    <article class="flex flex-col overflow-hidden rounded-2xl border border-off-black/10 bg-white transition hover:shadow-lg">
+                        @if ($post->cover_image_url)
+                            <a href="{{ route('blog.show', $post) }}"><img src="{{ $post->cover_image_url }}" alt="{{ $post->title }}" class="aspect-[16/9] w-full object-cover"></a>
+                        @endif
+                        <div class="flex flex-1 flex-col p-6">
+                            <time datetime="{{ $post->published_at->toDateString() }}" class="text-xs font-semibold uppercase tracking-wide text-off-black/40">{{ $post->published_at->format('d M Y') }}</time>
+                            <h2 class="mt-2 font-montserrat text-xl font-bold leading-tight"><a href="{{ route('blog.show', $post) }}" class="hover:text-primary">{{ $post->title }}</a></h2>
+                            <p class="mt-3 flex-1 text-sm text-off-black/70">{{ $post->description }}</p>
+                            <a href="{{ route('blog.show', $post) }}" class="mt-4 text-sm font-bold text-off-black hover:text-primary">Read more &rarr;</a>
+                        </div>
+                    </article>
+                @endforeach
+            </div>
+
+            <div class="mt-12">{{ $posts->links() }}</div>
+        @endif
+    </section>
+</x-layouts.marketing-page>

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -1,0 +1,62 @@
+@php
+    $articleSchema = [
+        '@context' => 'https://schema.org',
+        '@type' => 'Article',
+        'headline' => $post->title,
+        'description' => $post->description,
+        'datePublished' => optional($post->published_at)->toIso8601String(),
+        'dateModified' => $post->updated_at->toIso8601String(),
+        'author' => ['@type' => 'Person', 'name' => $post->author_name],
+        'publisher' => [
+            '@type' => 'Organization',
+            'name' => 'Kolabing',
+            'logo' => ['@type' => 'ImageObject', 'url' => url('/brand/kolabing-logo.png')],
+        ],
+        'mainEntityOfPage' => ['@type' => 'WebPage', '@id' => route('blog.show', $post)],
+    ];
+    if ($post->cover_image_url) {
+        $articleSchema['image'] = $post->cover_image_url;
+    }
+@endphp
+<x-layouts.marketing-page
+    :title="$post->title"
+    :description="$post->description"
+    :canonical="route('blog.show', $post)"
+    :image="$post->cover_image_url"
+    og-type="article"
+>
+    <x-slot:head>
+        <script type="application/ld+json">
+            {!! json_encode($articleSchema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+        </script>
+    </x-slot:head>
+
+    <article class="mx-auto max-w-3xl px-6 py-16">
+        <nav class="text-sm text-off-black/50"><a href="{{ route('blog.index') }}" class="hover:text-off-black">&larr; All articles</a></nav>
+        <header class="mt-6">
+            <time datetime="{{ $post->published_at->toDateString() }}" class="text-xs font-semibold uppercase tracking-wide text-off-black/40">{{ $post->published_at->format('d M Y') }}</time>
+            <h1 class="mt-2 font-montserrat text-4xl font-black leading-tight tracking-tight md:text-5xl">{{ $post->title }}</h1>
+            <p class="mt-4 text-lg text-off-black/70">{{ $post->description }}</p>
+            <p class="mt-4 text-sm text-off-black/60">By {{ $post->author_name }}@if ($post->author_title), {{ $post->author_title }}@endif</p>
+        </header>
+
+        @if ($post->cover_image_url)
+            <img src="{{ $post->cover_image_url }}" alt="{{ $post->title }}" class="mt-8 aspect-[16/9] w-full rounded-2xl object-cover">
+        @endif
+
+        <div class="prose prose-lg mt-8 max-w-none prose-headings:font-montserrat prose-a:text-off-black">
+            {!! $post->body !!}
+        </div>
+
+        @if ($related->isNotEmpty())
+            <aside class="mt-16 border-t border-off-black/10 pt-10">
+                <h2 class="font-montserrat text-lg font-bold uppercase tracking-wide">Keep reading</h2>
+                <ul class="mt-4 space-y-3">
+                    @foreach ($related as $item)
+                        <li><a href="{{ route('blog.show', $item) }}" class="font-medium hover:text-primary">{{ $item->title }}</a></li>
+                    @endforeach
+                </ul>
+            </aside>
+        @endif
+    </article>
+</x-layouts.marketing-page>

--- a/resources/views/components/layouts/marketing-page.blade.php
+++ b/resources/views/components/layouts/marketing-page.blade.php
@@ -4,7 +4,14 @@
     'canonical',
     'locale' => 'en',
     'alternates' => null,
+    'image' => null,
+    'ogType' => 'website',
 ])
+@php
+    $ogImage = $image
+        ? (str_starts_with($image, 'http') ? $image : url($image))
+        : url('/social-preview.svg');
+@endphp
 <!DOCTYPE html>
 <html lang="{{ $locale }}">
 <head>
@@ -19,17 +26,17 @@
             <link rel="alternate" hreflang="{{ $alternate['hreflang'] }}" href="{{ $alternate['href'] }}">
         @endforeach
     @endisset
-    <meta property="og:type" content="website">
+    <meta property="og:type" content="{{ $ogType }}">
     <meta property="og:site_name" content="Kolabing">
     <meta property="og:title" content="{{ $title }} | Kolabing">
     <meta property="og:description" content="{{ $description }}">
     <meta property="og:url" content="{{ $canonical }}">
-    <meta property="og:image" content="{{ url('/social-preview.svg') }}">
-    <meta property="og:image:alt" content="Kolabing local business and community collaboration platform">
+    <meta property="og:image" content="{{ $ogImage }}">
+    <meta property="og:image:alt" content="{{ $title }}">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ $title }} | Kolabing">
     <meta name="twitter:description" content="{{ $description }}">
-    <meta name="twitter:image" content="{{ url('/social-preview.svg') }}">
+    <meta name="twitter:image" content="{{ $ogImage }}">
     <meta name="theme-color" content="#0D1216">
     <link rel="icon" href="/favicon.ico?v=3" sizes="any">
     <link rel="icon" type="image/png" href="/favicon-512.png?v=3">
@@ -56,6 +63,18 @@
             },
         };
     </script>
+    <script type="application/ld+json">
+        {!! json_encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'Organization',
+            'name' => 'Kolabing',
+            'url' => route('home'),
+            'logo' => url('/brand/kolabing-logo.png'),
+            'description' => 'Kolabing helps local businesses and communities plan partnerships that turn events into foot traffic, member value, and repeat visits.',
+            'email' => 'support@kolabing.com',
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+    </script>
+    {{ $head ?? '' }}
 </head>
 <body class="bg-off-white text-off-black font-sans">
     <header class="border-b border-off-black/10 bg-white/90 backdrop-blur">
@@ -66,6 +85,7 @@
             <nav class="flex flex-wrap items-center gap-4 text-sm font-medium text-off-black/70">
                 <a href="{{ route('for-businesses') }}" class="hover:text-off-black">Businesses</a>
                 <a href="{{ route('for-communities') }}" class="hover:text-off-black">Communities</a>
+                <a href="{{ route('blog.index') }}" class="hover:text-off-black">Blog</a>
                 <a href="{{ route('support') }}" class="hover:text-off-black">Support</a>
                 <a href="{{ route('privacy') }}" class="hover:text-off-black">Privacy</a>
                 <a href="{{ route('terms') }}" class="hover:text-off-black">Terms</a>
@@ -84,6 +104,7 @@
                 <p class="mt-2 max-w-xl text-sm text-white/70">Kolabing helps local businesses and communities plan partnerships that turn events into foot traffic, member value, and repeat visits.</p>
             </div>
             <div class="flex flex-wrap gap-4 text-sm text-white/70">
+                <a href="{{ route('blog.index') }}" class="hover:text-primary">Blog</a>
                 <a href="{{ route('support') }}" class="hover:text-primary">Support</a>
                 <a href="mailto:support@kolabing.com" class="hover:text-primary">support@kolabing.com</a>
                 <a href="{{ route('sitemap') }}" class="hover:text-primary">Sitemap</a>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,6 +5,49 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>Kolabing — Local Business &amp; Community Collaboration</title>
+  <meta name="description" content="Kolabing connects local businesses with nearby communities to plan real-world collaborations that drive foot traffic, members, and repeat visits. Live in Barcelona.">
+  <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+  <link rel="canonical" href="{{ route('home') }}">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Kolabing">
+  <meta property="og:title" content="Kolabing — Local Business &amp; Community Collaboration">
+  <meta property="og:description" content="Connect with nearby communities to plan real-world collaborations that drive foot traffic, members, and repeat visits.">
+  <meta property="og:url" content="{{ route('home') }}">
+  <meta property="og:image" content="{{ url('/social-preview.svg') }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kolabing — Local Business &amp; Community Collaboration">
+  <meta name="twitter:description" content="Connect with nearby communities to plan real-world collaborations that drive foot traffic, members, and repeat visits.">
+  <meta name="twitter:image" content="{{ url('/social-preview.svg') }}">
+  <script type="application/ld+json">
+  {!! json_encode([
+      '@context' => 'https://schema.org',
+      '@graph' => [
+          [
+              '@type' => 'Organization',
+              'name' => 'Kolabing',
+              'url' => route('home'),
+              'logo' => url('/brand/kolabing-logo.png'),
+              'description' => 'Kolabing helps local businesses and communities plan partnerships that turn events into foot traffic, member value, and repeat visits.',
+              'email' => 'support@kolabing.com',
+          ],
+          [
+              '@type' => 'WebSite',
+              'name' => 'Kolabing',
+              'url' => route('home'),
+          ],
+          [
+              '@type' => 'FAQPage',
+              'mainEntity' => [
+                  ['@type' => 'Question', 'name' => 'Is it free for communities?', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Yes, Kolabing is always free for community leaders and groups.']],
+                  ['@type' => 'Question', 'name' => 'How do businesses get matched?', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'You post a Kolab and our system surfaces communities that match your location, audience, and goal.']],
+                  ['@type' => 'Question', 'name' => 'What kind of collaborations can I create?', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Events, venue partnerships, product trials, UGC sessions, weekly recurring meetups, anything involving real people in real places.']],
+                  ['@type' => 'Question', 'name' => 'Where is Kolabing available?', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Currently live in Barcelona, expanding to more cities soon.']],
+                  ['@type' => 'Question', 'name' => 'Can I cancel anytime?', 'acceptedAnswer' => ['@type' => 'Answer', 'text' => 'Yes, no long-term commitment. Paid plans for businesses can be cancelled at any time.']],
+              ],
+          ],
+      ],
+  ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+  </script>
   <link rel="icon" href="/favicon.ico?v=3" sizes="any">
   <link rel="icon" type="image/png" href="/favicon-512.png?v=3">
   <link rel="apple-touch-icon" href="/favicon-512.png?v=3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Admin\AuthController as AdminAuthController;
 use App\Http\Controllers\Admin\BadgeController as AdminBadgeController;
+use App\Http\Controllers\Admin\BlogController as AdminBlogController;
 use App\Http\Controllers\Admin\ChallengeController as AdminChallengeController;
 use App\Http\Controllers\Admin\ChallengeDefaultsController as AdminChallengeDefaultsController;
 use App\Http\Controllers\Admin\CommunityVerificationController as AdminCommunityVerificationController;
@@ -21,8 +22,10 @@ use App\Http\Controllers\Admin\TaskController as AdminTaskController;
 use App\Http\Controllers\Admin\TypeController as AdminTypeController;
 use App\Http\Controllers\Admin\XpEarnRuleController as AdminXpEarnRuleController;
 use App\Http\Controllers\Admin\XpLevelController as AdminXpLevelController;
+use App\Http\Controllers\BlogController;
 use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\PasswordResetPageController;
+use App\Models\BlogPost;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -68,6 +71,14 @@ Route::middleware(['auth:admin', 'maintainer'])->prefix('admin')->as('admin.')->
 
     Route::get('/reviews', [AdminReviewController::class, 'index'])->name('reviews.index');
     Route::post('/reviews/{review}/toggle-comment', [AdminReviewController::class, 'toggleComment'])->name('reviews.toggle-comment');
+
+    // Marketing / SEO blog — maintainer-authored posts served publicly at /blog.
+    Route::get('/blog', [AdminBlogController::class, 'index'])->name('blog.index');
+    Route::get('/blog/create', [AdminBlogController::class, 'create'])->name('blog.create');
+    Route::post('/blog', [AdminBlogController::class, 'store'])->name('blog.store');
+    Route::get('/blog/{post}/edit', [AdminBlogController::class, 'edit'])->name('blog.edit');
+    Route::put('/blog/{post}', [AdminBlogController::class, 'update'])->name('blog.update');
+    Route::delete('/blog/{post}', [AdminBlogController::class, 'destroy'])->name('blog.destroy');
 
     // Company / legal details — populate the public Terms + Privacy pages and
     // the consent version that drives the mobile re-consent gate.
@@ -176,6 +187,9 @@ Route::view('/terms', 'pages.terms')->name('terms');
 Route::view('/es/privacy', 'pages.es.privacy')->name('privacy.es');
 Route::view('/es/terms', 'pages.es.terms')->name('terms.es');
 
+Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
+Route::get('/blog/{post}', [BlogController::class, 'show'])->name('blog.show');
+
 Route::get('/sitemap.xml', function () {
     $urls = [
         route('home'),
@@ -187,7 +201,12 @@ Route::get('/sitemap.xml', function () {
         route('terms'),
         route('privacy.es'),
         route('terms.es'),
+        route('blog.index'),
     ];
+
+    foreach (BlogPost::query()->published()->orderByDesc('published_at')->pluck('slug') as $slug) {
+        $urls[] = route('blog.show', $slug);
+    }
 
     return response()->view('sitemap', [
         'urls' => $urls,
@@ -196,7 +215,7 @@ Route::get('/sitemap.xml', function () {
 })->name('sitemap');
 
 Route::get('/llms.txt', function () {
-    $content = implode("\n", [
+    $lines = [
         '# Kolabing',
         '',
         'Kolabing is a collaboration platform that helps local businesses and community groups launch in-person partnerships, events, and repeatable growth campaigns.',
@@ -205,14 +224,25 @@ Route::get('/llms.txt', function () {
         '- Home: '.route('home'),
         '- For businesses: '.route('for-businesses'),
         '- For communities: '.route('for-communities'),
+        '- Blog: '.route('blog.index'),
         '- Support: '.route('support'),
         '- Privacy: '.route('privacy'),
         '- Terms: '.route('terms'),
-        '',
-        'Contact: support@kolabing.com',
-    ]);
+    ];
 
-    return response($content, 200)->header('Content-Type', 'text/plain; charset=UTF-8');
+    $posts = BlogPost::query()->published()->orderByDesc('published_at')->limit(20)->get(['slug', 'title']);
+    if ($posts->isNotEmpty()) {
+        $lines[] = '';
+        $lines[] = 'Recent articles:';
+        foreach ($posts as $post) {
+            $lines[] = '- '.$post->title.': '.route('blog.show', $post->slug);
+        }
+    }
+
+    $lines[] = '';
+    $lines[] = 'Contact: support@kolabing.com';
+
+    return response(implode("\n", $lines), 200)->header('Content-Type', 'text/plain; charset=UTF-8');
 })->name('llms');
 
 Route::get('/.well-known/security.txt', function () {

--- a/tests/Feature/Admin/BlogAdminTest.php
+++ b/tests/Feature/Admin/BlogAdminTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\BlogPost;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class BlogAdminTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function maintainer(): User
+    {
+        return User::factory()->create(['is_maintainer' => true]);
+    }
+
+    public function test_index_rejects_non_maintainer(): void
+    {
+        $this->actingAs(User::factory()->create(['is_maintainer' => false]), 'admin')
+            ->get('/admin/blog')
+            ->assertForbidden();
+    }
+
+    public function test_index_redirects_a_guest_to_login(): void
+    {
+        $this->get('/admin/blog')->assertRedirect('/admin/login');
+    }
+
+    public function test_maintainer_can_create_a_post(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post('/admin/blog', [
+                'title' => 'How to get foot traffic without paid ads',
+                'slug' => 'foot-traffic-without-paid-ads',
+                'description' => 'A local-business playbook.',
+                'body' => '<p>Partner with a nearby community.</p>',
+                'author_name' => 'Clark',
+                'locale' => 'en',
+                'published_at' => now()->toDateTimeString(),
+            ])
+            ->assertRedirect(route('admin.blog.index'));
+
+        $this->assertDatabaseHas('blog_posts', [
+            'slug' => 'foot-traffic-without-paid-ads',
+            'author_name' => 'Clark',
+        ]);
+    }
+
+    public function test_slug_must_be_unique(): void
+    {
+        BlogPost::factory()->create(['slug' => 'taken']);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post('/admin/blog', [
+                'title' => 'Dup', 'slug' => 'taken', 'description' => 'x', 'body' => '<p>x</p>',
+                'author_name' => 'Clark', 'locale' => 'en',
+            ])
+            ->assertSessionHasErrors('slug');
+    }
+
+    public function test_maintainer_can_update_and_delete(): void
+    {
+        $post = BlogPost::factory()->create(['title' => 'Old']);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put("/admin/blog/{$post->slug}", [
+                'title' => 'New title', 'slug' => $post->slug, 'description' => 'y',
+                'body' => '<p>y</p>', 'author_name' => 'Clark', 'locale' => 'en',
+                'published_at' => now()->toDateTimeString(),
+            ])
+            ->assertRedirect(route('admin.blog.index'));
+        $this->assertDatabaseHas('blog_posts', ['id' => $post->id, 'title' => 'New title']);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->delete("/admin/blog/{$post->slug}")
+            ->assertRedirect(route('admin.blog.index'));
+        $this->assertDatabaseMissing('blog_posts', ['id' => $post->id]);
+    }
+}

--- a/tests/Feature/BlogPostTest.php
+++ b/tests/Feature/BlogPostTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\BlogPost;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class BlogPostTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_index_lists_published_and_hides_drafts_and_future(): void
+    {
+        BlogPost::factory()->create(['title' => 'Foot traffic without ads', 'published_at' => now()->subDay()]);
+        BlogPost::factory()->draft()->create(['title' => 'Secret draft']);
+        BlogPost::factory()->scheduled()->create(['title' => 'Coming soon post']);
+
+        $this->get('/blog')
+            ->assertOk()
+            ->assertSee('Foot traffic without ads')
+            ->assertDontSee('Secret draft')
+            ->assertDontSee('Coming soon post');
+    }
+
+    public function test_show_renders_published_post_with_article_schema(): void
+    {
+        BlogPost::factory()->create([
+            'slug' => 'foot-traffic-without-paid-ads',
+            'title' => 'How to get foot traffic without paid ads',
+            'body' => '<h2>Answer</h2><p>Partner with a local community.</p>',
+            'published_at' => now()->subDay(),
+        ]);
+
+        $this->get('/blog/foot-traffic-without-paid-ads')
+            ->assertOk()
+            ->assertSee('How to get foot traffic without paid ads')
+            ->assertSee('Partner with a local community.', false)
+            ->assertSee('"@type":"Article"', false)
+            ->assertSee('"@type":"Organization"', false);
+    }
+
+    public function test_show_404s_for_a_draft(): void
+    {
+        BlogPost::factory()->draft()->create(['slug' => 'hidden-draft']);
+
+        $this->get('/blog/hidden-draft')->assertNotFound();
+    }
+
+    public function test_show_404s_for_a_scheduled_future_post(): void
+    {
+        BlogPost::factory()->scheduled()->create(['slug' => 'future-post']);
+
+        $this->get('/blog/future-post')->assertNotFound();
+    }
+
+    public function test_sitemap_includes_published_post_and_blog_index_but_not_drafts(): void
+    {
+        BlogPost::factory()->create(['slug' => 'live-post', 'published_at' => now()->subDay()]);
+        BlogPost::factory()->draft()->create(['slug' => 'draft-post']);
+
+        $this->get('/sitemap.xml')
+            ->assertOk()
+            ->assertSee(url('/blog'), false)
+            ->assertSee(url('/blog/live-post'), false)
+            ->assertDontSee(url('/blog/draft-post'), false);
+    }
+
+    public function test_llms_txt_lists_published_posts(): void
+    {
+        BlogPost::factory()->create(['slug' => 'llms-post', 'title' => 'Community event marketing', 'published_at' => now()->subDay()]);
+
+        $this->get('/llms.txt')
+            ->assertOk()
+            ->assertSee('Community event marketing')
+            ->assertSee(url('/blog/llms-post'), false);
+    }
+
+    public function test_homepage_emits_canonical_and_faq_schema(): void
+    {
+        $this->get('/')
+            ->assertOk()
+            ->assertSee('<link rel="canonical"', false)
+            ->assertSee('"@type":"FAQPage"', false);
+    }
+}


### PR DESCRIPTION
## Summary
Stands up a maintainer-authored marketing blog on kolabing.com and closes the site's SEO/GEO gaps. Part of Clark taking ownership of the Kolabing blog + SEO/GEO workstream (2026-08-14 Fathom follow-up). Phase 1 of a phased roadmap; content articles + city pages follow.

## Linked tracking item
Closes #124

## Type of change
- [x] ✨ Feature

## Changes
- `blog_posts` table + `BlogPost` model + factory (uuid PK, `slug` route key, `published` scope, `isPublished()`).
- Public **`/blog`** + **`/blog/{slug}`** (`BlogController`) rendered with the existing `x-layouts.marketing-page` layout, so each post gets title/description/canonical/OG/Twitter for free; draft/future posts 404.
- Admin **`/admin/blog/*`** CRUD (`Admin\BlogController`, maintainer-gated like the rest of `/admin`) + `Store/UpdateBlogPostRequest` + AdminLTE sidebar entry + index/edit views.
- **SEO/GEO:** Article JSON-LD on each post; Organization JSON-LD site-wide (layout); Organization + WebSite + **FAQPage** JSON-LD on the homepage (built from the real on-page FAQ); a `head` slot on the layout for per-page schema; `image`/`ogType` props.
- **Homepage fix:** `welcome.blade.php` had no meta description / canonical / OG at all (it doesn't use the layout) — added them.
- **Discovery:** `/sitemap.xml` and `/llms.txt` now include published blog posts.
- 2 feature test files (public + admin); `BACKLOG.md` synced (BE-NF-16).

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — web-only (public marketing site + the `/admin` operator panel). No API contract, JSON payload, endpoint, enum, auth, or error-code change.

## Database / migrations
- [x] Includes migrations — additive & reversible

**Migration notes:** one new isolated table `blog_posts` (create up / dropIfExists down); no backfill, touches no existing table. The `master` environment's deploy command already runs `php artisan migrate --force`, so it applies on merge-deploy.

## Testing
- [ ] `php artisan test` passes — the build host (serra-ops-01) lacks the `pdo_sqlite` PHP extension, so the sqlite `:memory:` suite cannot run there (the whole pre-existing suite errors identically) — **validates in CI**, same limitation as #122. Instead verified locally: `php artisan route:list --path=blog` shows all 8 routes; `php artisan view:cache` compiles every Blade view (incl. the new blog views + edited layout/homepage) with no errors.
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path (routes register + views compile)

Test coverage added: public index lists published & hides drafts/future; show 404s on draft/future; Article + Organization JSON-LD present; sitemap includes published (not draft) posts; llms.txt lists posts; homepage emits canonical + FAQPage schema; admin CRUD gated to maintainers; slug uniqueness; create/update/delete.

## Docs & rules updated
- [x] `BACKLOG.md` updated (added BE-NF-16; bumped Last updated)
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` — N/A (no role/paywall/feed/onboarding/subscription surface touched)
- [ ] `docs/BACKEND-SCHEMA.md` — N/A (that file is referenced by `CLAUDE.md` but does not exist in the repo; `blog_posts` is a new isolated table)

## Screenshots / notes
- **Author byline** is free-text (`author_name` / `author_title`), not an FK — keeps marketing content decoupled from `profiles`/`users` and drives the Article schema `author`.
- **Post body** is trusted maintainer-authored HTML rendered in a Tailwind `prose` container (only maintainers can reach `/admin/blog`).
- **Next (Phase 2, Clark):** first Community-Commerce articles (foot-traffic-without-ads, community event marketing, sponsorship vs influencer) + a Barcelona city landing page with LocalBusiness schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
