### PR TITLE
feat(marketing): promote the web panel beside the app + fix the nav CTA

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -110,9 +110,11 @@
     .nav-links { display: flex; align-items: center; gap: 32px; }
     .nav-login { font-weight: 700; opacity: 0.9; }
     .btn-nav {
-      background: var(--dark); color: var(--yellow); padding: 11px 26px;
-      border-radius: 999px; font-weight: 700; font-size: 13px; text-decoration: none; opacity: 1 !important;
-      letter-spacing: 0.02em;
+      /* White, not the brand yellow: the header itself is yellow, so pale-yellow
+         text on the dark pill washed out against the surrounding field. */
+      background: var(--dark); color: #fff; padding: 12px 28px;
+      border-radius: 999px; font-weight: 800; font-size: 14px; text-decoration: none; opacity: 1 !important;
+      letter-spacing: 0.01em;
       transition: background .2s, transform .2s;
     }
     .btn-nav:hover { background: #1c2025; transform: translateY(-1px); }
@@ -540,13 +542,66 @@
       margin: 12px 0;
     }
 
-    /* RIGHT column — phone mockup */
+    /* RIGHT column — the two surfaces Kolabing ships on: the web panel
+       (browser frame, the larger of the two) with the mobile app overlapping it.
+       The panel is drawn in CSS rather than screenshotted so it never goes stale
+       against the real app. */
     .manifesto-phone {
       position: relative;
-      display: flex; align-items: center; justify-content: center;
-      min-height: 520px;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      min-height: 480px;
     }
     .manifesto-phone .phone-wrap { transform: rotate(-4deg); }
+
+    .surface-stack { position: relative; width: 100%; max-width: 500px; }
+
+    .browser-frame {
+      position: relative; z-index: 1;
+      border-radius: 14px; overflow: hidden; background: #fff;
+      transform: rotate(-1.5deg);
+      box-shadow: 0 26px 64px rgba(13,17,20,0.20), 0 2px 8px rgba(13,17,20,0.08);
+    }
+    .browser-bar {
+      display: flex; align-items: center; gap: 6px;
+      padding: 9px 12px; background: #ECE9E2; border-bottom: 1px solid rgba(13,17,20,0.07);
+    }
+    .browser-dot { width: 9px; height: 9px; border-radius: 50%; background: #C6C2BA; flex-shrink: 0; }
+    .browser-url {
+      margin-left: 8px; flex: 1; background: #fff; border-radius: 999px;
+      padding: 4px 12px; font-size: 10px; font-weight: 600; color: #7A7770; letter-spacing: 0.02em;
+    }
+    .browser-body { display: grid; grid-template-columns: 78px 1fr; background: #FBF7EF; height: 252px; }
+    .wp-side {
+      background: #fff; border-right: 1px solid rgba(13,17,20,0.07);
+      padding: 12px 10px; display: flex; flex-direction: column; gap: 8px;
+    }
+    .wp-logo { width: 24px; height: 24px; border-radius: 8px; background: var(--yellow); margin-bottom: 4px; }
+    .wp-nav { height: 9px; border-radius: 999px; background: rgba(13,17,20,0.09); }
+    .wp-nav.is-on { background: var(--yellow); }
+    .wp-main { padding: 12px; display: flex; flex-direction: column; gap: 10px; }
+    .wp-search { height: 22px; border-radius: 999px; background: #fff; border: 1px solid rgba(13,17,20,0.08); }
+    .wp-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 9px; }
+    .wp-card { background: #fff; border: 1px solid rgba(13,17,20,0.07); border-radius: 10px; overflow: hidden; }
+    .wp-card-img { height: 44px; background: linear-gradient(135deg, rgba(255,226,140,0.95), rgba(255,97,20,0.35)); }
+    .wp-card-img.alt { background: linear-gradient(135deg, rgba(13,17,20,0.82), rgba(13,17,20,0.42)); }
+    .wp-card-body { padding: 7px 8px; display: flex; flex-direction: column; gap: 5px; }
+    .wp-line { height: 6px; border-radius: 999px; background: rgba(13,17,20,0.14); }
+    .wp-line.short { width: 55%; background: rgba(13,17,20,0.09); }
+    .wp-tag { width: 34px; height: 8px; border-radius: 999px; background: var(--yellow); }
+
+    /* The phone rides on top of the panel. Scaling lives on this wrapper because
+       the tilt script writes directly to #phoneWrap's transform. */
+    .phone-mini {
+      position: absolute; right: -10px; bottom: -54px; z-index: 3;
+      transform: scale(0.56); transform-origin: bottom right;
+    }
+
+    .surface-caption {
+      margin-top: 84px; text-align: center;
+      font-size: 11px; font-weight: 600; letter-spacing: 0.14em; text-transform: uppercase;
+      color: rgba(13,17,20,0.45);
+    }
+    .surface-caption strong { color: var(--dark); font-weight: 800; }
     .manifesto-phone .phone-glow {
       position: absolute; width: 300px; height: 300px; border-radius: 50%;
       background: radial-gradient(circle, rgba(255,226,140,0.5) 0%, transparent 70%);
@@ -1086,8 +1141,13 @@
       .hero-right { justify-content: center; padding: 0 16px 24px; height: auto; min-height: 440px; }
       .hero h1 { font-size: clamp(2.2rem, 10vw, 56px); width: auto; max-width: 100%; }
       .phone-wrap { transform: rotate(2deg) translateY(0); }
-      .chip-runners { left: 16px; bottom: 20px; }
-      .chip-notification { right: 16px; top: 20px; }
+      .chip-runners { left: 8px; bottom: 4px; }
+      .chip-notification { right: 8px; top: 16px; }
+      .manifesto-phone { min-height: 380px; }
+      .surface-stack { max-width: 400px; }
+      .browser-body { height: 208px; grid-template-columns: 64px 1fr; }
+      .phone-mini { transform: scale(0.46); right: -18px; bottom: -48px; }
+      .surface-caption { margin-top: 58px; }
 
       .manifesto-track { padding: 0 24px; grid-template-columns: 1fr; gap: 40px; }
       .manifesto-headline { font-size: clamp(2.4rem, 10vw, 56px); }
@@ -1139,7 +1199,7 @@
       <a href="#faq">questions</a>
     </span>
     <a class="nav-login" href="{{ $appLogin }}">log in</a>
-    <a class="btn-nav" href="{{ $appRegister }}">get started — free</a>
+    <a class="btn-nav" href="{{ $appRegister }}">get started free</a>
   </nav>
 </header>
 
@@ -1336,9 +1396,9 @@
       </div>
     </div>
 
-    <!-- RIGHT: phone mockup -->
+    <!-- RIGHT: both surfaces — web panel + mobile app -->
     <div class="manifesto-phone fade in" style="transition-delay:.15s">
-      <div class="phone-wrap" id="phoneWrap">
+      <div class="surface-stack">
 
         <!-- Floating chip: runners -->
         <div class="chip chip-runners">
@@ -1358,22 +1418,68 @@
           </div>
         </div>
 
-        <!-- Phone frame -->
-        <div class="phone-frame">
-          <div class="phone-screen">
-            <video autoplay muted loop playsinline onerror="this.parentElement.style.background='#1a1a2e'">
-              <source src="assets/hero2.mp4" type="video/mp4"/>
-              <source src="assets/hero.mp4" type="video/mp4"/>
-            </video>
+        <!-- Web panel -->
+        <div class="browser-frame" role="img" aria-label="The Kolabing web panel at app.kolabing.com">
+          <div class="browser-bar" aria-hidden="true">
+            <span class="browser-dot"></span>
+            <span class="browser-dot"></span>
+            <span class="browser-dot"></span>
+            <div class="browser-url">app.kolabing.com</div>
           </div>
-          <div class="phone-notch" aria-hidden="true"></div>
-          <div class="phone-btn-right" aria-hidden="true"></div>
-          <div class="phone-btn-left-1" aria-hidden="true"></div>
-          <div class="phone-btn-left-2" aria-hidden="true"></div>
+          <div class="browser-body" aria-hidden="true">
+            <aside class="wp-side">
+              <div class="wp-logo"></div>
+              <div class="wp-nav is-on"></div>
+              <div class="wp-nav"></div>
+              <div class="wp-nav"></div>
+              <div class="wp-nav"></div>
+            </aside>
+            <div class="wp-main">
+              <div class="wp-search"></div>
+              <div class="wp-cards">
+                <div class="wp-card">
+                  <div class="wp-card-img"></div>
+                  <div class="wp-card-body"><div class="wp-line"></div><div class="wp-line short"></div></div>
+                </div>
+                <div class="wp-card">
+                  <div class="wp-card-img alt"></div>
+                  <div class="wp-card-body"><div class="wp-line"></div><div class="wp-tag"></div></div>
+                </div>
+                <div class="wp-card">
+                  <div class="wp-card-img alt"></div>
+                  <div class="wp-card-body"><div class="wp-line"></div><div class="wp-line short"></div></div>
+                </div>
+                <div class="wp-card">
+                  <div class="wp-card-img"></div>
+                  <div class="wp-card-body"><div class="wp-line"></div><div class="wp-tag"></div></div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
-        <div class="phone-glow" aria-hidden="true"></div>
+        <!-- Mobile app, riding on top of the panel -->
+        <div class="phone-mini">
+          <div class="phone-wrap" id="phoneWrap">
+            <div class="phone-frame">
+              <div class="phone-screen">
+                <video autoplay muted loop playsinline onerror="this.parentElement.style.background='#1a1a2e'">
+                  <source src="assets/hero2.mp4" type="video/mp4"/>
+                  <source src="assets/hero.mp4" type="video/mp4"/>
+                </video>
+              </div>
+              <div class="phone-notch" aria-hidden="true"></div>
+              <div class="phone-btn-right" aria-hidden="true"></div>
+              <div class="phone-btn-left-1" aria-hidden="true"></div>
+              <div class="phone-btn-left-2" aria-hidden="true"></div>
+            </div>
+            <div class="phone-glow" aria-hidden="true"></div>
+          </div>
+        </div>
+
       </div>
+
+      <p class="surface-caption">one account · <strong>web panel</strong> + <strong>mobile app</strong></p>
     </div>
 
   </div>

--- a/tests/Feature/Marketing/WebAppFunnelTest.php
+++ b/tests/Feature/Marketing/WebAppFunnelTest.php
@@ -31,7 +31,7 @@ class WebAppFunnelTest extends TestCase
         $response->assertOk();
         $response->assertSee('href="'.$this->app_url().'/login"', false);
         $response->assertSee('href="'.$this->app_url().'/register"', false);
-        $response->assertSee('get started — free', false);
+        $response->assertSee('get started free', false);
         // The old nav CTA scrolled to #cta and the hamburger opened nothing.
         $response->assertDontSee('href="#cta"', false);
         $response->assertDontSee('class="menu-icon"', false);
@@ -49,6 +49,19 @@ class WebAppFunnelTest extends TestCase
         $response->assertDontSee('Get it on', false);
         $response->assertDontSee('class="dl-btn"', false);
         $response->assertDontSee('iOS + Android', false);
+    }
+
+    public function test_homepage_journey_section_shows_both_the_web_panel_and_the_app(): void
+    {
+        $response = $this->get('/');
+
+        // The section used to show a phone alone, which sold the mobile app the
+        // site cannot yet link to. It now leads with the web panel.
+        $response->assertSee('class="browser-frame"', false);
+        $response->assertSee('class="browser-url">app.kolabing.com<', false);
+        $response->assertSee('class="phone-mini"', false);
+        $response->assertSee('<strong>web panel</strong>', false);
+        $response->assertSee('<strong>mobile app</strong>', false);
     }
 
     public function test_homepage_final_cta_deep_links_each_role_to_a_prefilled_register(): void


### PR DESCRIPTION
## Summary

Two design fixes on the marketing → web-app funnel: the nav CTA was unreadable, and the journey section sold only the mobile app — the one surface the site cannot link to, since neither store listing is live. It now promotes **both** surfaces the product ships on.

> **Scope note.** This PR originally carried the whole funnel (nav/hero/final-CTA/sticky-bar/layout/blog wiring). Those changes were written in the shared working tree and got swept into this base branch by a parallel session's commit `f917104`, so the rebase correctly dropped them as already-applied. What remains here is the follow-up design work. Base is `feat/kolabing-web-app`, not `master`, because `app.kolabing.com` does not exist on `master` yet.

## Linked tracking item

Closes #139

## Type of change

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes

- **Nav CTA readability.** `.btn-nav` rendered pale brand yellow (`#FFE28C`) on the dark pill while the header behind it is that same yellow — the label washed out against the surrounding field even though its contrast *against the pill* was fine. Now white, one step bolder and larger, and the label drops the em dash: `get started free`.
- **Journey section now promotes the web panel beside the app.** The section ("they visit / they buy / they share it / they come back") showed a phone alone. It now leads with the **web panel** as a browser frame at `app.kolabing.com`, with the phone scaled down and overlapping its corner, captioned *one account · web panel + mobile app*.
  - The panel interior (side nav, search bar, card grid, yellow accents) is **drawn in CSS, not screenshotted**, so it cannot go stale against the real app and needs no new assets.
  - The phone's scale lives on a `.phone-mini` wrapper because the existing tilt script writes `#phoneWrap`'s `transform` directly and would otherwise clobber it.
  - The two floating chips moved up to the shared stack so they float over the whole composition rather than just the phone.
  - The ≤900px breakpoint shrinks the stack, the panel body, and the phone to fit.

## Mobile impact (kolabing-app)

- [x] No mobile changes required
- [ ] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** N/A — one marketing Blade view and its test. No API endpoint, payload, enum, auth flow, or error code is touched.

## Database / migrations

- [x] No schema changes
- [ ] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change (explain rollback below)

**Migration notes:** N/A — no database access is added or changed.

## Testing

- [x] `php artisan test` passes — paste counts: **1488 passed (6861 assertions)**, 0 failures.
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — served the marketing host and confirmed the rendered HTML carries the new nav label, the browser frame with the `app.kolabing.com` chrome, the phone overlay, and all four CTA targets.

`WebAppFunnelTest` follows the new nav label and gains a case pinning both surfaces in the journey section (`browser-frame`, the `app.kolabing.com` URL chrome, `phone-mini`, and the caption), so the section cannot quietly regress to a phone-only design.

> Note for anyone running the suite from a git worktree with a symlinked `vendor/`: Laravel infers its base path from the registered Composer loader, so it resolves to the **main** checkout and silently tests that tree's views instead. Run with `APP_BASE_PATH="$PWD"`. The counts above were taken that way.

## Docs & rules updated

- [x] `BACKLOG.md` updated (work started → moved / completed → removed) — **BE-NF-27** describing this funnel work is already on the base branch (it rode in with `f917104`); this follow-up does not change its scope.
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md` (role/paywall/feed/onboarding surfaces)
- [ ] `docs/BACKEND-SCHEMA.md` (schema / payload / JSON keys)
- [x] No docs impact — presentation only; no role, paywall, feed, onboarding, or schema behaviour changes.

## Screenshots / notes

**No screenshots.** The only browser reachable from this session could not load the local dev server, so the CSS is **not visually verified** — worth eyeballing the journey section at desktop and ≤900px before this ships, particularly the phone's overlap on the panel corner and the caption spacing beneath it.

**Still open, deliberately out of scope**

- `/privacy` and `/terms` (and their `/es` copies) still describe subscriptions as billed exclusively through the Apple App Store. Stripe web checkout now exists and this funnel drives buyers to it, so those pages need a Stripe paragraph — a separate change that needs a legal decision.
- The marketing site stays English-only; nothing links to the web app's `/es` and `/ca` prefixes yet.
