### PR TITLE
feat(auth): accept web Google client id (Kolabing Web App enabler #1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ AWS_USE_PATH_STYLE_ENDPOINT=false
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_ID_IOS=
 GOOGLE_CLIENT_ID_ANDROID=
+# Web OAuth 2.0 client id (Google Identity Services on kolabing.com) — lets the
+# web app sign in with Google against the same POST /api/v1/auth/google endpoint.
+GOOGLE_CLIENT_ID_WEB=
 GOOGLE_PLACES_API_KEY=
 
 # OneSignal

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@
 > the authoritative app backlog. The live cross-repo board is **Kolabing Engineering**
 > (GitHub Project 4, owner `kolabing`).
 >
-> Last updated: 2026-08-15 (BE-NF-16 blog engine + SEO/GEO built, branch feat/blog-engine-seo-geo: public /blog + admin /admin/blog CRUD + Article/Organization/WebSite/FAQPage JSON-LD + homepage meta/OG + sitemap/llms now include posts. Prior 2026-08-02: BE-FX-11 F1 host_profile_id on EventResource + BE-FX-8 chat
+> Last updated: 2026-08-15 (BE-NF-18 Kolabing Web App epic #128 opened + plan doc; enabler 1 = web Google login (GOOGLE_CLIENT_ID_WEB audience), branch feat/web-google-login. Prior same day: BE-NF-16 blog engine + SEO/GEO built, branch feat/blog-engine-seo-geo: public /blog + admin /admin/blog CRUD + Article/Organization/WebSite/FAQPage JSON-LD + homepage meta/OG + sitemap/llms now include posts. Prior 2026-08-02: BE-FX-11 F1 host_profile_id on EventResource + BE-FX-8 chat
 > last_message preview + BE-FX-9 factory-avatar distinctness — fixed in code on branch
 > fix/qa-batch-host-profile-chat-preview-avatars; app half = kolabing-app PR 108. Prior:
 > added BE-FX-10 — Explore browse feed now hides date-exhausted
@@ -27,6 +27,7 @@ _Planned backend work that does not exist yet._
 | BE-NF-5 | **Admin-managed gamification economy** | Server-owned reward economy so the app stops hardcoding XP/badges. `GET /gamification/config` + `xp_earn_rules` (drives `point_ledger` + display), badge requirements, referral/withdrawal economics. Prompts: `docs/tickets/2026-06-01-admin-challenges-prompt.md`, `docs/tickets/2026-06-01-admin-xp-economy-prompt.md`. | Not started |
 | BE-NF-10 | **SMS notification channel** | Transactional SMS (Twilio/Vonage) alongside push: application accepted, kolab scheduled/reminder, check-in. Needs provider integration + per-user phone capture/verify + channel preference. **[VERIFY with Daniel]:** provider, trigger events, opt-in, cost ceiling. | Not started |
 | BE-NF-15 | **Scale audit & query optimization** | List endpoints issue O(N) queries/page (`EventResource` ~3 counts/event; `ChatService::visibleThreads` per-thread unread count; unpaginated `GET /chats`; non-index-friendly `COALESCE` time filter). Instrument → seed at scale → k6 load-test → fix via `withCount`/eager/grouped counts, cursor pagination + caps, covering indexes, chunked fan-out. Ticket: `docs/tickets/2026-06-05-backend-scale-audit-optimization.md`. | Spec ready — not started |
+| BE-NF-18 | **Kolabing Web App** (epic #128, plan `docs/plans/2026-08-15-kolabing-web-app-plan.md`) | Web client on the existing `/api/v1` (same flow as mobile): community/business login+register, buy+manage subscription, Kolab CRUD, feed for paid users; acquire+sell on web then nudge to the app (slight nudge after purchase). Arch = Blade + Alpine + axios in kolabing-v2, same-origin `kolabing.com/app` (token auth, no CORS/session rewrite needed). Backend enablers: (1) **web Google login** — `GOOGLE_CLIENT_ID_WEB` audience in `GoogleAuthService`, branch `feat/web-google-login` ✅ built; (2) buy = PR #127; (3) `POST /me/subscription/portal` Billing Portal (after #127); (4) paid-feed blur (closes ROLES §4). | In progress — enabler 1 (PR), rest queued |
 
 ---
 

--- a/app/Services/GoogleAuthService.php
+++ b/app/Services/GoogleAuthService.php
@@ -23,17 +23,30 @@ class GoogleAuthService
     {
         $this->client = new GoogleClient;
 
-        // Set all client IDs for token verification
-        $clientIds = array_filter([
-            config('services.google.client_id'),
-            config('services.google.client_id_ios'),
-            config('services.google.client_id_android'),
-        ]);
+        // Set the primary client ID for token verification.
+        $clientIds = $this->verificationClientIds();
 
         if (! empty($clientIds)) {
             // The first client ID is the primary one
             $this->client->setClientId($clientIds[0]);
         }
+    }
+
+    /**
+     * The Google OAuth client IDs a token audience may match, in priority order.
+     * A Google ID token's `aud` varies by platform (web / iOS / Android), so a
+     * token is accepted if it was issued for any of our configured clients.
+     *
+     * @return list<string>
+     */
+    public function verificationClientIds(): array
+    {
+        return array_values(array_filter([
+            config('services.google.client_id'),
+            config('services.google.client_id_ios'),
+            config('services.google.client_id_android'),
+            config('services.google.client_id_web'),
+        ]));
     }
 
     /**
@@ -44,11 +57,7 @@ class GoogleAuthService
     public function verifyIdToken(string $idToken): ?array
     {
         try {
-            $validClientIds = array_values(array_filter([
-                config('services.google.client_id'),
-                config('services.google.client_id_ios'),
-                config('services.google.client_id_android'),
-            ]));
+            $validClientIds = $this->verificationClientIds();
 
             // Try each client ID because the token audience varies by platform
             $payload = null;

--- a/config/services.php
+++ b/config/services.php
@@ -52,6 +52,7 @@ return [
         'client_id' => env('GOOGLE_CLIENT_ID'),
         'client_id_ios' => env('GOOGLE_CLIENT_ID_IOS'),
         'client_id_android' => env('GOOGLE_CLIENT_ID_ANDROID'),
+        'client_id_web' => env('GOOGLE_CLIENT_ID_WEB'),
     ],
 
     'google_places' => [

--- a/docs/plans/2026-08-15-kolabing-web-app-plan.md
+++ b/docs/plans/2026-08-15-kolabing-web-app-plan.md
@@ -1,0 +1,76 @@
+# Kolabing Web App — design & implementation plan
+
+**Date:** 2026-08-15 · **Owner:** Clark (build) · **Requested by:** Volkan · **Epic:** #128
+
+Bring the core Kolabing flows to the web, consuming the existing `/api/v1` (same flow as
+the mobile app). **Goal: acquire users and take sales on the web, then nudge them into the
+mobile app** (a slight nudge **after purchase**; the web stays usable).
+
+## Scope (Volkan)
+- Community + business **login / register** on web
+- **Buy + manage** subscription
+- **Create & manage Kolabs** (CRUD)
+- **Feed for paid users**
+- Reuse the existing API; continue the same flow as the app; **redirect web users to the mobile app**
+
+## Architecture (decided)
+Blade + **Alpine.js** + `axios` ("SPA-lite") inside **kolabing-v2** — same repo/deploy as the
+marketing site + admin panel — calling `/api/v1` exactly like the mobile client. Domain:
+`kolabing.com/app`.
+
+Rationale: the repo has no SPA framework today (just Vite + Tailwind v4 + axios). Adding
+Vue/React/Inertia means a new dependency + a second build/deploy target; Blade+Alpine reuses
+the existing stack and the marketing→signup funnel on one domain and ships far faster. Since
+the endgame is to push users into the mobile app, the web is a **conversion surface**, not a
+full-fidelity app. A Vue/React SPA remains the alternative if we later want a richer web product.
+
+### Auth model (grounded)
+The API is **token-based Sanctum** and already supports **both** Google (`auth/google`) **and
+email/password** (`auth/register/{business,community}`, `auth/login`, forgot/reset) — the
+"Google-only" line in `CLAUDE.md` is stale. Every endpoint returns a bearer token + refresh token.
+
+Because the web app is **same-origin** (`kolabing.com/app` → `kolabing.com/api/v1`), it can call
+the existing API directly with the bearer token — **no CORS and no Sanctum stateful/cookie rewrite
+required**. This is the same flow as mobile, per Volkan. Token hygiene: keep the access token in
+memory and (optionally, later) hold the refresh token in an httpOnly cookie to reduce XSS exposure.
+A cookie-session (Sanctum stateful) rewrite is only worth doing if we choose a **separate** web
+origin (e.g. `app.kolabing.com`) — deferred unless that decision changes.
+
+## Backend enablers (small, independent PRs)
+1. **Web Google login** — accept a web Google client id (`GOOGLE_CLIENT_ID_WEB`) as a valid token
+   audience in `GoogleAuthService` (previously only iOS/Android/primary). Web uses Google Identity
+   Services JS → posts the id_token to the existing `auth/google`. **← this PR.**
+2. **Subscription buy** — Stripe Checkout: **PR #127** (in review).
+3. **Subscription manage/cancel** — `POST /me/subscription/portal` → Stripe Billing Portal URL.
+   *(Depends on PR #127's `StripeService`; lands after #127 merges.)*
+4. **Paid-feed gating** — implement the identity-blur flag on the discovery resource (closes the
+   open `ROLES-BACKEND-DB-MAP.md` §4 gap): unpaid business → blurred feed + upgrade CTA; paid → full.
+   Benefits web **and** mobile.
+5. *(Optional)* email/password polish for web if we lean on it over Google.
+
+## Web pages (Blade + Alpine, on kolabing.com)
+- `/login` + `/register` — business/community toggle, "Sign in with Google" + email/password, the
+  extended-profile form, `accepted_terms`.
+- `/app` — authenticated dashboard (my Kolabs, applications, collaborations, profile).
+- `/app/kolabs` — list + **create/edit/publish/close** (business + community-seeking).
+- `/app/feed` — Explore/discovery; **paid → full, unpaid → blurred + upgrade CTA**.
+- `/app/subscription` — status + **Buy** (checkout) + **Manage** (portal).
+- **App-handoff surface** — store badges + `kolabing://` deep link + smart app banner, shown as a
+  **slight nudge after purchase**; the web-created account + web-purchased subscription are already
+  active in the app on first login.
+
+## Sequence
+- **Phase 0 (backend enablers):** #127 (buy) → web Google login (#1) → portal (#3, after #127) →
+  feed blur (#4).
+- **Phase 1 (web client):** auth pages → **subscription page first** (this is "do sales from web")
+  → dashboard + Kolab CRUD → feed → app-handoff.
+- **Phase 2:** es/i18n, funnel analytics events, polish, SEO on the logged-out → signup path.
+
+## Open items (non-blocking; defaults noted)
+1. **Domain:** `kolabing.com/app` (default — one deploy, no CORS) vs `app.kolabing.com` (would need
+   the cookie-session/CORS enabler).
+2. **Google web vs email/password** as the primary web sign-in (both are supported).
+
+## Verification (per PR)
+`vendor/bin/pint` clean; `php artisan test` (box lacks `pdo_sqlite` → CI-validated, per #122/#125);
+role/paywall-touching PRs (feed blur) update **both** ROLES docs; payments/auth PRs are red-teamed.

--- a/tests/Unit/Services/GoogleAuthServiceTest.php
+++ b/tests/Unit/Services/GoogleAuthServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\GoogleAuthService;
+use Tests\TestCase;
+
+class GoogleAuthServiceTest extends TestCase
+{
+    public function test_verification_client_ids_include_the_web_client_when_configured(): void
+    {
+        config([
+            'services.google.client_id' => 'primary.apps.googleusercontent.com',
+            'services.google.client_id_ios' => 'ios.apps.googleusercontent.com',
+            'services.google.client_id_android' => 'android.apps.googleusercontent.com',
+            'services.google.client_id_web' => 'web.apps.googleusercontent.com',
+        ]);
+
+        $ids = (new GoogleAuthService)->verificationClientIds();
+
+        // Web audience is accepted (so Google Identity Services on kolabing.com works),
+        // and the primary client stays first (it is set as the default on the client).
+        $this->assertContains('web.apps.googleusercontent.com', $ids);
+        $this->assertSame('primary.apps.googleusercontent.com', $ids[0]);
+        $this->assertSame([
+            'primary.apps.googleusercontent.com',
+            'ios.apps.googleusercontent.com',
+            'android.apps.googleusercontent.com',
+            'web.apps.googleusercontent.com',
+        ], $ids);
+    }
+
+    public function test_verification_client_ids_skip_unconfigured_clients(): void
+    {
+        config([
+            'services.google.client_id' => 'primary.apps.googleusercontent.com',
+            'services.google.client_id_ios' => null,
+            'services.google.client_id_android' => null,
+            'services.google.client_id_web' => 'web.apps.googleusercontent.com',
+        ]);
+
+        $ids = (new GoogleAuthService)->verificationClientIds();
+
+        $this->assertSame([
+            'primary.apps.googleusercontent.com',
+            'web.apps.googleusercontent.com',
+        ], $ids);
+    }
+}


### PR DESCRIPTION
## Summary
First backend enabler for the Kolabing Web App (epic #128). Lets the **web** sign in with Google against the existing `POST /api/v1/auth/google` by accepting a web Google client id as a valid token audience. Also lands the full web-app design/implementation plan doc.

## Linked tracking item
Part of #128

## Type of change
- [x] ✨ Feature
- [x] 🧪 Tests
- [x] 📝 Docs

## Changes
- `GoogleAuthService`: extracted `verificationClientIds()` (now includes `services.google.client_id_web`) and use it in both the constructor and `verifyIdToken`. A Google ID token issued for the **web** client is now accepted — symmetric with the existing iOS/Android/primary audiences.
- `config/services.php`: `google.client_id_web` from `GOOGLE_CLIENT_ID_WEB`.
- `.env.example`: `GOOGLE_CLIENT_ID_WEB` documented (Google Identity Services on kolabing.com).
- **Unit test** `GoogleAuthServiceTest`: web id is in the audience set, primary stays first (it is set as the client default), unconfigured clients are skipped.
- **`docs/plans/2026-08-15-kolabing-web-app-plan.md`** — the full web-app design + implementation plan (Blade + Alpine on the existing API, same-origin token auth, subscription buy/manage, Kolab CRUD, paid feed, acquire-then-nudge-to-app after purchase).
- `BACKLOG.md`: BE-NF-18.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** Purely additive — appends one more accepted audience to Google token verification. The iOS/Android token flows are unchanged (same `verifyIdToken` contract, same response). N/A for the app.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A.

## Testing
- [ ] `php artisan test` passes — paste counts: **box has no `pdo_sqlite`, runs in CI** (per #122/#125). Added `tests/Unit/Services/GoogleAuthServiceTest.php` (2 cases).
- [x] `vendor/bin/pint` clean (`{"result":"pass"}`)
- [x] `php -l` clean on changed PHP

## Docs & rules updated
- [x] `BACKLOG.md` updated (BE-NF-18)
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` — N/A (no role/paywall/feed change; this only adds a token audience)
- [ ] `docs/BACKEND-SCHEMA.md` — N/A (no schema change)
- Added `docs/plans/2026-08-15-kolabing-web-app-plan.md`

## Screenshots / notes
**Deploy:** set `GOOGLE_CLIENT_ID_WEB` on prod to the Google Cloud **Web** OAuth 2.0 client id (with `https://kolabing.com` as an authorized JS origin) once the web app ships. No behaviour change until it's set.

**Context / follow-ups (epic #128):** the web app is same-origin (`kolabing.com/app` → `kolabing.com/api/v1`), so it reuses the token API directly — no CORS/Sanctum-stateful rewrite needed (the earlier "web session auth" enabler is therefore near-moot unless we pick a separate `app.` origin). Next enablers: subscription **buy** = PR #127; **manage** = a Stripe Billing Portal endpoint (lands after #127 merges); **paid-feed blur** = closes the open ROLES-BACKEND-DB-MAP §4 gap. Note: `CLAUDE.md`'s "Google OAuth only" line is stale — email/password auth already exists; not touched here.