### PR TITLE
feat(marketing): wire Cal.com discovery calls into book-a-call CTAs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,3 +150,7 @@ WEBAPP_DEEP_LINK=kolabing://
 # until the App Store listing is live; leave blank to hide that badge).
 KOLABING_IOS_APP_URL=
 KOLABING_ANDROID_APP_URL=https://play.google.com/store/apps/details?id=com.kolabing.kolabingApp
+# Cal.com discovery-call links for the landing "Book a call" CTAs (role-matched).
+# Defaults point at the live Kolabing Cal.com calls; override only to change them.
+KOLABING_BOOK_A_CALL_URL_COMMUNITY=https://cal.com/kolabing/community-discovery
+KOLABING_BOOK_A_CALL_URL_BUSINESS=https://cal.com/kolabing/business-discovery

--- a/config/kolabing.php
+++ b/config/kolabing.php
@@ -6,15 +6,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Book-a-call URL
+    | Book-a-call URLs (Cal.com discovery calls)
     |--------------------------------------------------------------------------
     |
-    | External scheduling link used by the landing-page "Book a call" CTA
-    | (Cal.com). Set KOLABING_BOOK_A_CALL_URL in the environment to the real
-    | booking page once it exists; the default is a placeholder.
+    | External scheduling links for the landing-page "Book a call" CTAs, wired to
+    | the Kolabing Cal.com account. There are two role-specific 20-min discovery
+    | calls; `book_a_call_url` is the generic fallback (defaults to the community
+    | call). Override any of them via the environment.
     |
     */
 
-    'book_a_call_url' => env('KOLABING_BOOK_A_CALL_URL', 'https://cal.com/kolabing/intro'),
+    'book_a_call_url' => env('KOLABING_BOOK_A_CALL_URL', 'https://cal.com/kolabing/community-discovery'),
+
+    'book_a_call_url_community' => env('KOLABING_BOOK_A_CALL_URL_COMMUNITY', 'https://cal.com/kolabing/community-discovery'),
+
+    'book_a_call_url_business' => env('KOLABING_BOOK_A_CALL_URL_BUSINESS', 'https://cal.com/kolabing/business-discovery'),
 
 ];

--- a/resources/views/pages/for-businesses.blade.php
+++ b/resources/views/pages/for-businesses.blade.php
@@ -37,6 +37,7 @@
             </div>
             <div class="mt-6 flex shrink-0 flex-col gap-3 md:mt-0">
                 <a href="{{ rtrim(config('webapp.url'), '/') }}/register?type=business" class="rounded-full bg-primary px-7 py-3 text-center font-bold text-off-black transition hover:bg-primary/90">Create your business account</a>
+                <a href="{{ config('kolabing.book_a_call_url_business') }}" target="_blank" rel="noopener" class="text-center text-sm font-medium text-white/75 underline decoration-white/30 underline-offset-4 hover:text-white">Prefer to talk first? Book a 20-min call</a>
                 <a href="{{ rtrim(config('webapp.url'), '/') }}/login" class="text-center text-sm font-medium text-white/60 hover:text-white">Already have an account? Log in</a>
             </div>
         </div>

--- a/resources/views/pages/for-communities.blade.php
+++ b/resources/views/pages/for-communities.blade.php
@@ -37,6 +37,7 @@
             </div>
             <div class="mt-6 flex shrink-0 flex-col gap-3 md:mt-0">
                 <a href="{{ rtrim(config('webapp.url'), '/') }}/register?type=community" class="rounded-full bg-off-black px-7 py-3 text-center font-bold text-primary transition hover:bg-off-black/90">Create your community account</a>
+                <a href="{{ config('kolabing.book_a_call_url_community') }}" target="_blank" rel="noopener" class="text-center text-sm font-medium text-off-black/70 underline decoration-off-black/30 underline-offset-4 hover:text-off-black">Prefer to talk first? Book a 20-min call</a>
                 <a href="{{ rtrim(config('webapp.url'), '/') }}/login" class="text-center text-sm font-medium text-off-black/60 hover:text-off-black">Already have an account? Log in</a>
             </div>
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1923,7 +1923,7 @@ COMMUNITIES GET PERKS.</div>
 
       <div class="kb-pop__or"><span>or</span></div>
       <a class="kb-pop__call kb-pop__call--primary" href="{{ $appRegister }}">Create your free account →</a>
-      <a class="kb-pop__call" href="{{ config('kolabing.book_a_call_url') }}" target="_blank" rel="noopener">Book a call with us →</a>
+      <a class="kb-pop__call kb-pop__bookcall" data-url-community="{{ config('kolabing.book_a_call_url_community') }}" data-url-business="{{ config('kolabing.book_a_call_url_business') }}" href="{{ config('kolabing.book_a_call_url_community') }}" target="_blank" rel="noopener">Book a call with us →</a>
     </div>
 
     <div class="kb-pop__body kb-pop__done" id="kbPopDone" hidden>
@@ -1931,7 +1931,7 @@ COMMUNITIES GET PERKS.</div>
       <h2 class="kb-pop__title">You're on the list</h2>
       <p class="kb-pop__sub">Thanks — we'll be in touch. Want to start now?</p>
       <a class="kb-pop__call kb-pop__call--primary" href="{{ $appRegister }}">Create your free account →</a>
-      <a class="kb-pop__call" href="{{ config('kolabing.book_a_call_url') }}" target="_blank" rel="noopener">Book a call with us →</a>
+      <a class="kb-pop__call kb-pop__bookcall" data-url-community="{{ config('kolabing.book_a_call_url_community') }}" data-url-business="{{ config('kolabing.book_a_call_url_business') }}" href="{{ config('kolabing.book_a_call_url_community') }}" target="_blank" rel="noopener">Book a call with us →</a>
     </div>
   </div>
 </div>
@@ -1959,11 +1959,21 @@ COMMUNITIES GET PERKS.</div>
   }
 
   // Audience toggle
+  // Point the "Book a call" CTAs at the discovery call that matches the segment.
+  function syncBookCall(){
+    pop.querySelectorAll('.kb-pop__bookcall').forEach(function(a){
+      var url = a.getAttribute('data-url-' + audience);
+      if (url) a.setAttribute('href', url);
+    });
+  }
+  syncBookCall();
+
   pop.querySelectorAll('.kb-pop__seg-btn').forEach(function(btn){
     btn.addEventListener('click', function(){
       audience = btn.getAttribute('data-aud');
       pop.querySelectorAll('.kb-pop__seg-btn').forEach(function(b){ b.classList.remove('is-on'); });
       btn.classList.add('is-on');
+      syncBookCall();
     });
   });
 


### PR DESCRIPTION
## Summary
Wires the two Cal.com **discovery calls** (set up on the Kolabing Cal.com account) into the landing "book a call" CTAs, role-matched. Replaces the old placeholder link, which pointed at a non-existent `cal.com/kolabing/intro`.

## Changes
- **`config/kolabing.php`**: `book_a_call_url_community` + `book_a_call_url_business`, defaulting to the live `cal.com/kolabing/community-discovery` and `.../business-discovery` (20-min Cal Video calls). The generic `book_a_call_url` fallback now points at a real call too.
- **Landing pop-up** (`welcome.blade.php`): the pop-up already has a community/business segment toggle — the "Book a call" CTA now **follows the selected segment** (swaps `href` to the matching discovery call on toggle + on open).
- **`for-communities` / `for-businesses` pages**: a role-matched *"Prefer to talk first? Book a 20-min call"* link under the create-account CTA.
- **`.env.example`**: documents `KOLABING_BOOK_A_CALL_URL_COMMUNITY` / `_BUSINESS` (both optional — defaults are the live links).

## Testing
- [x] `vendor/bin/pint` clean; `php artisan view:cache` compiles.
- [x] Config resolves to the live URLs.
- [x] Rendered locally: the **community** page links the community call, the **business** page the business call, and the home pop-up carries both `data-url-community` / `data-url-business` attributes for the JS swap.

## Notes
- The Cal.com event types are already live and public: `cal.com/kolabing/community-discovery` + `cal.com/kolabing/business-discovery` (both 20 min, Cal Video, on the Kolabing account).
- No migrations. Base `master`.