### PR TITLE
fix(webapp): repair 12 broken Alpine :class bindings (kb-on-yellow prefix)

### DIFF
--- a/resources/views/webapp/kolab-form.blade.php
+++ b/resources/views/webapp/kolab-form.blade.php
@@ -54,7 +54,7 @@
             <div class="mt-[22px]">
                 <div class="flex gap-1.5">
                     <template x-for="(s, i) in visibleSteps" :key="s.key">
-                        <div class="flex-1 h-1 rounded-sm transition" :class="kb-on-yellow i <= stepIndex ? 'kb-on-yellow bg-primary' : 'bg-ink/10'"></div>
+                        <div class="flex-1 h-1 rounded-sm transition" :class="i <= stepIndex ? 'kb-on-yellow bg-primary' : 'bg-ink/10'"></div>
                     </template>
                 </div>
 
@@ -71,7 +71,7 @@
                                         class="text-left flex items-center gap-3 p-4 rounded-xl border transition"
                                         :class="form[step.field] === op.value ? 'bg-primary-tint border-primary' : 'bg-white border-ink/10'">
                                     <span class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center border-[1.5px]"
-                                          :class="kb-on-yellow form[step.field] === op.value ? 'kb-on-yellow bg-primary border-primary' : 'border-ink/20'">
+                                          :class="form[step.field] === op.value ? 'kb-on-yellow bg-primary border-primary' : 'border-ink/20'">
                                         <template x-if="form[step.field] === op.value">
                                             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                         </template>
@@ -179,7 +179,7 @@
                                     <template x-for="(d, i) in dayLabels" :key="d">
                                         <button type="button" @click="toggleArray('recurring_days', i + 1)"
                                                 class="w-[42px] h-[42px] rounded-full text-xs font-bold border transition"
-                                                :class="kb-on-yellow form.recurring_days.includes(i + 1) ? 'kb-on-yellow bg-primary border-primary text-ink' : 'bg-white border-ink/[.12] text-ink'"
+                                                :class="form.recurring_days.includes(i + 1) ? 'kb-on-yellow bg-primary border-primary text-ink' : 'bg-white border-ink/[.12] text-ink'"
                                                 x-text="d"></button>
                                     </template>
                                 </div>
@@ -211,7 +211,7 @@
                             class="h-12 px-6 rounded-pill bg-white border border-line text-ink text-sm font-bold hover:border-ink transition">{{ __('webapp.common.back') }}</button>
                     <button type="button" @click="next()" :disabled="busy"
                             class="flex-1 h-12 rounded-pill text-sm font-bold shadow-btn hover:-translate-y-px transition disabled:opacity-50"
-                            :class="kb-on-yellow isReview ? 'bg-inverse text-on-inverse' : 'kb-on-yellow bg-primary text-ink'"
+                            :class="isReview ? 'bg-inverse text-on-inverse' : 'kb-on-yellow bg-primary text-ink'"
                             x-text="busy ? t('form.saving') : nextLabel"></button>
                 </div>
             </div>

--- a/resources/views/webapp/kolabs.blade.php
+++ b/resources/views/webapp/kolabs.blade.php
@@ -79,10 +79,10 @@
                     <div class="flex p-1 bg-white border border-ink/[.12] rounded-pill">
                         <button type="button" @click="setReqSub('sent')"
                                 class="min-w-[100px] h-8 rounded-pill text-[12.5px] font-bold tracking-[.4px] transition"
-                                :class="kb-on-yellow reqSub === 'sent' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.applications.tab_sent') }}</button>
+                                :class="reqSub === 'sent' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.applications.tab_sent') }}</button>
                         <button type="button" @click="setReqSub('received')"
                                 class="min-w-[100px] h-8 rounded-pill text-[12.5px] font-bold tracking-[.4px] transition"
-                                :class="kb-on-yellow reqSub === 'received' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.applications.tab_received') }}</button>
+                                :class="reqSub === 'received' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.applications.tab_received') }}</button>
                     </div>
                 </div>
 

--- a/resources/views/webapp/partials/login-modal.blade.php
+++ b/resources/views/webapp/partials/login-modal.blade.php
@@ -55,10 +55,10 @@
             <div class="flex p-1 bg-white border border-ink/[.12] rounded-pill mb-3">
                 <button type="button" @click="userType = 'business'"
                         class="flex-1 h-8 rounded-pill text-xs font-bold tracking-wide transition"
-                        :class="kb-on-yellow userType === 'business' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.login.business') }}</button>
+                        :class="userType === 'business' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.login.business') }}</button>
                 <button type="button" @click="userType = 'community'"
                         class="flex-1 h-8 rounded-pill text-xs font-bold tracking-wide transition"
-                        :class="kb-on-yellow userType === 'community' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.login.community') }}</button>
+                        :class="userType === 'community' ? 'kb-on-yellow bg-primary text-ink' : 'text-muted'">{{ __('webapp.login.community') }}</button>
             </div>
 
             <div x-show="hasGoogle" x-cloak class="w-full max-w-[400px] mx-auto">

--- a/resources/views/webapp/partials/sidebar.blade.php
+++ b/resources/views/webapp/partials/sidebar.blade.php
@@ -103,14 +103,14 @@
             <div class="flex p-1 bg-white border border-ink/[.12] rounded-pill">
                 <button type="button" @click="setTheme('light')"
                         class="flex-1 h-8 rounded-pill text-xs font-bold tracking-wide flex items-center justify-center gap-1.5 transition"
-                        :class="kb-on-yellow !isDark ? 'kb-on-yellow bg-primary text-ink' : 'text-muted hover:text-ink'"
+                        :class="!isDark ? 'kb-on-yellow bg-primary text-ink' : 'text-muted hover:text-ink'"
                         :aria-pressed="!isDark">
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>
                     {{ __('webapp.nav.theme_light') }}
                 </button>
                 <button type="button" @click="setTheme('dark')"
                         class="flex-1 h-8 rounded-pill text-xs font-bold tracking-wide flex items-center justify-center gap-1.5 transition"
-                        :class="kb-on-yellow isDark ? 'kb-on-yellow bg-primary text-ink' : 'text-muted hover:text-ink'"
+                        :class="isDark ? 'kb-on-yellow bg-primary text-ink' : 'text-muted hover:text-ink'"
                         :aria-pressed="isDark">
                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></svg>
                     {{ __('webapp.nav.theme_dark') }}

--- a/resources/views/webapp/register.blade.php
+++ b/resources/views/webapp/register.blade.php
@@ -195,7 +195,7 @@
                                 class="text-left flex items-center gap-3 p-4 rounded-xl border transition"
                                 :class="form.has_venue === opt.value ? 'bg-primary-tint border-primary' : 'bg-white border-ink/10'">
                             <span class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center border-[1.5px]"
-                                  :class="kb-on-yellow form.has_venue === opt.value ? 'kb-on-yellow bg-primary border-primary' : 'border-ink/20'">
+                                  :class="form.has_venue === opt.value ? 'kb-on-yellow bg-primary border-primary' : 'border-ink/20'">
                                 <template x-if="form.has_venue === opt.value">
                                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
                                 </template>

--- a/resources/views/webapp/subscription.blade.php
+++ b/resources/views/webapp/subscription.blade.php
@@ -84,7 +84,7 @@
                     @foreach ($plans as $key => $plan)
                         @if ($showAll || $configured[$key])
                             <button type="button" @click="plan = '{{ $key }}'"
-                                    :class="kb-on-yellow plan === '{{ $key }}' ? 'kb-on-yellow border-ink bg-primary ring-2 ring-ink' : 'border-ink/[.12] bg-white hover:border-ink/40'"
+                                    :class="plan === '{{ $key }}' ? 'kb-on-yellow border-ink bg-primary ring-2 ring-ink' : 'border-ink/[.12] bg-white hover:border-ink/40'"
                                     class="text-left rounded-3xl border p-5 transition">
                                 <div class="flex items-center justify-between gap-2">
                                     <span class="text-[13px] font-bold tracking-[.06em] uppercase text-ink">{{ $plan['name'] }}</span>

--- a/tests/Feature/WebApp/WebappAlpineBindingsTest.php
+++ b/tests/Feature/WebApp/WebappAlpineBindingsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\WebApp;
+
+use Tests\TestCase;
+
+class WebappAlpineBindingsTest extends TestCase
+{
+    /**
+     * Every Alpine `:class` binding must be a SINGLE JS expression. A common
+     * copy-paste mistake is prefixing it with a bare CSS class, e.g.
+     * `:class="kb-on-yellow foo === bar ? '…' : '…'"`, which is invalid JS —
+     * Alpine throws an "Expression Error" and the binding silently does nothing
+     * (breaking selected-state styling on plan cards, role pills, the create
+     * wizard, etc.). Guard against it across the whole web-app view tree.
+     */
+    public function test_no_alpine_class_binding_starts_with_a_bare_css_class(): void
+    {
+        $offenders = [];
+
+        $dir = resource_path('views/webapp');
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        foreach ($iterator as $file) {
+            if ($file->isDir() || ! str_ends_with($file->getFilename(), '.blade.php')) {
+                continue;
+            }
+            $contents = file_get_contents($file->getPathname());
+
+            // :class="<hyphenated-css-class> <rest>"  — a leading token that looks
+            // like a CSS class (contains a hyphen) followed by a space then more
+            // expression is never a valid single JS expression.
+            if (preg_match_all('/:class="([a-z][a-z0-9]*-[a-z0-9-]*)\s+\S/i', $contents, $m)) {
+                foreach ($m[1] as $token) {
+                    $offenders[] = $file->getFilename().": :class starts with the bare class '{$token}'";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "Alpine `:class` must be a single JS expression, not a leading CSS class:\n".implode("\n", $offenders),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a systemic bug introduced with the redesigned web app: **12 Alpine `:class` bindings are invalid JavaScript**, so their selected-state styling silently breaks and the browser console fills with "Alpine Expression Error".

Each was written as `:class="kb-on-yellow <expression>"` — the `kb-on-yellow` CSS class was pasted **inside** the dynamic expression. `:class` must be a single JS expression; `kb-on-yellow foo === bar ? …` is a syntax error, so Alpine skips the binding.

## Impact (what the user sees)
The click handlers still fire (forms *submit*), but **nothing highlights to confirm the choice**, on:
- **Subscription plan cards** (Monthly vs 3-months — the checkout selection)
- **Login** business/community role pills
- **Register** "do you have a venue?" radio
- **Create-Kolab wizard** — step progress, option radios, recurring-day toggles, review/submit button
- **My Kolabs** sent/received application tabs
- **Sidebar** light/dark toggle

No selection feedback + a console full of errors reads as "the form is broken" — the reported submission issue.

## Fix
Strip the stray leading `kb-on-yellow ` from each `:class` expression. The ternary's **true-branch already includes `kb-on-yellow`** for the yellow/selected state (`.kb-on-yellow` is the on-yellow contrast utility defined in `layout.blade.php`), so the styling intent is fully preserved.

Added **`WebappAlpineBindingsTest`** — fails if any `:class` in the web-app views starts with a bare hyphenated CSS class again.

## Testing
- [x] `WebappAlpineBindingsTest` **passes** (0 offenders); it fails against the pre-fix code (12 offenders).
- [x] `vendor/bin/pint` clean; `php artisan view:cache` compiles all views.
- [x] Verified against prod first: every submission endpoint (register/login/create-Kolab/apply/checkout/chat/profile) returns 2xx — the server is healthy; this was purely the client-side binding bug.

## Notes
- **Separate prod issue found while investigating (not code):** the Laravel Cloud `master` env is missing **`POSTMARK_API_KEY`**, so background emails (welcome/onboarding/reactivation) fail with retry-storms (`RuntimeException` in `PostmarkClient`). Registration itself still succeeds (email is queued), but no emails go out. Fix = set `POSTMARK_API_KEY` on the prod env. Flagging for @olucvolkan / Daniel.
- Base `master`; no migrations.