### PR TITLE
fix(landing): keep the header CTA readable on hover

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -104,7 +104,9 @@
     }
     nav { display: flex; align-items: center; gap: 32px; }
     nav a { text-decoration: none; color: var(--dark); font-size: 13px; font-weight: 600; opacity: 0.75; transition: opacity .2s, color .2s; }
-    nav a:hover { opacity: 1; color: var(--dark); }
+    /* Plain nav links only. The filled CTA is a dark pill with white text, so
+       letting this reach it repainted its label near-black on near-black. */
+    nav a:not(.btn-nav):hover { opacity: 1; color: var(--dark); }
     /* In-page section anchors — these drop away on mobile so the two web-app
        CTAs are the only things left in the header. */
     .nav-links { display: flex; align-items: center; gap: 32px; }
@@ -117,7 +119,8 @@
       letter-spacing: 0.01em;
       transition: background .2s, transform .2s;
     }
-    .btn-nav:hover { background: #1c2025; transform: translateY(-1px); }
+    /* Restates the colour so no nav-wide rule can wash the label out again. */
+    .btn-nav:hover, .btn-nav:focus-visible { background: #1c2025; color: #fff; transform: translateY(-1px); }
     .menu-icon {
       display: none;
       width: 34px; height: 34px;


### PR DESCRIPTION
## Summary
The header's **"get started free"** pill lost its label on hover — dark text on a dark fill.

## Linked tracking item
Part of #128 (web app / landing). N/A — reported visually, no separate issue.

## Cause
`resources/views/welcome.blade.php` had:

```css
nav a { color: var(--dark); }              /* plain links on the yellow bar */
nav a:hover { opacity: 1; color: var(--dark); }
.btn-nav { background: var(--dark); color: #fff; }
.btn-nav:hover { background: #1c2025; transform: translateY(-1px); }
```

`nav a:hover` matches **every** anchor in the header, the CTA included. `.btn-nav:hover` has higher specificity but declares no `color`, so the label fell through to `nav a:hover` → `var(--dark)` (`#0D1114`) while the pill kept its dark fill (`#1c2025`). Near-black on near-black.

## Fix
- The nav-wide rule is scoped to the plain links: `nav a:not(.btn-nav):hover`.
- The button restates its own colour, so no future nav-wide rule can wash it out: `.btn-nav:hover, .btn-nav:focus-visible { background: #1c2025; color: #fff; … }` (focus included so keyboard users get the same treatment).

## Testing
- [x] **Browser-verified** by resolving the hover cascade against the real stylesheets: the only rule that sets `color` on the hovered pill is now `.btn-nav:hover -> rgb(255,255,255)`, over a `rgb(28,32,37)` fill — ~16:1 contrast. At rest it is unchanged (white on `rgb(13,17,20)`).
- [x] `php artisan test` (marketing/landing pages) — 54 passed (307 assertions).
- [x] Checked the shared marketing layout (`components/layouts/marketing-page.blade.php`) and the newsletter popup for the same shape of bug: both set hover colours per element, so neither is affected.

## Mobile impact (kolabing-app)
- [x] No mobile changes required — landing-page CSS only.

## Database / migrations
- [x] No schema changes.

## Docs & rules updated
- [x] N/A — no role, paywall or permission behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
