### PR TITLE
feat: community-rankings directory — living per-category pages + honest social proof

### DIFF
--- a/app/Http/Controllers/DirectoryController.php
+++ b/app/Http/Controllers/DirectoryController.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\CrmAccount;
+use App\Models\ListingClaim;
+use App\Models\RankingPage;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\View\View;
+
+/**
+ * Public community-rankings directory (the GTM lead-magnet pages).
+ *
+ * Editorial copy comes from ranking_pages; the ranked LIST is a live projection of
+ * crm_accounts (type=community, listed=true) filtered by the page's city + verticals
+ * and ordered by the admin-managed CRM score (with an optional metrics.rank_override).
+ * So re-rank / edit / add / remove all happen in /admin/crm, never in code.
+ */
+class DirectoryController extends Controller
+{
+    public function index(): View
+    {
+        $cities = RankingPage::query()->published()->whereNull('topic')
+            ->orderBy('sort')->orderBy('city')->get();
+
+        return view('directory.index', [
+            'cities' => $cities->map(fn (RankingPage $p) => [
+                'page' => $p,
+                'count' => $this->communities($p->city)->count(),
+            ]),
+        ]);
+    }
+
+    public function show(string $city): View
+    {
+        $page = RankingPage::query()->published()->where('city', $city)->whereNull('topic')->firstOrFail();
+
+        $communities = $this->communities($city);
+
+        return view('directory.city', [
+            'page' => $page,
+            'ranked' => $this->rank($communities)->take((int) config('rankings.hub_limit', 12)),
+            'total' => $communities->count(),
+            'topics' => RankingPage::query()->published()->where('city', $city)->whereNotNull('topic')
+                ->orderBy('sort')->get(),
+        ]);
+    }
+
+    public function topic(string $city, string $slug): View
+    {
+        $page = RankingPage::query()->published()->where('slug', $slug)->where('city', $city)->firstOrFail();
+
+        $communities = $this->communities($city, (array) $page->verticals);
+
+        return view('directory.topic', [
+            'page' => $page,
+            'ranked' => $this->rank($communities),
+        ]);
+    }
+
+    public function howWeRank(): View
+    {
+        return view('directory.how-we-rank');
+    }
+
+    public function claim(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'community_name' => ['required', 'string', 'max:160'],
+            'handle' => ['nullable', 'string', 'max:120'],
+            'email' => ['required', 'email', 'max:255'],
+            'city' => ['nullable', 'string', 'max:60'],
+            'source' => ['nullable', 'string', 'max:60'],
+            'website' => ['nullable', 'size:0'], // honeypot
+        ]);
+
+        // Best-effort link to the existing CRM lead by name.
+        $account = CrmAccount::query()->where('type', 'community')
+            ->where('name', $data['community_name'])->first();
+
+        ListingClaim::query()->create([
+            'community_name' => $data['community_name'],
+            'handle' => $data['handle'] ?? null,
+            'email' => $data['email'],
+            'city' => $data['city'] ?? null,
+            'source' => $data['source'] ?? null,
+            'crm_account_id' => $account?->id,
+        ]);
+
+        return back()->with('claimed', true);
+    }
+
+    /**
+     * Listed community leads for a city, optionally narrowed to a set of vertical keywords.
+     *
+     * @param  list<string>  $verticals
+     * @return Collection<int, CrmAccount>
+     */
+    private function communities(string $city, array $verticals = []): Collection
+    {
+        $query = CrmAccount::query()
+            ->where('type', 'community')
+            ->where('listed', true)
+            ->where('metrics->city', $city);
+
+        if ($verticals !== []) {
+            $query->where(function ($q) use ($verticals): void {
+                foreach ($verticals as $keyword) {
+                    $q->orWhere('metrics->vertical', 'like', '%'.$keyword.'%');
+                }
+            });
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * Order the ranked list: an explicit metrics.rank_override first, then the
+     * admin-managed CRM score (desc), then name — all resolved in PHP so the JSON
+     * override works regardless of the database driver.
+     *
+     * @param  Collection<int, CrmAccount>  $communities
+     * @return Collection<int, CrmAccount>
+     */
+    private function rank(Collection $communities): Collection
+    {
+        return $communities->sortBy([
+            fn (CrmAccount $a) => $a->metrics['rank_override'] ?? PHP_INT_MAX,
+            fn (CrmAccount $a) => -1 * (int) $a->score,
+            fn (CrmAccount $a) => $a->name,
+        ])->values();
+    }
+}

--- a/app/Models/CrmAccount.php
+++ b/app/Models/CrmAccount.php
@@ -24,7 +24,7 @@ class CrmAccount extends Model
     protected $fillable = [
         'type', 'name', 'status', 'owner', 'email', 'phone',
         'instagram_handle', 'whatsapp', 'next_action', 'notes',
-        'score', 'metrics', 'linked_profile_id', 'last_activity_at',
+        'score', 'listed', 'metrics', 'linked_profile_id', 'last_activity_at',
     ];
 
     /**

--- a/app/Models/ListingClaim.php
+++ b/app/Models/ListingClaim.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A community's "claim your listing" lead capture from a public ranking page.
+ * Kept deliberately light (one honest form field beyond the name) — the free
+ * listing is never gated behind a sales call.
+ */
+class ListingClaim extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'community_name', 'handle', 'email', 'city', 'source', 'crm_account_id',
+    ];
+
+    /**
+     * @return BelongsTo<CrmAccount, $this>
+     */
+    public function crmAccount(): BelongsTo
+    {
+        return $this->belongsTo(CrmAccount::class);
+    }
+}

--- a/app/Models/RankingPage.php
+++ b/app/Models/RankingPage.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Editorial copy for one public ranking page (a city hub or a city×topic page).
+ * The ranked LIST itself is a live projection of CrmAccount (see DirectoryController);
+ * this model only holds the curated marketing copy so it can be edited without
+ * touching the community leads.
+ *
+ * @property array<int, array{q: string, a: string}>|null $faq
+ */
+class RankingPage extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'city', 'topic', 'slug', 'title', 'meta_description',
+        'intro', 'how_ranked', 'faq', 'editor_name', 'published', 'sort',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'faq' => 'array',
+            'published' => 'boolean',
+            'sort' => 'integer',
+        ];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function isHub(): bool
+    {
+        return $this->topic === null;
+    }
+
+    /**
+     * @param  Builder<RankingPage>  $query
+     * @return Builder<RankingPage>
+     */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where('published', true);
+    }
+}

--- a/config/rankings.php
+++ b/config/rankings.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Community rankings (public lead-magnet directory)
+    |--------------------------------------------------------------------------
+    |
+    | The public "best {topic} in {city}" pages. The ranked list is a LIVE
+    | projection of crm_accounts (type=community, listed=true) — re-rank / edit /
+    | add / remove all happen in /admin/crm. This config holds only the display
+    | knobs: the named editor (E-E-A-T), the CTA links, and how many entries a hub
+    | shows.
+    |
+    */
+
+    'editor_name' => env('RANKINGS_EDITOR_NAME', 'The Kolabing editorial team'),
+
+    // Cross-vertical entries shown on a city hub page.
+    'hub_limit' => 12,
+
+    // CTA targets (the two live Cal.com discovery calls + the marketing pages).
+    'community_cta_url' => env('KOLABING_BOOK_A_CALL_URL_COMMUNITY', 'https://cal.com/kolabing/community-discovery'),
+    'business_cta_url' => env('KOLABING_BOOK_A_CALL_URL_BUSINESS', 'https://cal.com/kolabing/business-discovery'),
+
+];

--- a/database/data/community_rankings.json
+++ b/database/data/community_rankings.json
@@ -1,0 +1,2645 @@
+{
+ "generated_for": "Kolabing community rankings (GTM lead-magnet directory)",
+ "cities": [
+  {
+   "city": "Barcelona",
+   "sort": 0,
+   "pieces": [
+    {
+     "title": "The 14 Best Community Groups in Barcelona (2026)",
+     "slug": "best-community-groups-in-barcelona",
+     "meta_description": "The best community groups in Barcelona in 2026: language exchanges, running and cycling clubs, AI meetups, wellness and social collectives worth hosting.",
+     "intro": "The strongest community groups in Barcelona are Barcelona Language Exchange (58,080 members) and Midnight Runners Barcelona (around 19k followers from public profile). Below them sit a full spread: founder networks, AI meetups, cold-plunge crews, book clubs, and social brands like The Brunch Club, all filling real rooms on a fixed cadence.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Barcelona Language Exchange",
+       "handle": "",
+       "summary": "The city's biggest social community with 58,080 members, running language nights six evenings a week at Space Cowboy and Jardinet d'Aribau. Sheer scale and cadence put it at the top."
+      },
+      {
+       "rank": 2,
+       "name": "Language Exchange & Party (Barcelona International Social)",
+       "handle": "",
+       "summary": "44,563 members across multiple weekly events at La Pecera and OGHAM, blending language practice with social parties. One of the largest recurring social engines in Barcelona."
+      },
+      {
+       "rank": 3,
+       "name": "Midnight Runners Barcelona",
+       "handle": "@midnightrunnersbarcelona",
+       "summary": "Around 19k followers (from public profile), a Wednesday bootcamp-run at roughly 19:45 out of TimeOut Market, Puma-backed. The most visible running community in the city."
+      },
+      {
+       "rank": 4,
+       "name": "BARCELONA FRIENDS",
+       "handle": "",
+       "summary": "Around 17,568 members running regular social meetups. A large, steady community whose whole reason to exist is getting people into a room together."
+      },
+      {
+       "rank": 5,
+       "name": "Barcelona Digital Nomads",
+       "handle": "",
+       "summary": "14,615 members with a weekly Wednesday afterwork. A dependable, high-frequency audience of remote workers who show up on a fixed night."
+      },
+      {
+       "rank": 6,
+       "name": "Running Club BCN (RCB)",
+       "handle": "@runningclub_bcn",
+       "summary": "Around 12k followers (from public profile), meeting Mondays at 19:00 from Sea You Barcelona. A large, consistent running community with a clear home base."
+      },
+      {
+       "rank": 7,
+       "name": "Startup Grind Barcelona",
+       "handle": "",
+       "summary": "9,227 members and a monthly fireside format hosted at ITnig. The anchor founder-and-startup community in the city, with a room that turns over every month."
+      },
+      {
+       "rank": 8,
+       "name": "NPK Club",
+       "handle": "@npk_club",
+       "summary": "Around 7,004 followers (from public profile) built around a social run. A mid-sized running crew with a steady following and a sociable format."
+      },
+      {
+       "rank": 9,
+       "name": "Barcelona Road Cycling Group",
+       "handle": "",
+       "summary": "5,359 members across Meetup and Strava, riding Tuesday, Wednesday, Thursday and Saturday. The largest and most active road-cycling community in Barcelona."
+      },
+      {
+       "rank": 10,
+       "name": "BarcelonaJS",
+       "handle": "",
+       "summary": "5,466 members meeting monthly, historically at the MongoDB office. The city's biggest JavaScript developer community and a fixture on the tech calendar."
+      },
+      {
+       "rank": 11,
+       "name": "ProductTank Barcelona",
+       "handle": "",
+       "summary": "5,218 members with a roughly monthly cadence at Mango Poblenou and Talent Garden. The core product-management community, with an audience that reliably fills a venue."
+      },
+      {
+       "rank": 12,
+       "name": "The Brunch Club Barcelona",
+       "handle": "@thebrunchclubbcn",
+       "summary": "Around 3,955 followers (from public profile), running pop-up brunches and social events at secret locations. Its bio says it plainly: connecting communities, hosting unique events, booking secret locations, which is exactly the venue-and-community fit Kolabing is built on."
+      },
+      {
+       "rank": 13,
+       "name": "Life Drawing Barcelona (Drink & Draw)",
+       "handle": "",
+       "summary": "A weekly life-drawing session running 12-plus years and described as the city's largest artist community. Longevity and a fixed weekly slot make it a standout creative group."
+      },
+      {
+       "rank": 14,
+       "name": "Barcelona Wim Hof Method Group",
+       "handle": "",
+       "summary": "815 members meeting Saturday mornings on Poblenou beach for cold dips and breathwork. The leading wellness and cold-exposure community in Barcelona, with a clear weekly ritual."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking across verticals, weighted first by public audience size, then by activity and cadence, platform presence, and any real venue or brand collaborations, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Barcelona?",
+       "a": "Barcelona Language Exchange is the biggest, with 58,080 members and language nights six evenings a week at Space Cowboy and Jardinet d'Aribau. Language Exchange & Party (Barcelona International Social) follows with 44,563 members across multiple weekly events."
+      },
+      {
+       "q": "What are the best community groups in Barcelona for meeting people?",
+       "a": "For meeting people, the strongest are Barcelona Language Exchange, Language Exchange & Party, BARCELONA FRIENDS (around 17,568 members) and Barcelona Digital Nomads (14,615 members, weekly Wednesday afterwork). The Brunch Club runs pop-up brunches and social events at secret locations."
+      },
+      {
+       "q": "Are there community groups in Barcelona that partner with venues?",
+       "a": "Yes. Most of these groups already run at fixed venues, from TimeOut Market to Talent Garden, and The Brunch Club is built entirely around booking secret locations for its events, which is the exact venue-and-community pairing Kolabing arranges."
+      }
+     ],
+     "cta": "If your community is on this list, you can claim your listing and let Barcelona venues host your next event; if you run a venue, these are the groups worth hosting.",
+     "topic": null,
+     "verticals": null,
+     "wave": 1
+    },
+    {
+     "title": "The 8 Best AI & Tech Communities in Barcelona (2026)",
+     "slug": "best-ai-tech-communities-in-barcelona",
+     "meta_description": "The best AI and tech communities in Barcelona in 2026, ranked: BarcelonaJS, ProductTank, Python Barcelona, GDG, AWS, AI Tinkerers and more.",
+     "intro": "The best AI and tech communities in Barcelona are BarcelonaJS (5,466 members) and ProductTank Barcelona (5,218 members). Behind them is a deep bench of developer and AI meetups: Python Barcelona, GDG, AWS User Group, plus newer AI-first crews like AI Tinkerers running demo nights and hackathons across Poblenou.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "BarcelonaJS",
+       "handle": "",
+       "summary": "5,466 members meeting monthly, historically at the MongoDB office. The largest JavaScript developer community in the city and a reliable monthly draw."
+      },
+      {
+       "rank": 2,
+       "name": "ProductTank Barcelona",
+       "handle": "",
+       "summary": "5,218 members with a roughly monthly cadence at Mango Poblenou and Talent Garden. The core product community, pulling a full room of PMs and builders."
+      },
+      {
+       "rank": 3,
+       "name": "Python Barcelona",
+       "handle": "",
+       "summary": "4,646 members meeting monthly. A large, established developer community with a steady calendar of talks."
+      },
+      {
+       "rank": 4,
+       "name": "GDG Barcelona",
+       "handle": "",
+       "summary": "3,376 members with a recurring calendar, including the Build With AI series, at UPF Poblenou. A well-organised Google-developer community with a clear AI track."
+      },
+      {
+       "rank": 5,
+       "name": "AWS User Group Barcelona",
+       "handle": "",
+       "summary": "2,830 members meeting roughly monthly at bsport Tasso. The main cloud-and-AWS community in the city, with a fixed venue and cadence."
+      },
+      {
+       "rank": 6,
+       "name": "AI Tinkerers Barcelona",
+       "handle": "",
+       "summary": "A Luma-run community holding roughly monthly demo nights and hackathons, with a Demo Night set for 17 September 2026. One of the most active AI-first crews in Barcelona."
+      },
+      {
+       "rank": 7,
+       "name": "Create With - Barcelona AI Meetup",
+       "handle": "",
+       "summary": "A recurring Luma-run AI meetup hosted at Talent Garden. A focused, builder-oriented AI community with a consistent home base."
+      },
+      {
+       "rank": 8,
+       "name": "Global AI Barcelona",
+       "handle": "",
+       "summary": "108 members meeting roughly monthly, Microsoft-sponsored. Smaller than the developer meetups but a dedicated AI community with regular sessions."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public member count, then by cadence and how established the community is, plus its venue base, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the biggest AI or tech community in Barcelona?",
+       "a": "BarcelonaJS is the biggest developer community, with 5,466 members meeting monthly, followed by ProductTank Barcelona at 5,218 members and Python Barcelona at 4,646. On the AI-first side, AI Tinkerers Barcelona runs monthly demo nights and hackathons."
+      },
+      {
+       "q": "Where do AI meetups in Barcelona happen?",
+       "a": "AI and tech meetups cluster around Poblenou and the tech hubs: Talent Garden hosts Create With and ProductTank, GDG runs at UPF Poblenou, AWS User Group meets at bsport Tasso, and AI Tinkerers runs demo nights on Luma, with a Demo Night on 17 September 2026."
+      },
+      {
+       "q": "Which Barcelona tech communities focus specifically on AI?",
+       "a": "AI Tinkerers Barcelona (monthly demo nights and hackathons), Create With - Barcelona AI Meetup at Talent Garden, Global AI Barcelona (108 members, Microsoft-sponsored) and GDG's Build With AI series are the most AI-focused communities in the city."
+      }
+     ],
+     "cta": "Running one of these meetups? Claim your listing and let a Barcelona venue host your next demo night or talk; venues with space to fill can host a room of engineers and builders on a fixed monthly cadence.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 1
+    },
+    {
+     "title": "The 9 Best Language Exchanges & Social Communities in Barcelona (2026)",
+     "slug": "best-language-exchanges-social-communities-in-barcelona",
+     "meta_description": "The best language exchanges and social communities in Barcelona in 2026, ranked by size and cadence: Barcelona Language Exchange, Mundo Lingo, The Brunch Club and more.",
+     "intro": "The best language exchanges and social communities in Barcelona are Barcelona Language Exchange (58,080 members, six nights a week) and Language Exchange & Party (44,563 members). The rest of the field runs the gamut: Mundo Lingo, expat networks, digital-nomad afterworks, and social brands like The Brunch Club filling secret locations.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Barcelona Language Exchange",
+       "handle": "",
+       "summary": "58,080 members with language nights six evenings a week at Space Cowboy and Jardinet d'Aribau. The largest social community in the city by a wide margin, and the most frequent."
+      },
+      {
+       "rank": 2,
+       "name": "Language Exchange & Party (Barcelona International Social)",
+       "handle": "",
+       "summary": "44,563 members across multiple weekly events at La Pecera and OGHAM, mixing language practice with parties. A huge, high-cadence social engine."
+      },
+      {
+       "rank": 3,
+       "name": "BARCELONA FRIENDS",
+       "handle": "",
+       "summary": "Around 17,568 members running regular social meetups. A large general-social community built purely around getting people together."
+      },
+      {
+       "rank": 4,
+       "name": "Barcelona Digital Nomads",
+       "handle": "",
+       "summary": "14,615 members with a weekly Wednesday afterwork. A dependable remote-worker community that meets on the same night every week."
+      },
+      {
+       "rank": 5,
+       "name": "The Brunch Club Barcelona",
+       "handle": "@thebrunchclubbcn",
+       "summary": "Around 3,955 followers (from public profile), running pop-up brunches and social events at secret locations. Its bio sums it up: connecting communities, hosting unique events, booking secret locations, which is the venue-and-community fit at the heart of what Kolabing does."
+      },
+      {
+       "rank": 6,
+       "name": "Mundo Lingo Barcelona",
+       "handle": "",
+       "summary": "Around 80 people per event, meeting Wednesdays and Fridays at 21:00 across Inusual Project and Delabuela. A well-known language-exchange format with a steady twice-weekly slot."
+      },
+      {
+       "rank": 7,
+       "name": "InterNations Barcelona",
+       "handle": "",
+       "summary": "Multiple monthly events, including Open House and BBQ formats on rooftop terraces. An established expat network with a full monthly calendar."
+      },
+      {
+       "rank": 8,
+       "name": "ESN Barcelona (Erasmus)",
+       "handle": "",
+       "summary": "Frequent term-time events across UB, UPF and UAB. The main Erasmus student community, dense with activity during the academic term."
+      },
+      {
+       "rank": 9,
+       "name": "Couchsurfing Barcelona",
+       "handle": "",
+       "summary": "A weekly Thursday meetup in the Gòtic. A long-running, low-key social community with a fixed weekly slot for travellers and locals."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public member count, then by how often the community meets and how established it is, plus its venue base, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the biggest language exchange in Barcelona?",
+       "a": "Barcelona Language Exchange is the biggest, with 58,080 members and language nights six evenings a week at Space Cowboy and Jardinet d'Aribau. Language Exchange & Party (Barcelona International Social) follows with 44,563 members across multiple weekly events."
+      },
+      {
+       "q": "What social communities in Barcelona are best for expats and newcomers?",
+       "a": "InterNations Barcelona (multiple monthly events on rooftop terraces), Barcelona Digital Nomads (14,615 members, weekly afterwork), BARCELONA FRIENDS (around 17,568 members) and Couchsurfing Barcelona (weekly Thursday in the Gòtic) are the strongest for newcomers."
+      },
+      {
+       "q": "Where can I go to a brunch or social event in Barcelona?",
+       "a": "The Brunch Club Barcelona (around 3,955 followers from public profile) runs pop-up brunches and social events at secret locations. Language exchanges like Mundo Lingo (Wednesdays and Fridays at 21:00) and the two big exchange communities also run frequent social nights."
+      }
+     ],
+     "cta": "If your community runs language nights or socials, claim your listing and let Barcelona venues host you; venues with quiet weeknights can fill a room with one of these recurring crowds.",
+     "topic": "social-expat",
+     "verticals": [
+      "expat",
+      "social",
+      "nomad",
+      "language",
+      "friend",
+      "international",
+      "couchsurf",
+      "student",
+      "erasmus"
+     ],
+     "wave": 1
+    },
+    {
+     "title": "The 4 Best Wellness Communities in Barcelona (2026)",
+     "slug": "best-wellness-communities-in-barcelona",
+     "meta_description": "The best wellness communities in Barcelona in 2026: cold-plunge, ice-bath and breathwork groups from Poblenou beach to Barceloneta rooftops.",
+     "intro": "The best wellness communities in Barcelona are the Barcelona Wim Hof Method Group (815 members, Saturday beach dips) and Seneca Barcelona Ice Bath & Breathwork (daily 07:30 sessions in Barceloneta). Cold-plunge and breathwork run the wellness scene here, with fixed weekly and daily rituals by the water.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Barcelona Wim Hof Method Group",
+       "handle": "",
+       "summary": "815 members meeting Saturday mornings on Poblenou beach for cold dips and breathwork. The largest wellness community of its kind in the city, with a clear weekly ritual."
+      },
+      {
+       "rank": 2,
+       "name": "Seneca Barcelona Ice Bath & Breathwork",
+       "handle": "",
+       "summary": "54 members running a daily 07:30 Café con Hielo session on the Seneca Rooftop in Barceloneta. Smaller but the most frequent, with a daily cold-plunge slot and a fixed venue."
+      },
+      {
+       "rank": 3,
+       "name": "El Club del Hielo (Wim Hof)",
+       "handle": "",
+       "summary": "A recurring Wim Hof cold-exposure community led by Emilio Garmendia. An established breathwork-and-ice crew with regular sessions."
+      },
+      {
+       "rank": 4,
+       "name": "Barcelona Ice Baths",
+       "handle": "",
+       "summary": "Guided cold-plunge sessions for people who want structured ice-bath time. A dedicated cold-exposure community focused on hosted, guided plunges."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public member count, then by how often the community meets and whether it has a fixed venue, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the biggest wellness or cold-plunge community in Barcelona?",
+       "a": "The Barcelona Wim Hof Method Group is the biggest, with 815 members meeting Saturday mornings on Poblenou beach for cold dips and breathwork. Seneca Barcelona Ice Bath & Breathwork runs the most frequent sessions, daily at 07:30 in Barceloneta."
+      },
+      {
+       "q": "Where are the cold-plunge and ice-bath sessions in Barcelona?",
+       "a": "Cold-plunge sessions run by the water: the Wim Hof group meets on Poblenou beach on Saturdays, and Seneca hosts a daily 07:30 Café con Hielo on its Barceloneta rooftop. El Club del Hielo and Barcelona Ice Baths run further guided sessions."
+      },
+      {
+       "q": "How often do Barcelona wellness communities meet?",
+       "a": "Cadence varies. Seneca Barcelona runs a daily 07:30 session, the Barcelona Wim Hof Method Group meets weekly on Saturday mornings, and El Club del Hielo and Barcelona Ice Baths run recurring guided cold-plunge sessions."
+      }
+     ],
+     "cta": "Run a wellness or cold-plunge community? Claim your listing and let a rooftop, beach bar or studio host your sessions; venues near the water can host a recurring wellness crowd at quiet morning hours.",
+     "topic": "wellness",
+     "verticals": [
+      "wellness",
+      "sauna",
+      "recovery",
+      "longevity",
+      "ice",
+      "cold",
+      "plunge",
+      "mors",
+      "wim",
+      "breath"
+     ],
+     "wave": 1
+    },
+    {
+     "title": "The 12 Best Running Clubs in Barcelona (2026)",
+     "slug": "best-running-clubs-in-barcelona",
+     "meta_description": "The best running clubs in Barcelona in 2026, ranked: Midnight Runners, Running Club BCN, NPK, plus sunrise crews and coffee runs across the city.",
+     "intro": "The best running clubs in Barcelona are Midnight Runners Barcelona (around 19k followers from public profile) and Running Club BCN (around 12k). The scene runs from big Puma- and Sea You-backed crews to sunrise runs on Barceloneta and Saturday coffee-runs, with a club for nearly every morning and evening slot.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Midnight Runners Barcelona",
+       "handle": "@midnightrunnersbarcelona",
+       "summary": "Around 19k followers (from public profile), a Wednesday bootcamp-run at roughly 19:45 out of TimeOut Market, Puma-backed. The biggest and most visible running community in the city."
+      },
+      {
+       "rank": 2,
+       "name": "Running Club BCN (RCB)",
+       "handle": "@runningclub_bcn",
+       "summary": "Around 12k followers (from public profile), meeting Mondays at 19:00 from Sea You Barcelona. A large, consistent club with a clear waterfront home base."
+      },
+      {
+       "rank": 3,
+       "name": "NPK Club",
+       "handle": "@npk_club",
+       "summary": "Around 7,004 followers (from public profile) built around a social run. A mid-sized crew with a steady following and a sociable format."
+      },
+      {
+       "rank": 4,
+       "name": "B3tter Run Club",
+       "handle": "@b3tterrunclub",
+       "summary": "A 07:00 run from La Cala Barceloneta, backed by B3TTER Foods. An early-morning club with a brand partner and a fixed seaside start."
+      },
+      {
+       "rank": 5,
+       "name": "Sunrise Runners Club",
+       "handle": "@sunriserunnersclub",
+       "summary": "A 07:30 run starting from Buenas Migas Barceloneta. A sunrise crew with a café start point and a consistent morning slot."
+      },
+      {
+       "rank": 6,
+       "name": "Founders Running Club",
+       "handle": "@foundersrc",
+       "summary": "A Saturday 09:00 run-and-coffee out of FIKKA Coffee Market. A weekend club that pairs the run with a café stop, aimed at founders and professionals."
+      },
+      {
+       "rank": 7,
+       "name": "Casual Runners Barcelona",
+       "handle": "@barcelona_casual_runners",
+       "summary": "A 19:30 run from Passeig Pujades 33. An evening club with a relaxed, casual format and a fixed meeting point."
+      },
+      {
+       "rank": 8,
+       "name": "Saturnday Run Club",
+       "handle": "@saturndayrunclub",
+       "summary": "A Saturday 09:00 run from Enric Granados 98. A weekend morning club with a set city-centre start."
+      },
+      {
+       "rank": 9,
+       "name": "No Name Crew Barcelona",
+       "handle": "",
+       "summary": "Runs Wednesdays at 19:45 plus Saturday and Sunday at 09:30. A multi-day crew with both midweek and weekend slots."
+      },
+      {
+       "rank": 10,
+       "name": "Beer Runners Barcelona",
+       "handle": "@beerrunners_bcn",
+       "summary": "A social run that ends with a beer. A relaxed community built around the run-then-drink format."
+      },
+      {
+       "rank": 11,
+       "name": "adidas Runners Barcelona",
+       "handle": "",
+       "summary": "A brand-run club (operated by Gaudium Sports) meeting Tuesdays and Thursdays at 19:30. Well-organised and twice-weekly, but as a brand-owned club it is less collaboration-available than the independents above."
+      },
+      {
+       "rank": 12,
+       "name": "Oysho Community",
+       "handle": "@oysho_community",
+       "summary": "A brand-run club meeting at 19:30 from Oysho Diagonal. A consistent, brand-owned running community, which places it below the independent clubs for venue collaboration."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public following, then by cadence, platform presence and real venue or brand collaborations; brand-owned clubs like adidas Runners and Oysho rank below independents because they are less available for outside venue partnerships.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Barcelona?",
+       "a": "Midnight Runners Barcelona is the biggest, with around 19k followers (from public profile) and a Wednesday bootcamp-run out of TimeOut Market, Puma-backed. Running Club BCN follows with around 12k followers, meeting Mondays from Sea You Barcelona."
+      },
+      {
+       "q": "Are there morning running clubs in Barcelona?",
+       "a": "Yes. B3tter Run Club starts at 07:00 from La Cala Barceloneta, Sunrise Runners Club at 07:30 from Buenas Migas Barceloneta, and Founders Running Club and Saturnday Run Club both run Saturdays at 09:00 from café start points."
+      },
+      {
+       "q": "Which Barcelona running clubs are brand-run?",
+       "a": "adidas Runners Barcelona (operated by Gaudium Sports, Tuesdays and Thursdays at 19:30) and Oysho Community (19:30 from Oysho Diagonal) are brand-run. They are well-organised but less available for outside venue partnerships than the independent clubs."
+      }
+     ],
+     "cta": "If you organise a running club, claim your listing and let a Barcelona café or bar host your start and finish; venues on a run route can trade a warm space and perks for a crew of regulars every week.",
+     "topic": "running-clubs",
+     "verticals": [
+      "running"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 5 Best Cycling Clubs in Barcelona (2026)",
+     "slug": "best-cycling-clubs-in-barcelona",
+     "meta_description": "The best cycling clubs in Barcelona in 2026, ranked: Barcelona Road Cycling Group, Barcelona Gravel Club, EazyGravel, La Grupa and Eat Sleep Cycle.",
+     "intro": "The best cycling clubs in Barcelona are the Barcelona Road Cycling Group (5,359 members, riding four days a week) and Barcelona Gravel Club (942 members). Road and gravel both run strong here, from weekday road rides to weekend gravel loops in Collserola and out toward the Girona hub.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Barcelona Road Cycling Group",
+       "handle": "",
+       "summary": "5,359 members across Meetup and Strava, riding Tuesday, Wednesday, Thursday and Saturday. The largest and most active road-cycling community in the city."
+      },
+      {
+       "rank": 2,
+       "name": "Barcelona Gravel Club",
+       "handle": "",
+       "summary": "942 members on Strava riding weekend gravel in Collserola. The main gravel community in Barcelona, with a clear weekend rhythm."
+      },
+      {
+       "rank": 3,
+       "name": "EazyGravel Barcelona",
+       "handle": "@eazygravel",
+       "summary": "Saturday and Sunday gravel rides at 08:30 paired with coffee. A weekend gravel crew with a fixed early start and a café-stop format."
+      },
+      {
+       "rank": 4,
+       "name": "A.C. Montjuïc \"La Grupa\"",
+       "handle": "",
+       "summary": "A club dating to 1917, running weekend rides around Montjuïc, tracked on Strava. One of the oldest cycling communities in the city, with a historic base."
+      },
+      {
+       "rank": 5,
+       "name": "Eat Sleep Cycle",
+       "handle": "@eatsleepcycle",
+       "summary": "A Girona-hub operation running group rides. Well-known in the wider Catalonia cycling scene, centred on the Girona base rather than the city itself."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public member count, then by riding cadence, platform presence and how established the club is, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the biggest cycling club in Barcelona?",
+       "a": "The Barcelona Road Cycling Group is the biggest, with 5,359 members across Meetup and Strava and rides on Tuesday, Wednesday, Thursday and Saturday. Barcelona Gravel Club is the largest gravel community, with 942 members riding weekends in Collserola."
+      },
+      {
+       "q": "Are there gravel cycling clubs in Barcelona?",
+       "a": "Yes. Barcelona Gravel Club (942 members) runs weekend gravel rides in Collserola, and EazyGravel Barcelona runs Saturday and Sunday gravel rides at 08:30 paired with coffee. Both centre on weekend off-road loops."
+      },
+      {
+       "q": "How often do Barcelona cycling clubs ride?",
+       "a": "The Barcelona Road Cycling Group rides four days a week (Tuesday, Wednesday, Thursday and Saturday), while gravel clubs like Barcelona Gravel Club and EazyGravel focus on weekends, and A.C. Montjuïc's La Grupa runs weekend rides around Montjuïc."
+      }
+     ],
+     "cta": "Run a cycling club? Claim your listing and let a Barcelona café host your ride start or coffee stop; a venue on a popular route can trade space and perks for a group of riders every week.",
+     "topic": "cycling-clubs",
+     "verticals": [
+      "cycling"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 4 Best Book & Creative Clubs in Barcelona (2026)",
+     "slug": "best-book-creative-clubs-in-barcelona",
+     "meta_description": "The best book and creative clubs in Barcelona in 2026: life drawing, book clubs and writing groups meeting weekly and monthly across the city.",
+     "intro": "The best book and creative clubs in Barcelona are Life Drawing Barcelona (a weekly session running 12-plus years) and Barcelona Book Club (804 members, first Thursday monthly). Between them sit steady write-ins and writing circles, giving readers, artists and writers a fixed slot to show up for.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Life Drawing Barcelona (Drink & Draw)",
+       "handle": "",
+       "summary": "A weekly life-drawing session running more than 12 years, described as the city's largest artist community. Longevity and a fixed weekly slot make it the standout creative club."
+      },
+      {
+       "rank": 2,
+       "name": "Barcelona Book Club",
+       "handle": "",
+       "summary": "804 members meeting monthly on the first Thursday, with a €3 entry. The main book community in the city, with a clear, predictable monthly slot."
+      },
+      {
+       "rank": 3,
+       "name": "Get Creative Writers Barcelona",
+       "handle": "",
+       "summary": "Recurring write-ins hosted at Backstory English Bookshop. A writing community with a dependable home base for its sessions."
+      },
+      {
+       "rank": 4,
+       "name": "International Writers of Barcelona (IWB)",
+       "handle": "",
+       "summary": "A recurring writing community for the city's international writers. A steady creative group focused on regular writing meetups."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighted first by public member count and how established the group is, then by cadence and whether it has a fixed venue, kept transparent rather than falsely precise.",
+     "faq": [
+      {
+       "q": "What is the best book club in Barcelona?",
+       "a": "Barcelona Book Club is the main one, with 804 members meeting monthly on the first Thursday for a €3 entry. On the creative side, Life Drawing Barcelona runs a weekly session and is described as the city's largest artist community."
+      },
+      {
+       "q": "Are there writing groups in Barcelona?",
+       "a": "Yes. Get Creative Writers Barcelona runs recurring write-ins at Backstory English Bookshop, and International Writers of Barcelona (IWB) runs regular meetups for the city's international writers. Both give writers a fixed, recurring slot."
+      },
+      {
+       "q": "How often do Barcelona book and creative clubs meet?",
+       "a": "Cadence varies. Life Drawing Barcelona meets weekly, Barcelona Book Club meets monthly on the first Thursday, and the writing groups (Get Creative Writers and IWB) run recurring write-ins and meetups on their own schedules."
+      }
+     ],
+     "cta": "If you run a book or creative club, claim your listing and let a Barcelona bookshop, café or bar host your session; a venue with a quiet evening can host readers, writers or artists on a recurring slot.",
+     "topic": "creative-books",
+     "verticals": [
+      "book",
+      "creative",
+      "writer",
+      "drawing",
+      "art",
+      "culture"
+     ],
+     "wave": 2
+    }
+   ]
+  },
+  {
+   "city": "Madrid",
+   "sort": 1,
+   "pieces": [
+    {
+     "title": "The 12 Best Community Groups in Madrid (2026)",
+     "slug": "best-community-groups-in-madrid",
+     "meta_description": "The best community groups in Madrid in 2026, ranked: from Spanish & International Friends and FITCLUB COLLECTIVE to Madrid's biggest running clubs and networking nights.",
+     "intro": "The strongest community groups in Madrid right now are Spanish & International Friends, the city's biggest language-exchange night, and FITCLUB COLLECTIVE for wellness. Add the padel spectacle of Madrid Premier Padel P1, running crews like TRC, and the Madrid Expats social calendar, and you have a full picture of who fills rooms here.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Madrid Premier Padel P1 by Oysho",
+       "handle": "@madridpremierpadel",
+       "summary": "A padel showcase drawing around 34,000 on Instagram, running 1-6 September 2026 at Movistar Arena. It is a brand-titled event (Oysho as title, Movistar Arena as venue) rather than an open community, so it sits at the top for reach but is less collaboration-available than the independent groups below."
+      },
+      {
+       "rank": 2,
+       "name": "Spanish & International Friends — Language Exchange",
+       "handle": "",
+       "summary": "Madrid's largest language-exchange community with 28,715 Meetup members, run by David. It meets twice weekly (Thursday 20:00 and Sunday 19:30, about 42 people per event) at Beer Station and El Chulo near Plaza Santo Domingo, making it a reliable venue partner."
+      },
+      {
+       "rank": 3,
+       "name": "FITCLUB COLLECTIVE",
+       "handle": "@fitclubcollective",
+       "summary": "A fitness and wellness community with around 22,000 followers on Instagram, running ongoing sessions from paid studios at Columela 4 and Diego de León 5."
+      },
+      {
+       "rank": 4,
+       "name": "TRC – The Run Club",
+       "handle": "@trc_therunclub",
+       "summary": "Madrid's biggest running club by reach at about 14,000 Instagram followers, founded by Antonio Brunete. It runs daily across five Madrid locations on a paid membership."
+      },
+      {
+       "rank": 5,
+       "name": "Madrid Expats — Social Events",
+       "handle": "",
+       "summary": "A social community of 10,096 Meetup members organised by Nico, meeting weekly with 6-14 people per event. It has partnered with Madrid for Refugees, a signal that it works well with cause-led hosts."
+      },
+      {
+       "rank": 6,
+       "name": "osom running club",
+       "handle": "@osomrunningclub",
+       "summary": "A running community of around 10,000 Instagram followers meeting Wednesday and Saturday mornings. Its runs start from Osom Coffee, the parent brand and venue, a clean example of a café-anchored group."
+      },
+      {
+       "rank": 7,
+       "name": "Professionals & Entrepreneurs Network Madrid (PNM)",
+       "handle": "",
+       "summary": "A business-networking community of 8,952 Meetup members run by Stefania, meeting monthly on the first Monday. Its last event, a Business Networking Rooftop on 3 August 2026, drew 202 people, and it openly recruits sponsors and stands."
+      },
+      {
+       "rank": 8,
+       "name": "Volta Run Club",
+       "handle": "@voltarunclub",
+       "summary": "A running club with around 7,176 Instagram followers, meeting Wednesday 20:00 in Retiro and Saturday 10:00 at Casa de Campo. It runs hydrated by Electrolit, an existing brand collaboration."
+      },
+      {
+       "rank": 9,
+       "name": "DEGENS Run Club",
+       "handle": "@degensrunclub",
+       "summary": "A running community of about 6,464 Instagram followers meeting Friday 19:30 and Sunday 10:00 at Puerta Felipe IV. It runs powered by Belevels, an active brand partnership."
+      },
+      {
+       "rank": 10,
+       "name": "Madrid Urban / Digital Nomads (Office&Coffee)",
+       "handle": "",
+       "summary": "A digital-nomad community of 3,865 Meetup members meeting monthly (around 5 per event) at The Shed Coworking, with collaborations including Immigram and Startups Institute."
+      },
+      {
+       "rank": 11,
+       "name": "Madrid Startup Founder 101",
+       "handle": "",
+       "summary": "A startup community of 3,299 Meetup members running recurring events for founders in the city."
+      },
+      {
+       "rank": 12,
+       "name": "Guiris de Mierda",
+       "handle": "",
+       "summary": "An expat and social community running weekly on Luma with roughly 93 or more RSVPs per event, hosted by Nicholas Farrell and Enmary Margaret at Generator Madrid."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking across all verticals, weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations.",
+     "faq": [
+      {
+       "q": "What are the best community groups in Madrid?",
+       "a": "By public audience and cadence, Spanish & International Friends (28,715 language-exchange members) and FITCLUB COLLECTIVE (around 22,000 wellness followers) lead the independent groups, alongside TRC for running and Madrid Expats for social events."
+      },
+      {
+       "q": "Which Madrid community has the most members?",
+       "a": "Among community groups, Spanish & International Friends is the largest with 28,715 Meetup members. Madrid Premier Padel P1 by Oysho reaches around 34,000 on Instagram, but it is a brand-titled event rather than an open community."
+      },
+      {
+       "q": "What types of community groups are active in Madrid?",
+       "a": "Madrid has running clubs, fitness and wellness communities, language exchanges, expat and social nights, business-networking groups, digital-nomad meetups, and startup founder circles, most meeting weekly or monthly at cafés, bars, studios, and coworking venues."
+      }
+     ],
+     "cta": "If your community is on this list and you want a venue to host your next event, or you run a Madrid venue looking to bring these groups through your door, Kolabing can make the introduction.",
+     "topic": null,
+     "verticals": null,
+     "wave": 2
+    },
+    {
+     "title": "The 9 Best Running Clubs in Madrid (2026)",
+     "slug": "best-running-clubs-in-madrid",
+     "meta_description": "The best running clubs in Madrid in 2026, ranked: TRC, osom, Volta and DEGENS lead, with weekly Retiro and Casa de Campo runs and real brand partners.",
+     "intro": "The best running clubs in Madrid in 2026 are TRC, the biggest by reach at around 14,000 followers, and osom running club at about 10,000. Below them sit Volta, DEGENS and a set of crews meeting weekly across Retiro, Casa de Campo and Puerta Felipe IV, several already running with brand partners.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "TRC – The Run Club",
+       "handle": "@trc_therunclub",
+       "summary": "Madrid's biggest running club by audience at about 14,000 Instagram followers, founded by Antonio Brunete. It runs daily across five Madrid locations on a paid membership."
+      },
+      {
+       "rank": 2,
+       "name": "osom running club",
+       "handle": "@osomrunningclub",
+       "summary": "Around 10,000 Instagram followers, meeting Wednesday and Saturday mornings. Runs start from Osom Coffee, the parent brand and run-start venue, a working café-anchored model."
+      },
+      {
+       "rank": 3,
+       "name": "Volta Run Club",
+       "handle": "@voltarunclub",
+       "summary": "About 7,176 Instagram followers, meeting Wednesday 20:00 in Retiro and Saturday 10:00 at Casa de Campo. It runs hydrated by Electrolit, an existing brand collaboration."
+      },
+      {
+       "rank": 4,
+       "name": "DEGENS Run Club",
+       "handle": "@degensrunclub",
+       "summary": "Around 6,464 Instagram followers, meeting Friday 19:30 and Sunday 10:00 at Puerta Felipe IV. It runs powered by Belevels, an active brand partnership."
+      },
+      {
+       "rank": 5,
+       "name": "Revel",
+       "handle": "@therevelclub",
+       "summary": "A running and social club of around 1,244 Instagram followers, meeting Sunday 11:00 in Retiro as a paid experience."
+      },
+      {
+       "rank": 6,
+       "name": "We Run Madrid",
+       "handle": "",
+       "summary": "An inclusive club with a nobody-left-behind ethos, active on Telegram and Instagram (audience not public), meeting Wednesday 20:00 and Saturday 10:00."
+      },
+      {
+       "rank": 7,
+       "name": "Triboost Running Club",
+       "handle": "",
+       "summary": "A triathlon-focused club running recurring paid sessions (audience not public)."
+      },
+      {
+       "rank": 8,
+       "name": "adidas Runners Madrid",
+       "handle": "",
+       "summary": "A brand-run club meeting Tuesday and Thursday 19:30. As a brand-run crew it ranks below the independent community clubs above, since it is less available for open venue collaborations."
+      },
+      {
+       "rank": 9,
+       "name": "Nike Run Club Madrid",
+       "handle": "",
+       "summary": "A brand-run club running recurring sessions. Like other brand-run crews it sits below the independent community clubs, being less collaboration-available."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public Instagram audience first, then activity and cadence, platform presence, and real brand or venue collaborations, with brand-run clubs placed below independent community groups.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Madrid?",
+       "a": "TRC – The Run Club is the biggest by public audience, at around 14,000 Instagram followers. Founded by Antonio Brunete, it runs daily across five Madrid locations on a paid membership."
+      },
+      {
+       "q": "Which Madrid running clubs meet in Retiro?",
+       "a": "Volta Run Club meets Wednesday 20:00 in Retiro, Revel meets Sunday 11:00 in Retiro, and DEGENS Run Club meets at nearby Puerta Felipe IV on Fridays and Sundays."
+      },
+      {
+       "q": "Are there free running clubs in Madrid?",
+       "a": "Several clubs run open weekly sessions, including We Run Madrid with its inclusive, nobody-left-behind approach on Wednesdays and Saturdays. Others such as TRC, Revel and Triboost operate on paid membership or as paid experiences."
+      }
+     ],
+     "cta": "If you run one of these clubs and want a café or venue to anchor your weekly meet-up, or you own a Madrid venue that wants runners through the door, Kolabing can set up the match.",
+     "topic": "running-clubs",
+     "verticals": [
+      "running"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 5 Best Social & Expat Communities in Madrid (2026)",
+     "slug": "best-social-expat-communities-in-madrid",
+     "meta_description": "The best social and expat communities in Madrid in 2026, ranked: Spanish & International Friends, Madrid Expats, Guiris de Mierda, OneThousandClub and Madrid Urban nomads.",
+     "intro": "The best social and expat communities in Madrid in 2026 are Spanish & International Friends, the city's largest language exchange at 28,715 members, and Madrid Expats at 10,096. Add Guiris de Mierda's weekly Luma nights, the ticketed OneThousandClub, and the Madrid Urban nomad meetups for a full social calendar.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Spanish & International Friends — Language Exchange",
+       "handle": "",
+       "summary": "The largest social and language-exchange community in Madrid with 28,715 Meetup members, run by David. It meets twice weekly (Thursday 20:00 and Sunday 19:30, about 42 people per event) at Beer Station and El Chulo near Plaza Santo Domingo."
+      },
+      {
+       "rank": 2,
+       "name": "Madrid Expats — Social Events",
+       "handle": "",
+       "summary": "A social community of 10,096 Meetup members organised by Nico, meeting weekly with 6-14 people per event. It has collaborated with Madrid for Refugees."
+      },
+      {
+       "rank": 3,
+       "name": "Guiris de Mierda",
+       "handle": "",
+       "summary": "An expat and social community running weekly on Luma with roughly 93 or more RSVPs per event. It is run by Nicholas Farrell and Enmary Margaret at Generator Madrid."
+      },
+      {
+       "rank": 4,
+       "name": "Madrid OneThousandClub",
+       "handle": "",
+       "summary": "A ticketed social club running weekly events on Luma, hosted by Gigi Vicoletto and Mel Miles at venues including Ski Club Náutico de Madrid and ABYA."
+      },
+      {
+       "rank": 5,
+       "name": "Madrid Urban / Digital Nomads (Office&Coffee)",
+       "handle": "",
+       "summary": "A digital-nomad community of 3,865 Meetup members meeting monthly (around 5 per event) at The Shed Coworking, with collaborations including Immigram and Startups Institute."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public membership or RSVP size first, then activity and cadence, platform presence, and real venue or organisation collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest expat community in Madrid?",
+       "a": "By public membership, Spanish & International Friends is the largest at 28,715 Meetup members, followed by Madrid Expats at 10,096. Both meet weekly, so they are among the most active social communities in the city."
+      },
+      {
+       "q": "Where do expat groups meet in Madrid?",
+       "a": "Spanish & International Friends meets at Beer Station and El Chulo near Plaza Santo Domingo, Guiris de Mierda at Generator Madrid, OneThousandClub at Ski Club Náutico de Madrid and ABYA, and Madrid Urban nomads at The Shed Coworking."
+      },
+      {
+       "q": "How often do Madrid social and expat communities meet?",
+       "a": "Most meet weekly. Spanish & International Friends runs twice a week, Madrid Expats, Guiris de Mierda and OneThousandClub run weekly events, and Madrid Urban nomads meet monthly at The Shed Coworking."
+      }
+     ],
+     "cta": "If you organise one of these communities and want a bar, café or venue to host your next night, or you run a Madrid venue that wants an international crowd, Kolabing can connect you.",
+     "topic": "social-expat",
+     "verticals": [
+      "expat",
+      "social",
+      "nomad",
+      "language",
+      "friend",
+      "international",
+      "couchsurf",
+      "student",
+      "erasmus"
+     ],
+     "wave": 2
+    }
+   ]
+  },
+  {
+   "city": "Berlin",
+   "sort": 2,
+   "pieces": [
+    {
+     "title": "The 12 Best Community Groups in Berlin (2026)",
+     "slug": "best-community-groups-in-berlin",
+     "meta_description": "The best community groups in Berlin in 2026: Midnight Runners, Berlin Braves, AI Builders Club and nine more real running, tech and social communities.",
+     "intro": "The strongest community groups in Berlin start with Midnight Runners Berlin (roughly 46,000 on Instagram) and the AI Builders Club, which draws 100 to 300 people per event. Below them sit running crews, founder networks, book clubs and a sauna club that fill Berlin venues week after week.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Midnight Runners Berlin",
+       "handle": "@midnightrunnersberlin",
+       "summary": "A running and experience crew with roughly 46,000 Instagram followers, the largest public audience on this list. Weekly bootcamp runs pull 30 to 80 people each session."
+      },
+      {
+       "rank": 2,
+       "name": "Berlin Braves Sports Club",
+       "handle": "@berlinbraves",
+       "summary": "A running and fitness club with roughly 24,000 Instagram followers and weekly runs. Real brand collaborations include Nike, Oakley and Ciele."
+      },
+      {
+       "rank": 3,
+       "name": "AI Builders Club (Berlin)",
+       "handle": "",
+       "summary": "A tech and AI community of 5,000+ members on Meetup and Luma, drawing 100 to 300+ per event. Runs Builders & Brews nights and hackathons, sponsored by Nebius, n8n, Tavily and Base44."
+      },
+      {
+       "rank": 4,
+       "name": "Berlin Track Club",
+       "handle": "@berlintrackclub",
+       "summary": "A track-focused running club with weekly track sessions. Audience size not public. Real collaborations include Nike Running and Maurten."
+      },
+      {
+       "rank": 5,
+       "name": "Rapha Cycling Club Berlin",
+       "handle": "@rapha_berlin",
+       "summary": "A cycling club with roughly 8,000 Instagram followers and weekly rides out of the Rapha clubhouse. Brand-run by Rapha, so less collaboration-available than an independent crew."
+      },
+      {
+       "rank": 6,
+       "name": "Startup Grind Berlin",
+       "handle": "",
+       "summary": "A business networking community on Luma running monthly founder events of 50 to 150 people. Google-powered."
+      },
+      {
+       "rank": 7,
+       "name": "Berlin AI Developers Group",
+       "handle": "",
+       "summary": "A tech and AI group on Meetup and Luma running a weekly series of 50 to 150 per event. Audience size not public. Collaborates with Google Cloud."
+      },
+      {
+       "rank": 8,
+       "name": "Running FOMO Berlin",
+       "handle": "@runningfomo",
+       "summary": "A running events platform keeping an ongoing calendar of Berlin runs. Audience size not public. Real collaboration: a VIP dinner with LIQID."
+      },
+      {
+       "rank": 9,
+       "name": "Berlin Entrepreneurs Group",
+       "handle": "",
+       "summary": "A business networking group on Meetup running events of 50 to 100 people, organised by Markus Luhmann. Audience size not public."
+      },
+      {
+       "rank": 10,
+       "name": "Gegen Running Club",
+       "handle": "@gegenrunningclub",
+       "summary": "A queer-inclusive running club with weekly runs. Audience size not public."
+      },
+      {
+       "rank": 11,
+       "name": "Gezellig Sessions",
+       "handle": "@gezelligsessions",
+       "summary": "A creative and live-music community on Meetup and Luma running recurring living-room concerts. Audience size not public. Partners with FOMO Berlin."
+      },
+      {
+       "rank": 12,
+       "name": "Sauna Social Club Berlin",
+       "handle": "@sauna_social_club_berlin",
+       "summary": "A wellness and sauna community with roughly 2,300 Instagram followers and recurring sauna socials."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience size first, then activity and cadence, platform presence and real brand or venue collaborations; brand-run clubs sit below independent community groups.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Berlin?",
+       "a": "By public audience, Midnight Runners Berlin is the biggest, with roughly 46,000 Instagram followers and weekly bootcamp runs of 30 to 80 people. Berlin Braves Sports Club follows at roughly 24,000 followers."
+      },
+      {
+       "q": "What types of communities are on this list?",
+       "a": "The list spans running crews (Midnight Runners, Berlin Braves, Berlin Track Club), tech and AI groups (AI Builders Club, Berlin AI Developers Group), founder networks (Startup Grind, Berlin Entrepreneurs), a cycling club, a creative music series and a sauna club."
+      },
+      {
+       "q": "Which Berlin community draws the most people per event?",
+       "a": "Among groups that publish attendance, the AI Builders Club draws the most, with 100 to 300+ people per event. Its Builders & Brews nights and hackathons are sponsored by Nebius, n8n, Tavily and Base44."
+      }
+     ],
+     "cta": "If your group is on this list and you want a Berlin venue to host your next event, or you run a venue and want these communities in your space, claim your listing on Kolabing.",
+     "topic": null,
+     "verticals": null,
+     "wave": 3
+    },
+    {
+     "title": "The 9 Best Running Clubs in Berlin (2026)",
+     "slug": "best-running-clubs-in-berlin",
+     "meta_description": "The best running clubs in Berlin in 2026: Midnight Runners, Berlin Braves and Berlin Track Club lead nine real crews with weekly runs and brand collaborations.",
+     "intro": "The best running clubs in Berlin are Midnight Runners Berlin (roughly 46,000 on Instagram) and Berlin Braves Sports Club (roughly 24,000). Both run weekly. Behind them: a track club, an events platform, a queer-inclusive crew, a run-and-rave crossover and two brand-run clubs.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Midnight Runners Berlin",
+       "handle": "@midnightrunnersberlin",
+       "summary": "A running and experience crew with roughly 46,000 Instagram followers, the largest here. Weekly bootcamp runs draw 30 to 80 people each."
+      },
+      {
+       "rank": 2,
+       "name": "Berlin Braves Sports Club",
+       "handle": "@berlinbraves",
+       "summary": "A running and fitness club with roughly 24,000 Instagram followers and weekly runs. Real collaborations with Nike, Oakley and Ciele."
+      },
+      {
+       "rank": 3,
+       "name": "Berlin Track Club",
+       "handle": "@berlintrackclub",
+       "summary": "A track-focused club with weekly track sessions. Audience size not public. Collaborates with Nike Running and Maurten."
+      },
+      {
+       "rank": 4,
+       "name": "Running FOMO Berlin",
+       "handle": "@runningfomo",
+       "summary": "A running events platform with an ongoing calendar of Berlin runs. Audience size not public. Real collaboration: a VIP dinner with LIQID."
+      },
+      {
+       "rank": 5,
+       "name": "Gegen Running Club",
+       "handle": "@gegenrunningclub",
+       "summary": "A queer-inclusive running club with weekly runs. Audience size not public."
+      },
+      {
+       "rank": 6,
+       "name": "Run-N-Rave",
+       "handle": "@run_n_rave",
+       "summary": "A nightlife and running crossover pairing a run with a rave, recurring. Audience size not public."
+      },
+      {
+       "rank": 7,
+       "name": "ARYS Outdoor Club",
+       "handle": "@arysstore_berlin",
+       "summary": "A running and outdoor club tied to the ARYS retail brand, meeting on a recurring basis. Brand-run, so less collaboration-available than an independent crew."
+      },
+      {
+       "rank": 8,
+       "name": "Adidas Runners Berlin",
+       "handle": "@adidasrunners",
+       "summary": "A weekly running club run by adidas. Brand-run, so it ranks below the independent crews above."
+      },
+      {
+       "rank": 9,
+       "name": "OYSHO Run Club Berlin",
+       "handle": "@oysho_community",
+       "summary": "A recurring running club run by OYSHO. Brand-run, so it ranks below the independent crews above."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience size first, then cadence, platform presence and real brand collaborations; brand-run clubs (ARYS, adidas, OYSHO) sit below the independent crews.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Berlin?",
+       "a": "Midnight Runners Berlin is the biggest by public audience, with roughly 46,000 Instagram followers and weekly bootcamp runs of 30 to 80 people. Berlin Braves Sports Club is next at roughly 24,000 followers."
+      },
+      {
+       "q": "Are there running clubs in Berlin run by brands?",
+       "a": "Yes. Adidas Runners Berlin (weekly) and OYSHO Run Club Berlin (recurring) are brand-run, and ARYS Outdoor Club ties to the ARYS retail brand. We rank these below independent crews because they are less collaboration-available."
+      },
+      {
+       "q": "Which Berlin running clubs collaborate with brands?",
+       "a": "Berlin Braves collaborates with Nike, Oakley and Ciele; Berlin Track Club with Nike Running and Maurten; and Running FOMO Berlin ran a VIP dinner with LIQID. These real collaborations helped set the order."
+      }
+     ],
+     "cta": "If you run one of these crews and want a Berlin venue to host your next run or after-party, claim your listing on Kolabing.",
+     "topic": "running-clubs",
+     "verticals": [
+      "running"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The 5 Best AI & Tech Communities in Berlin (2026)",
+     "slug": "best-ai-tech-communities-in-berlin",
+     "meta_description": "The best AI and tech communities in Berlin in 2026: AI Builders Club, Berlin AI Developers Group, Startup Grind and two more founder and builder groups.",
+     "intro": "The best AI and tech communities in Berlin are the AI Builders Club, with 5,000+ members and 100 to 300+ per event, and the Berlin AI Developers Group, running a weekly series. Rounding out the five: Deep Work Club, Startup Grind and the Berlin Entrepreneurs Group.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "AI Builders Club (Berlin)",
+       "handle": "",
+       "summary": "A tech and AI community of 5,000+ members on Meetup and Luma, drawing 100 to 300+ per event. Runs Builders & Brews nights and hackathons, sponsored by Nebius, n8n, Tavily and Base44."
+      },
+      {
+       "rank": 2,
+       "name": "Berlin AI Developers Group",
+       "handle": "",
+       "summary": "A tech and AI group on Meetup and Luma running a weekly series of 50 to 150 per event. Audience size not public. Collaborates with Google Cloud."
+      },
+      {
+       "rank": 3,
+       "name": "Startup Grind Berlin",
+       "handle": "",
+       "summary": "A business networking community on Luma running monthly founder events of 50 to 150 people. Google-powered."
+      },
+      {
+       "rank": 4,
+       "name": "Berlin Entrepreneurs Group",
+       "handle": "",
+       "summary": "A business networking group on Meetup running events of 50 to 100 people, organised by Markus Luhmann. Audience size not public."
+      },
+      {
+       "rank": 5,
+       "name": "Deep Work Club Berlin",
+       "handle": "",
+       "summary": "A tech and productivity community on Luma with recurring sessions. Audience size not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public membership and per-event attendance first, then cadence, platform presence and real sponsor or partner collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest AI community in Berlin?",
+       "a": "The AI Builders Club is the biggest, with 5,000+ members on Meetup and Luma and 100 to 300+ people per event. Its Builders & Brews nights and hackathons are sponsored by Nebius, n8n, Tavily and Base44."
+      },
+      {
+       "q": "Which Berlin tech communities meet most often?",
+       "a": "The Berlin AI Developers Group runs a weekly series of 50 to 150 per event and collaborates with Google Cloud. Startup Grind Berlin runs monthly founder events of 50 to 150, and the Berlin Entrepreneurs Group runs events of 50 to 100."
+      },
+      {
+       "q": "Where do Berlin AI and founder events happen?",
+       "a": "Most of these communities organise through Meetup and Luma. The AI Builders Club and Berlin AI Developers Group use both platforms, while Deep Work Club and Startup Grind run on Luma and the Berlin Entrepreneurs Group on Meetup."
+      }
+     ],
+     "cta": "If you organise a Berlin AI or founder community and want a venue to host your next event or hackathon, claim your listing on Kolabing.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The 5 Best Social & Creative Communities in Berlin (2026)",
+     "slug": "best-social-creative-communities-in-berlin",
+     "meta_description": "The best social and creative communities in Berlin in 2026: Berlin Social Meet Up, Gezellig Sessions, Berlin Book Club, Digital Nomads and Sauna Social Club.",
+     "intro": "The best social and creative communities in Berlin are Berlin Social Meet Up, which meets daily across rotating bars and venues, and Gezellig Sessions, whose living-room concerts partner with FOMO Berlin. Add the Digital Nomads meetup, a book club and a sauna club, and you have five real ways to fill a room.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Berlin Social Meet Up",
+       "handle": "",
+       "summary": "An expat and social community on Meetup meeting daily across rotating bars and venues. Audience size not public."
+      },
+      {
+       "rank": 2,
+       "name": "Gezellig Sessions",
+       "handle": "@gezelligsessions",
+       "summary": "A creative and live-music community on Meetup and Luma running recurring living-room concerts. Audience size not public. Partners with FOMO Berlin."
+      },
+      {
+       "rank": 3,
+       "name": "Berlin Digital Nomads",
+       "handle": "",
+       "summary": "A digital-nomad community on Meetup meeting on a recurring basis. Audience size not public."
+      },
+      {
+       "rank": 4,
+       "name": "Berlin Book Club",
+       "handle": "",
+       "summary": "A book club on Meetup running events of 10 to 30 people at cafe and cultural-centre venues, organised by Craig S. Audience size not public."
+      },
+      {
+       "rank": 5,
+       "name": "Sauna Social Club Berlin",
+       "handle": "@sauna_social_club_berlin",
+       "summary": "A wellness and sauna community with roughly 2,300 Instagram followers and recurring sauna socials."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by cadence and reach first (public audience where available), then platform presence and real partner collaborations.",
+     "faq": [
+      {
+       "q": "Which social community in Berlin meets most often?",
+       "a": "Berlin Social Meet Up meets daily, rotating across bars and venues, making it the most frequent on this list. Its audience size is not public, but the daily cadence gives venues steady, repeatable footfall."
+      },
+      {
+       "q": "Are there creative communities in Berlin for live music?",
+       "a": "Yes. Gezellig Sessions runs recurring living-room concerts on Meetup and Luma and partners with FOMO Berlin. It sits alongside the Berlin Book Club, which runs reading events of 10 to 30 people at cafe and cultural-centre venues."
+      },
+      {
+       "q": "What kinds of venues do these communities use?",
+       "a": "Berlin Social Meet Up rotates through bars and venues, the Berlin Book Club meets at cafes and cultural centres, and Gezellig Sessions hosts living-room concerts. All three are a natural fit for venues wanting community footfall."
+      }
+     ],
+     "cta": "If you run one of these communities, or a Berlin cafe, bar or venue that wants to host them, claim your listing on Kolabing.",
+     "topic": "creative-books",
+     "verticals": [
+      "book",
+      "creative",
+      "writer",
+      "drawing",
+      "art",
+      "culture"
+     ],
+     "wave": 3
+    }
+   ]
+  },
+  {
+   "city": "Paris",
+   "sort": 3,
+   "pieces": [
+    {
+     "title": "The 12 Best Community Groups in Paris (2026)",
+     "slug": "best-community-groups-in-paris",
+     "meta_description": "The strongest community groups in Paris in 2026, from Food Runners Club and Shotgun to INTERNATIONALS in Paris: real audiences venues can host.",
+     "intro": "Paris's strongest community groups in 2026 are Food Runners Club, a roughly 72,000-follower running crew that ends its runs at partner bakeries, and Shotgun, a 52,000-follower music-events collective. Below them sit big expat networks, running clubs, book nights and AI meetups that fill venues on a schedule.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Food Runners Club",
+       "handle": "@foodrunners.club",
+       "summary": "A running community of around 72,000 Instagram followers with a weekly run, founded by Théo Delahaye and Théo Chaudet. It routes runs through partner restaurants and bakeries including Land & Monkeys, Boni's and Munch."
+      },
+      {
+       "rank": 2,
+       "name": "Shotgun (Experience)",
+       "handle": "@shotgunexperience",
+       "summary": "A nightlife and music-events collective of around 52,000 Instagram followers, running ongoing Paris events at venues such as La Nuit Paris."
+      },
+      {
+       "rank": 3,
+       "name": "INTERNATIONALS in Paris",
+       "handle": "",
+       "summary": "One of the city's largest expat and social communities, around 22,000 members on Meetup and Instagram, with weekly after-work meetups organised by Fabiano, Tom, Toto and Benoit."
+      },
+      {
+       "rank": 4,
+       "name": "Collision Running",
+       "handle": "@collisionrunning",
+       "summary": "A running club of around 15,000 Instagram followers with a regular Sunday run, notable for its collaboration with Saucony EU during Paris Fashion Week 2025."
+      },
+      {
+       "rank": 5,
+       "name": "Midnight Runners Paris",
+       "handle": "@midnightrunnersparis",
+       "summary": "A running and fitness crew of around 13,000 Instagram followers known for its bootcamp-style run, powered by I-Run."
+      },
+      {
+       "rank": 6,
+       "name": "The Safe Page (Book Club Paris)",
+       "handle": "@thesafepage_",
+       "summary": "A creative and culture community of around 5,000 Instagram followers running a monthly themed workshop at Let's Café & Atelier."
+      },
+      {
+       "rank": 7,
+       "name": "Le Peloton Cycling Club",
+       "handle": "@lepelotoncyclingclub",
+       "summary": "A cycling club of around 4,000 Instagram followers with weekly road rides, running a 2026 pop-up with Insta360 (\"Vibrez en Jaune\")."
+      },
+      {
+       "rank": 8,
+       "name": "adidas Runners Paris",
+       "handle": "@runnersofparis",
+       "summary": "A brand-owned running community of around 3,000 Instagram followers with weekly runs and yoga, captained by Laura Grasset and six others. Being brand-owned, it is less available for independent venue collaborations."
+      },
+      {
+       "rank": 9,
+       "name": "GenAI Summit Paris",
+       "handle": "",
+       "summary": "An annual generative-AI summit drawing 1,500-plus attendees and 300-plus investors, with 500-plus companies and sponsors. The 2026 edition runs on 10 April."
+      },
+      {
+       "rank": 10,
+       "name": "K I I N Run Club",
+       "handle": "@we.are.kiin",
+       "summary": "A running club of around 2,000 Instagram followers with a weekly run, founded by Maria in 2020."
+      },
+      {
+       "rank": 11,
+       "name": "Paname Run Club",
+       "handle": "@paname_run",
+       "summary": "A running and social club of around 2,000 Instagram followers, known for its Tuesday \"Mardisco\" DJ run and weekend coffee runs."
+      },
+      {
+       "rank": 12,
+       "name": "Air Street Paris AI",
+       "handle": "",
+       "summary": "A high-signal AI gathering with a VC-heavy audience, hosted roughly quarterly by Nathan Benaich of Air Street Capital, with past speakers from Black Forest Labs and Google DeepMind."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience size first, then activity and cadence, platform presence and real brand or venue collaborations; brand-owned clubs sit below independent community groups because they are less collaboration-available.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Paris?",
+       "a": "By public following, Food Runners Club is the biggest on this list, at around 72,000 Instagram followers. It runs weekly and partners with restaurants and bakeries including Land & Monkeys, Boni's and Munch."
+      },
+      {
+       "q": "What kinds of communities are strongest in Paris?",
+       "a": "Running clubs dominate the top of the list, led by Food Runners Club, Collision Running and Midnight Runners Paris. Nightlife (Shotgun) and expat networks (INTERNATIONALS in Paris) also draw large, venue-ready audiences."
+      },
+      {
+       "q": "Which Paris communities already work with venues and brands?",
+       "a": "Several do. Food Runners Club partners with bakeries and restaurants, Collision Running collaborated with Saucony EU, Midnight Runners is powered by I-Run, and Le Peloton ran an Insta360 pop-up in 2026."
+      }
+     ],
+     "cta": "Run a venue in Paris and want one of these communities filling your space on a set night? Kolabing connects you. If this is your community, claim your listing to get matched with venues.",
+     "topic": null,
+     "verticals": null,
+     "wave": 2
+    },
+    {
+     "title": "The 7 Best Running Clubs in Paris (2026)",
+     "slug": "best-running-clubs-in-paris",
+     "meta_description": "The best running clubs in Paris in 2026, led by Food Runners Club and Collision Running: real crews, cadences and brand collabs for venues to host.",
+     "intro": "The best running club in Paris in 2026 is Food Runners Club, a roughly 72,000-follower crew that ends its weekly runs at partner bakeries. Behind it come Collision Running and Midnight Runners Paris, both big, brand-connected crews that move hundreds of runners through the city every week.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Food Runners Club",
+       "handle": "@foodrunners.club",
+       "summary": "Around 72,000 Instagram followers and a weekly run, founded by Théo Delahaye and Théo Chaudet. Runs finish at partner restaurants and bakeries including Land & Monkeys, Boni's and Munch."
+      },
+      {
+       "rank": 2,
+       "name": "Collision Running",
+       "handle": "@collisionrunning",
+       "summary": "Around 15,000 Instagram followers with a regular Sunday run, and a collaboration with Saucony EU during Paris Fashion Week 2025."
+      },
+      {
+       "rank": 3,
+       "name": "Midnight Runners Paris",
+       "handle": "@midnightrunnersparis",
+       "summary": "Around 13,000 Instagram followers with a bootcamp-style run, powered by I-Run."
+      },
+      {
+       "rank": 4,
+       "name": "adidas Runners Paris",
+       "handle": "@runnersofparis",
+       "summary": "A brand-owned crew of around 3,000 Instagram followers with weekly runs and yoga, captained by Laura Grasset and six others. Being brand-owned, it is less available for independent venue collaborations."
+      },
+      {
+       "rank": 5,
+       "name": "K I I N Run Club",
+       "handle": "@we.are.kiin",
+       "summary": "Around 2,000 Instagram followers with a weekly run, founded by Maria in 2020."
+      },
+      {
+       "rank": 6,
+       "name": "Paname Run Club",
+       "handle": "@paname_run",
+       "summary": "Around 2,000 Instagram followers, with a Tuesday \"Mardisco\" DJ run and weekend coffee runs."
+      },
+      {
+       "rank": 7,
+       "name": "Paris Running Club (PRC)",
+       "handle": "@paris_rc",
+       "summary": "One of the city's longest-running crews, founded by Jay Smith in 2008, with around 130 active members and Tuesday-evening runs. Co-founders include NIKELAB and Black Rainbow."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience size first, then activity and cadence, platform presence and real brand collaborations; brand-owned clubs sit below independent community groups because they are less collaboration-available.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Paris?",
+       "a": "Food Runners Club is the biggest by public following, at around 72,000 Instagram followers. It was founded by Théo Delahaye and Théo Chaudet, runs weekly, and partners with bakeries and restaurants including Land & Monkeys, Boni's and Munch."
+      },
+      {
+       "q": "Which Paris running clubs collaborate with brands?",
+       "a": "Several do. Collision Running collaborated with Saucony EU at Paris Fashion Week 2025, Midnight Runners Paris is powered by I-Run, and Paris Running Club counts NIKELAB and Black Rainbow among its co-founders."
+      },
+      {
+       "q": "Are there beginner-friendly running clubs in Paris?",
+       "a": "Yes. Most listed clubs run weekly on a set day, from Paname Run Club's Tuesday \"Mardisco\" DJ run to K I I N Run Club's weekly meet, so runners can pick a cadence and pace that suits them."
+      }
+     ],
+     "cta": "If you run a café, bar or bakery in Paris, these crews are ready-made regulars: Kolabing pairs your space with a running club that finishes at your door. Communities can claim their listing to get matched.",
+     "topic": "running-clubs",
+     "verticals": [
+      "running"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 4 Best AI & Tech Communities in Paris (2026)",
+     "slug": "best-ai-tech-communities-in-paris",
+     "meta_description": "The best AI and tech communities in Paris in 2026: Air Street Paris AI, GenAI Summit Paris, Paris.AI Meetup and the Tech:Europe AI Hackathon.",
+     "intro": "The best AI and tech communities in Paris in 2026 are Air Street Paris AI, a high-signal, VC-heavy gathering hosted by Nathan Benaich, and GenAI Summit Paris, an annual event pulling 1,500-plus attendees and 300-plus investors. Both draw the founders and capital that make a venue partnership worth it.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Air Street Paris AI",
+       "handle": "",
+       "summary": "A high-signal AI event with a VC-heavy audience, hosted roughly quarterly by Nathan Benaich of Air Street Capital on Luma (lu.ma/parisai). Past speakers have come from Black Forest Labs and Google DeepMind."
+      },
+      {
+       "rank": 2,
+       "name": "GenAI Summit Paris",
+       "handle": "",
+       "summary": "An annual generative-AI summit on Luma drawing 1,500-plus attendees and 300-plus investors, with 500-plus companies and sponsors. The 2026 edition runs on 10 April."
+      },
+      {
+       "rank": 3,
+       "name": "Paris.AI Meetup",
+       "handle": "",
+       "summary": "A recurring AI meetup on Luma (lu.ma/parisai2). Audience size is not public."
+      },
+      {
+       "rank": 4,
+       "name": "{Tech:Europe} Paris AI Hackathon",
+       "handle": "",
+       "summary": "A recurring AI hackathon on Luma organised by Tech:Europe. Audience size is not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience and signal quality first, then cadence, platform presence and notable speakers or backers; events with published attendance rank above those whose audience is not public.",
+     "faq": [
+      {
+       "q": "What is the best AI event in Paris?",
+       "a": "Air Street Paris AI is the highest-signal on this list, a roughly quarterly gathering with a VC-heavy audience hosted by Nathan Benaich of Air Street Capital, with past speakers from Black Forest Labs and Google DeepMind."
+      },
+      {
+       "q": "What is the biggest AI conference in Paris?",
+       "a": "GenAI Summit Paris is the largest here by published numbers, drawing 1,500-plus attendees and 300-plus investors, with 500-plus companies and sponsors. The 2026 edition takes place on 10 April."
+      },
+      {
+       "q": "How often do Paris AI communities meet?",
+       "a": "It varies. Air Street Paris AI runs roughly quarterly, GenAI Summit Paris is annual (10 April 2026), and both Paris.AI Meetup and the Tech:Europe Paris AI Hackathon are recurring."
+      }
+     ],
+     "cta": "Got a Paris venue that suits founders and investors, from a private room to a rooftop? Kolabing can host one of these AI communities in your space. Organisers can claim a listing to find the right room.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 4 Best Social & Expat Communities in Paris (2026)",
+     "slug": "best-social-expat-communities-in-paris",
+     "meta_description": "The best social and expat communities in Paris in 2026, led by INTERNATIONALS in Paris: real member counts and cadences for venues to host.",
+     "intro": "The best social and expat community in Paris in 2026 is INTERNATIONALS in Paris, a roughly 22,000-member network running weekly after-work meetups. Alongside it, InterNations Paris, Paris Social Club and Paris for Digital Nomads keep new arrivals and remote workers meeting on a regular schedule.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "INTERNATIONALS in Paris",
+       "handle": "",
+       "summary": "Around 22,000 members on Meetup and Instagram, with weekly after-work meetups organised by Fabiano, Tom, Toto and Benoit."
+      },
+      {
+       "rank": 2,
+       "name": "InterNations Paris",
+       "handle": "",
+       "summary": "An expat networking community on internations.org/paris with monthly events plus after-work meetups, run by local Ambassadors. Audience size is not public."
+      },
+      {
+       "rank": 3,
+       "name": "Paris Social Club",
+       "handle": "@paris.social.club",
+       "summary": "A social and expat meetup community on Meetup and Instagram. Audience size is not public."
+      },
+      {
+       "rank": 4,
+       "name": "Paris for Digital Nomads",
+       "handle": "",
+       "summary": "A digital-nomad community on Meetup running a weekly coworking day. Audience size is not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking by public audience size first, then activity and cadence, platform presence and format; communities with a published member count rank above those whose audience is not public.",
+     "faq": [
+      {
+       "q": "What is the biggest expat community in Paris?",
+       "a": "INTERNATIONALS in Paris is the largest on this list, at around 22,000 members across Meetup and Instagram. It runs weekly after-work meetups organised by Fabiano, Tom, Toto and Benoit."
+      },
+      {
+       "q": "Where do new arrivals meet people in Paris?",
+       "a": "Through regular meetups. INTERNATIONALS in Paris runs weekly after-work events, InterNations Paris holds monthly and after-work meetups via local Ambassadors, and Paris for Digital Nomads runs a weekly coworking day."
+      },
+      {
+       "q": "Are there communities in Paris for digital nomads?",
+       "a": "Yes. Paris for Digital Nomads runs a weekly coworking day on Meetup, and broader social networks like INTERNATIONALS in Paris and Paris Social Club host regular meetups remote workers can join."
+      }
+     ],
+     "cta": "If your café, bar or coworking space in Paris wants a room full of regulars, these communities meet weekly and need venues. Kolabing makes the match, and communities can claim their listing to get found.",
+     "topic": "social-expat",
+     "verticals": [
+      "expat",
+      "social",
+      "nomad",
+      "language",
+      "friend",
+      "international",
+      "couchsurf",
+      "student",
+      "erasmus"
+     ],
+     "wave": 2
+    }
+   ]
+  },
+  {
+   "city": "Lisbon",
+   "sort": 4,
+   "pieces": [
+    {
+     "title": "The 12 Best Community Groups in Lisbon (2026)",
+     "slug": "best-community-groups-in-lisbon",
+     "meta_description": "The best community groups in Lisbon in 2026: Lisbon Digital Nomads (~25k members) and Rookie Run Club (~15k) lead across running, cycling, AI, wellness and social.",
+     "intro": "The biggest community groups in Lisbon are Lisbon Digital Nomads (~25,000 members on Meetup) and Rookie Run Club (~15,000 on Instagram). Below them sits a deep bench of running, cycling, AI, wellness and creative groups that meet every week and pull real regulars into cafés, bars and venues across the city.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Lisbon Digital Nomads",
+       "handle": "",
+       "summary": "The largest expat and nomad social group in the city, roughly 25,000 members on Meetup with a big weekly gathering. Led by Ash and Aykut A, with Wine Hunters as a regular venue."
+      },
+      {
+       "rank": 2,
+       "name": "Rookie Run Club Lisbon",
+       "handle": "@rookierunclub_pt",
+       "summary": "A running and fitness crew of around 15,000 on Instagram. Two fixed sessions a week: Wednesday 19:30 at Cais do Sodré and Saturday 10:00 at Praça do Comércio, with treat sponsors Oakberry and Marquise."
+      },
+      {
+       "rank": 3,
+       "name": "Fable Lisbon",
+       "handle": "@fablelisbon",
+       "summary": "A creative, book and culture community of around 11,000 on Instagram, running events and workshops for writers, readers and makers."
+      },
+      {
+       "rank": 4,
+       "name": "Lisbon Running Community (LXRC)",
+       "handle": "@lisbonrunningcommunity",
+       "summary": "A running club of around 9,000 on Instagram with a heavy weekly cadence: Tuesday and Thursday at 19:30 plus a Sunday 9:00 long run."
+      },
+      {
+       "rank": 5,
+       "name": "Lisbon GenAI Community",
+       "handle": "",
+       "summary": "A monthly AI meetup on Meetup drawing 100 or more per event, with collaborators including Google and synvert xgeeks. Its last GDG x GenAI session ran at PagerDuty on 2 July 2026."
+      },
+      {
+       "rank": 6,
+       "name": "Founders Running Club Lisbon (FRC)",
+       "handle": "@frclisbon",
+       "summary": "Running plus startup networking aimed squarely at a founder audience, meeting Fridays 08:30 at Praça do Comércio. Led by Ivan Soo, Michael P. Robinson, Tania Ávila and Tim T."
+      },
+      {
+       "rank": 7,
+       "name": "Nonstop Cycling Club (NSCC)",
+       "handle": "@nscc.lisbon",
+       "summary": "A cycling club running weekly rides, audience not public. Partners with Grupeto Bike Shop Café, Rise Bike Shop, Powerlab.pt and Cadê a Bike."
+      },
+      {
+       "rank": 8,
+       "name": "Padel Social Club",
+       "handle": "",
+       "summary": "A sport and wellness group at padelsocial.club combining a recurring 7k run, cold plunge, padel and games. Audience not public, but the multi-format cadence keeps regulars coming back."
+      },
+      {
+       "rank": 9,
+       "name": "The Offline Club Lisbon",
+       "handle": "",
+       "summary": "A phone-free wellness and social community on Luma and Meetup, hosted by Joëlle and Lilly. Regular venues include ABSENT and Casa Casa Café. Audience not public."
+      },
+      {
+       "rank": 10,
+       "name": "Hot Cold Club",
+       "handle": "@hotcoldclub",
+       "summary": "A wellness group built around recurring sauna, ice plunge and brunch sessions. Audience not public, cadence is regular."
+      },
+      {
+       "rank": 11,
+       "name": "GDG Lisbon",
+       "handle": "",
+       "summary": "A Google Developer Group on Meetup and GDG, hosted with Devoteam Creative Tech and Google. Audience not public. Its last MongoDB UG x GDG session ran at Devoteam on 19 March 2026."
+      },
+      {
+       "rank": 12,
+       "name": "Lisbon AI Tinkerers",
+       "handle": "",
+       "summary": "A recurring meetup for AI builders on aitinkerers.org and Luma, with LXthon as a launch sponsor. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Lisbon?",
+       "a": "Lisbon Digital Nomads is the biggest, with roughly 25,000 members on Meetup and a large weekly gathering. Rookie Run Club follows with around 15,000 on Instagram and two fixed sessions a week across the city centre."
+      },
+      {
+       "q": "What kinds of communities are most active in Lisbon?",
+       "a": "Running and cycling clubs meet most often, several running multiple sessions a week. AI and tech meetups run roughly monthly, and wellness groups host recurring sauna, plunge and phone-free social rituals across venues in the city."
+      },
+      {
+       "q": "Which Lisbon groups partner with local venues and brands?",
+       "a": "Rookie Run Club works with Oakberry and Marquise, Nonstop Cycling Club with Grupeto, Rise, Powerlab.pt and Cadê a Bike, and Lisbon Digital Nomads uses Wine Hunters as a regular venue."
+      }
+     ],
+     "cta": "If your group is on this list and you want a venue to host your next session, or you run a venue and want these communities through your door, Kolabing can make the introduction.",
+     "topic": null,
+     "verticals": null,
+     "wave": 2
+    },
+    {
+     "title": "The 5 Best AI & Tech Communities in Lisbon (2026)",
+     "slug": "best-ai-tech-communities-in-lisbon",
+     "meta_description": "The best AI and tech communities in Lisbon in 2026: Lisbon GenAI Community leads, with GDG Lisbon, AI Tinkerers, Founders Club and AI & Innovation.",
+     "intro": "The strongest AI and tech community in Lisbon is the Lisbon GenAI Community, drawing 100 or more people per monthly meetup with Google and synvert xgeeks as collaborators. Around it sit GDG Lisbon, Lisbon AI Tinkerers, Lisbon Founders Club and Lisbon AI & Innovation, all running recurring sessions for builders, founders and engineers.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Lisbon GenAI Community",
+       "handle": "",
+       "summary": "The most active AI meetup in the city, roughly 100 or more per event on Meetup, running about monthly. Collaborators include Google and synvert xgeeks, and its last GDG x GenAI session ran at PagerDuty on 2 July 2026."
+      },
+      {
+       "rank": 2,
+       "name": "GDG Lisbon",
+       "handle": "",
+       "summary": "A Google Developer Group on Meetup and GDG, hosted with Devoteam Creative Tech and Google. Audience not public. Its last MongoDB UG x GDG session ran at Devoteam on 19 March 2026."
+      },
+      {
+       "rank": 3,
+       "name": "Lisbon AI Tinkerers",
+       "handle": "",
+       "summary": "A recurring community for AI builders on aitinkerers.org and Luma, with LXthon as a launch sponsor. Audience not public, focus is hands-on building."
+      },
+      {
+       "rank": 4,
+       "name": "Lisbon Founders Club",
+       "handle": "",
+       "summary": "A recurring business networking group on Luma for founders and operators. Audience not public."
+      },
+      {
+       "rank": 5,
+       "name": "Lisbon AI & Innovation",
+       "handle": "",
+       "summary": "A recurring AI and innovation meetup on Meetup. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest AI community in Lisbon?",
+       "a": "The Lisbon GenAI Community is the most active, drawing 100 or more people per event on Meetup and meeting about monthly. It collaborates with Google and synvert xgeeks, and recently hosted a GDG x GenAI session at PagerDuty."
+      },
+      {
+       "q": "Where do AI builders meet in Lisbon?",
+       "a": "AI builders gather at Lisbon AI Tinkerers, a hands-on group on aitinkerers.org and Luma with LXthon as launch sponsor, and at the Lisbon GenAI Community. GDG Lisbon runs Google Developer sessions hosted with Devoteam Creative Tech."
+      },
+      {
+       "q": "Are there founder-focused tech groups in Lisbon?",
+       "a": "Yes. Lisbon Founders Club runs recurring business networking on Luma for founders and operators, and several AI meetups draw a founder-heavy crowd. Audience figures for these groups are not public."
+      }
+     ],
+     "cta": "Run an AI or tech community in Lisbon and need a venue for your next meetup? Kolabing connects your group with local spaces looking to host builders and founders.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 5 Best Running & Cycling Clubs in Lisbon (2026)",
+     "slug": "best-running-cycling-clubs-in-lisbon",
+     "meta_description": "The best running and cycling clubs in Lisbon in 2026: Rookie Run Club (~15k) and LXRC (~9k) lead, plus Founders Running Club and two cycling crews.",
+     "intro": "The biggest running club in Lisbon is Rookie Run Club, around 15,000 on Instagram with two fixed weekly sessions. Lisbon Running Community follows at roughly 9,000. Founders Running Club adds a founder-networking angle, while Nonstop Cycling Club and Lisbon Social Cycling Club cover the road on weekly rides.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Rookie Run Club Lisbon",
+       "handle": "@rookierunclub_pt",
+       "summary": "The largest running crew here, around 15,000 on Instagram. Two fixed sessions a week: Wednesday 19:30 at Cais do Sodré and Saturday 10:00 at Praça do Comércio, with treat sponsors Oakberry and Marquise."
+      },
+      {
+       "rank": 2,
+       "name": "Lisbon Running Community (LXRC)",
+       "handle": "@lisbonrunningcommunity",
+       "summary": "A running club of around 9,000 on Instagram with a heavy weekly cadence: Tuesday and Thursday at 19:30 plus a Sunday 9:00 long run."
+      },
+      {
+       "rank": 3,
+       "name": "Founders Running Club Lisbon (FRC)",
+       "handle": "@frclisbon",
+       "summary": "Running plus startup networking for a founder audience, meeting Fridays 08:30 at Praça do Comércio. Led by Ivan Soo, Michael P. Robinson, Tania Ávila and Tim T."
+      },
+      {
+       "rank": 4,
+       "name": "Nonstop Cycling Club (NSCC)",
+       "handle": "@nscc.lisbon",
+       "summary": "A cycling club running weekly rides, audience not public. Partners with Grupeto Bike Shop Café, Rise Bike Shop, Powerlab.pt and Cadê a Bike, giving riders a strong shop and café network."
+      },
+      {
+       "rank": 5,
+       "name": "Lisbon Social Cycling Club",
+       "handle": "@lisbonsocialcyclingclub",
+       "summary": "A social cycling club built around relaxed group rides. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Lisbon?",
+       "a": "Rookie Run Club is the biggest, with around 15,000 followers on Instagram and two fixed weekly sessions: Wednesday evenings at Cais do Sodré and Saturday mornings at Praça do Comércio. Lisbon Running Community follows at roughly 9,000."
+      },
+      {
+       "q": "Which Lisbon running club is best for founders and networking?",
+       "a": "Founders Running Club Lisbon pairs running with startup networking for a founder audience, meeting Fridays at 08:30 at Praça do Comércio. It is led by Ivan Soo, Michael P. Robinson, Tania Ávila and Tim T."
+      },
+      {
+       "q": "Are there cycling clubs in Lisbon?",
+       "a": "Yes. Nonstop Cycling Club runs weekly rides and partners with Grupeto, Rise Bike Shop, Powerlab.pt and Cadê a Bike. Lisbon Social Cycling Club offers more relaxed social rides. Audience figures for both are not public."
+      }
+     ],
+     "cta": "If your run or ride crew wants a café or venue to finish at, Kolabing pairs Lisbon clubs with local spaces glad to host your regulars.",
+     "topic": "running-cycling",
+     "verticals": [
+      "running",
+      "cycling"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 6 Best Wellness & Social Communities in Lisbon (2026)",
+     "slug": "best-wellness-social-communities-in-lisbon",
+     "meta_description": "The best wellness and social communities in Lisbon in 2026: Lisbon Digital Nomads (~25k) leads, with Padel Social Club, Hot Cold Club, The Offline Club and more.",
+     "intro": "The biggest social community in Lisbon is Lisbon Digital Nomads, roughly 25,000 members on Meetup with a large weekly gathering. On the wellness side, Padel Social Club, Hot Cold Club, Healthy Horizon and The Offline Club run recurring sauna, plunge, padel and phone-free rituals, while OneThousandClub covers nightlife.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Lisbon Digital Nomads",
+       "handle": "",
+       "summary": "The largest expat and nomad social group in the city, roughly 25,000 members on Meetup with a big weekly gathering. Led by Ash and Aykut A, with Wine Hunters as a regular venue and a sponsorship form on the site."
+      },
+      {
+       "rank": 2,
+       "name": "Padel Social Club",
+       "handle": "",
+       "summary": "A sport and wellness group at padelsocial.club mixing a recurring 7k run, cold plunge, padel and games. Audience not public, though the multi-format cadence keeps a steady crowd."
+      },
+      {
+       "rank": 3,
+       "name": "The Offline Club Lisbon",
+       "handle": "",
+       "summary": "A phone-free wellness and social community on Luma and Meetup, hosted by Joëlle and Lilly. Regular venues include ABSENT and Casa Casa Café. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "Hot Cold Club",
+       "handle": "@hotcoldclub",
+       "summary": "A wellness group built around recurring sauna, ice plunge and brunch sessions. Audience not public, cadence is regular."
+      },
+      {
+       "rank": 5,
+       "name": "Healthy Horizon Longevity Club",
+       "handle": "",
+       "summary": "A wellness and longevity club at healthyhorizon.com running weekly sauna and plunge rituals. Audience not public."
+      },
+      {
+       "rank": 6,
+       "name": "OneThousandClub (OTC) Lisbon",
+       "handle": "",
+       "summary": "A nightlife and social club on Luma meeting monthly or more, hosted by Mel Miles and Patricia R, with a collaboration with the label Musique de Lune."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest social community in Lisbon?",
+       "a": "Lisbon Digital Nomads is the biggest, with roughly 25,000 members on Meetup and a large weekly gathering. It is led by Ash and Aykut A and uses Wine Hunters as a regular venue, with a sponsorship form on its site."
+      },
+      {
+       "q": "Where can I find sauna and cold plunge groups in Lisbon?",
+       "a": "Hot Cold Club runs recurring sauna, ice plunge and brunch sessions, and Healthy Horizon Longevity Club hosts weekly sauna and plunge rituals. Padel Social Club also folds a cold plunge into its mix of running, padel and games."
+      },
+      {
+       "q": "Are there phone-free social communities in Lisbon?",
+       "a": "Yes. The Offline Club Lisbon runs phone-free wellness and social meetups on Luma and Meetup, hosted by Joëlle and Lilly, with regular venues including ABSENT and Casa Casa Café. Audience figures are not public."
+      }
+     ],
+     "cta": "Host a wellness or social community in Lisbon and want a venue for your sauna, plunge or social night? Kolabing connects your group with local spaces ready to host.",
+     "topic": "wellness",
+     "verticals": [
+      "wellness",
+      "sauna",
+      "recovery",
+      "longevity",
+      "ice",
+      "cold",
+      "plunge",
+      "mors",
+      "wim",
+      "breath"
+     ],
+     "wave": 2
+    }
+   ]
+  },
+  {
+   "city": "Amsterdam",
+   "sort": 5,
+   "pieces": [
+    {
+     "title": "The 12 Best Community Groups in Amsterdam (2026)",
+     "slug": "best-community-groups-in-amsterdam",
+     "meta_description": "The best community groups in Amsterdam in 2026: running clubs, AI meetups, expat socials and nightlife collectives, ranked by real size and activity.",
+     "intro": "The biggest organised community in Amsterdam is The Amsterdam Expat Meetup Group, with 35,966 members running weekly. Right behind sits AIC: Amsterdam International Community at 25,489. Below them is a dense scene of running clubs, AI builder meetups and techno collectives that fill venues week in, week out.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "The Amsterdam Expat Meetup Group",
+       "handle": "",
+       "summary": "Amsterdam's largest expat social group with 35,966 members, running weekly events of 3 to 83 people. Organised by Summer and four co-hosts, sponsored by the City of Amsterdam."
+      },
+      {
+       "rank": 2,
+       "name": "AIC: Amsterdam International Community",
+       "handle": "@Aloha",
+       "summary": "An expat and social community of 25,489 members meeting weekly or more, 8 to 41 per event. Organised by Attila and five others, using venues like Breugem Brewery, Amsterdam Comedy Club and The College Hotel."
+      },
+      {
+       "rank": 3,
+       "name": "Amsterdam Culture Club (ACC)",
+       "handle": "",
+       "summary": "A culture, art and music community of 4,677 members meeting roughly monthly. Organised by Arthur Augustijn and three others, at venues including Theater De Richel and the Luther Museum."
+      },
+      {
+       "rank": 4,
+       "name": "EAST Techno Collective",
+       "handle": "@eastcollective_amsterdam",
+       "summary": "A weekly techno night with around 4,877 Instagram followers, programmed with and hosted at Paradiso."
+      },
+      {
+       "rank": 5,
+       "name": "Amsterdam AI Developers Group (AICamp)",
+       "handle": "",
+       "summary": "An AI developer meetup of 2,651 members on Meetup and aicamp.ai, 6 to 12 per event. Co-hosted by Google Cloud, previously with ML6."
+      },
+      {
+       "rank": 6,
+       "name": "Ethereum DEV NL",
+       "handle": "",
+       "summary": "A Web3 developer community of 2,444 members meeting monthly, 15 to 69 per event. Organised by Wesley and seven others, hosted at VC firm Maven 11."
+      },
+      {
+       "rank": 7,
+       "name": "Product Meetup Amsterdam",
+       "handle": "",
+       "summary": "A product community of 1,344 members meeting monthly, 51 to 73 per event. Organised by Parth Parikh, hosted by Silverflow, Amplitude, Adyen and Fairphone."
+      },
+      {
+       "rank": 8,
+       "name": "Amsterdam Film Group",
+       "handle": "",
+       "summary": "A film and creative community of 1,179 members meeting roughly weekly, 4 to 13 per event. Organised by Ben and four others at LAB111, De Uitkijk and the H'ART Museum."
+      },
+      {
+       "rank": 9,
+       "name": "Kaptein Cycling Club (KCC)",
+       "handle": "@kaptein_cycling_club",
+       "summary": "A cycling club with 330+ members riding Wednesday and Thursday evenings and Sunday mornings. Led by president Daan Kahmann, partnered with Kaptein Tweewielers, Sockeloen and Brouwerij De Eeuwige Jeugd."
+      },
+      {
+       "rank": 10,
+       "name": "AI Tinkerers Amsterdam",
+       "handle": "",
+       "summary": "A monthly AI builders meetup of 130+ per event on Luma. Sponsored by Gradium and ML6, with prior support from Cloudflare, Auth0, MotherDuck and Google Cloud."
+      },
+      {
+       "rank": 11,
+       "name": "Cycle Capital Cycling Club",
+       "handle": "@cycle_capital",
+       "summary": "A cycling club with around 1,000 Instagram followers, riding every Sunday in groups of 4 to 30. Organised by Arjen Kuin, sponsored by CIOVITA."
+      },
+      {
+       "rank": 12,
+       "name": "Sunday Run Club",
+       "handle": "@sun.dayrunclub",
+       "summary": "A running and fitness community with around 29,000 Instagram followers, running social, interval and beginner sessions. Founded by Sophie Nordenhed, partnered with PerfectTed and La Place."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations; brand-owned clubs rank below independent community groups.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Amsterdam?",
+       "a": "The Amsterdam Expat Meetup Group is the biggest, with 35,966 members and weekly events drawing 3 to 83 people. It is organised by Summer and four co-hosts, and sponsored by the City of Amsterdam."
+      },
+      {
+       "q": "What kinds of communities are strongest in Amsterdam?",
+       "a": "Amsterdam is strong across expat and social groups, AI and tech meetups, running and cycling clubs, and nightlife collectives. The largest are expat groups like The Amsterdam Expat Meetup Group and AIC, followed by AI developer and product meetups."
+      },
+      {
+       "q": "Which Amsterdam communities partner with venues?",
+       "a": "Many do. AIC uses Breugem Brewery and The College Hotel, Product Meetup is hosted by Adyen and Amplitude, EAST is programmed at Paradiso, and Kaptein Cycling Club partners with Kaptein Tweewielers and a local brewery."
+      }
+     ],
+     "cta": "If you run one of these communities and want a venue to host your next event, or you own a venue and want to bring these regulars through your door, Kolabing can make the introduction.",
+     "topic": null,
+     "verticals": null,
+     "wave": 3
+    },
+    {
+     "title": "The 5 Best AI & Tech Communities in Amsterdam (2026)",
+     "slug": "best-ai-tech-communities-in-amsterdam",
+     "meta_description": "The best AI and tech communities in Amsterdam in 2026: AICamp, Ethereum DEV NL, Product Meetup, AI Tinkerers and the Weaviate GenAI meetup, ranked.",
+     "intro": "The biggest AI and tech community in Amsterdam is the Amsterdam AI Developers Group (AICamp), with 2,651 members and Google Cloud co-hosting. Ethereum DEV NL follows at 2,444. Together with Product Meetup, AI Tinkerers and Weaviate's GenAI meetup, they form the core of the city's builder scene.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Amsterdam AI Developers Group (AICamp)",
+       "handle": "",
+       "summary": "An AI developer community of 2,651 members on Meetup and aicamp.ai, drawing 6 to 12 per event. Co-hosted by Google Cloud, previously with ML6."
+      },
+      {
+       "rank": 2,
+       "name": "Ethereum DEV NL",
+       "handle": "",
+       "summary": "A Web3 developer community of 2,444 members meeting monthly, 15 to 69 per event. Organised by Wesley and seven others, hosted at VC firm Maven 11."
+      },
+      {
+       "rank": 3,
+       "name": "Product Meetup Amsterdam",
+       "handle": "",
+       "summary": "A product community of 1,344 members meeting monthly, 51 to 73 per event. Organised by Parth Parikh, hosted by Silverflow, Amplitude, Adyen and Fairphone."
+      },
+      {
+       "rank": 4,
+       "name": "AI Tinkerers Amsterdam",
+       "handle": "",
+       "summary": "A monthly AI builders meetup drawing 130+ per event on Luma. Sponsored by Gradium and ML6, with prior support from Cloudflare, Auth0, MotherDuck and Google Cloud."
+      },
+      {
+       "rank": 5,
+       "name": "GenAI/LLM/ML Meetup (Weaviate)",
+       "handle": "",
+       "summary": "A recurring GenAI meetup on Luma organised by Marion Nehring of Weaviate. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public member count first, then per-event turnout and cadence, platform presence, and named venue or corporate collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest AI community in Amsterdam?",
+       "a": "The Amsterdam AI Developers Group (AICamp) is the biggest, with 2,651 members across Meetup and aicamp.ai. Events draw 6 to 12 people and are co-hosted by Google Cloud, with prior support from ML6."
+      },
+      {
+       "q": "Which Amsterdam tech meetup has the highest per-event turnout?",
+       "a": "Product Meetup Amsterdam and AI Tinkerers pull the biggest crowds. Product Meetup draws 51 to 73 per event, hosted by companies like Adyen and Amplitude, while AI Tinkerers regularly brings 130+ builders per session."
+      },
+      {
+       "q": "Are there Web3 or blockchain communities in Amsterdam?",
+       "a": "Yes. Ethereum DEV NL is the main one, a Web3 developer community of 2,444 members meeting monthly with 15 to 69 people per event. It is organised by Wesley and seven co-organisers and hosted at VC firm Maven 11."
+      }
+     ],
+     "cta": "If you organise one of these meetups and need a reliable venue, or you run a space that wants to host Amsterdam's AI and tech builders, Kolabing can connect you.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The 7 Best Running & Cycling Clubs in Amsterdam (2026)",
+     "slug": "best-running-cycling-clubs-in-amsterdam",
+     "meta_description": "The best running and cycling clubs in Amsterdam in 2026: Sunday Run Club, Patta, Midnight Runners, Cycle Capital, Kaptein and more, ranked.",
+     "intro": "The biggest running community in Amsterdam is Sunday Run Club, with around 29,000 Instagram followers and partners like PerfectTed and La Place. On the bikes, Cycle Capital and the 330-member Kaptein Cycling Club lead a club scene built on fixed weekly rides and real local sponsors.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Sunday Run Club",
+       "handle": "@sun.dayrunclub",
+       "summary": "A running and fitness community with around 29,000 Instagram followers, running social, interval and beginner sessions. Founded by Sophie Nordenhed, partnered with PerfectTed and La Place."
+      },
+      {
+       "rank": 2,
+       "name": "Cycle Capital Cycling Club",
+       "handle": "@cycle_capital",
+       "summary": "A cycling club with around 1,000 Instagram followers, riding every Sunday in groups of 4 to 30. Organised by Arjen Kuin, sponsored by CIOVITA."
+      },
+      {
+       "rank": 3,
+       "name": "Kaptein Cycling Club (KCC)",
+       "handle": "@kaptein_cycling_club",
+       "summary": "A cycling club with 330+ members riding Wednesday and Thursday evenings and Sunday mornings. Led by president Daan Kahmann, partnered with Kaptein Tweewielers, Sockeloen and Brouwerij De Eeuwige Jeugd."
+      },
+      {
+       "rank": 4,
+       "name": "Midnight Runners Amsterdam",
+       "handle": "",
+       "summary": "A running and fitness community running weekly sessions plus parties, 50 to 150 per event, promoted via Eventbrite and Facebook. Backed by global sponsor Mizuno."
+      },
+      {
+       "rank": 5,
+       "name": "Running Late Club",
+       "handle": "@runninglateclub_ams",
+       "summary": "A running and fitness club running daily, including a Monday 18:30 session with The Hoxton, its weekly hotel partner."
+      },
+      {
+       "rank": 6,
+       "name": "Patta Running Team",
+       "handle": "@pattarunningteam",
+       "summary": "A street-culture running team meeting Monday and Tuesday 19:30 and Sunday 10:30, founded by Edson Sabajo. It collaborates with Nike (Patta x Nike RT); as the arm of a global brand it is less collaboration-available than the independent clubs above. Audience not public."
+      },
+      {
+       "rank": 7,
+       "name": "Rapha Cycling Club Amsterdam",
+       "handle": "",
+       "summary": "A weekly Sunday ride of 20 to 40, run from the Rapha clubhouse at Wolvenstraat 10. As a brand-run club it ranks below the independent community clubs. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience first, then ride and run cadence, membership, and real brand or venue collaborations; brand-owned clubs like Rapha rank below independent community clubs.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Amsterdam?",
+       "a": "Sunday Run Club is the biggest by public audience, with around 29,000 Instagram followers. It runs social, interval and beginner sessions, was founded by Sophie Nordenhed, and partners with PerfectTed and La Place."
+      },
+      {
+       "q": "What is the biggest cycling club in Amsterdam?",
+       "a": "Cycle Capital Cycling Club leads by public following with around 1,000 on Instagram, riding every Sunday in groups of 4 to 30. Kaptein Cycling Club is close behind with 330+ members riding three times a week."
+      },
+      {
+       "q": "Are the running and cycling clubs in Amsterdam free to join?",
+       "a": "Cadences and formats vary, from Sunday Run Club's beginner-friendly runs to Kaptein's midweek and Sunday rides. Details differ by club, so check each group's Instagram or website for how to join their next session."
+      }
+     ],
+     "cta": "If you lead one of these clubs and want a café or venue to end your run or ride at, or you own a spot that wants those regulars, Kolabing can set it up.",
+     "topic": "running-cycling",
+     "verticals": [
+      "running",
+      "cycling"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The 6 Best Social, Nightlife & Culture Communities in Amsterdam (2026)",
+     "slug": "best-social-nightlife-culture-communities-in-amsterdam",
+     "meta_description": "The best social, nightlife and culture communities in Amsterdam in 2026: AIC, the Expat Meetup, Amsterdam Film Group, Culture Club, IsBurning and EAST.",
+     "intro": "The biggest social community in Amsterdam is AIC: Amsterdam International Community, with 25,489 members meeting weekly. The Amsterdam Expat Meetup Group is larger still at 35,966. For culture and nightlife, Amsterdam Culture Club, IsBurning and Paradiso-programmed EAST anchor the scene.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "The Amsterdam Expat Meetup Group",
+       "handle": "",
+       "summary": "Amsterdam's largest expat social group with 35,966 members and weekly events of 3 to 83 people. Organised by Summer and four co-hosts, sponsored by the City of Amsterdam."
+      },
+      {
+       "rank": 2,
+       "name": "AIC: Amsterdam International Community",
+       "handle": "@Aloha",
+       "summary": "An expat and social community of 25,489 members meeting weekly or more, 8 to 41 per event. Organised by Attila and five others, at venues like Breugem Brewery, Amsterdam Comedy Club and The College Hotel."
+      },
+      {
+       "rank": 3,
+       "name": "Amsterdam Culture Club (ACC)",
+       "handle": "",
+       "summary": "A culture, art and music community of 4,677 members meeting roughly monthly. Organised by Arthur Augustijn and three others, at Theater De Richel and the Luther Museum."
+      },
+      {
+       "rank": 4,
+       "name": "EAST Techno Collective",
+       "handle": "@eastcollective_amsterdam",
+       "summary": "A weekly techno night with around 4,877 Instagram followers, programmed with and hosted at Paradiso."
+      },
+      {
+       "rank": 5,
+       "name": "Amsterdam Film Group",
+       "handle": "",
+       "summary": "A film and creative community of 1,179 members meeting roughly weekly, 4 to 13 per event. Organised by Ben and four others at LAB111, De Uitkijk and the H'ART Museum."
+      },
+      {
+       "rank": 6,
+       "name": "IsBurning",
+       "handle": "@isburningparty",
+       "summary": "A queer house and techno party running roughly monthly plus a Pride edition, co-founded by Carlos Valdes and Sandrien in collaboration with CVNT Collective. Resident Advisor calls it Amsterdam's most popular LGBTQIA+ party. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public member count and following first, then cadence and turnout, platform presence, and named venue collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest social community in Amsterdam?",
+       "a": "By members, The Amsterdam Expat Meetup Group leads with 35,966, followed by AIC: Amsterdam International Community at 25,489. Both run weekly events, with AIC using venues like Breugem Brewery and The College Hotel."
+      },
+      {
+       "q": "What is the best nightlife community in Amsterdam?",
+       "a": "IsBurning and EAST Techno Collective lead the nightlife scene. IsBurning is a monthly queer house and techno party that Resident Advisor calls Amsterdam's most popular LGBTQIA+ party, while EAST runs weekly, programmed at Paradiso."
+      },
+      {
+       "q": "Are there culture and film communities in Amsterdam?",
+       "a": "Yes. Amsterdam Culture Club has 4,677 members meeting monthly across art and music venues, and Amsterdam Film Group has 1,179 members meeting roughly weekly at LAB111, De Uitkijk and the H'ART Museum."
+      }
+     ],
+     "cta": "If you run one of these communities and want a venue for your next night or meetup, or you own a space that wants their crowd, Kolabing can make the connection.",
+     "topic": "nightlife-culture",
+     "verticals": [
+      "nightlife",
+      "techno",
+      "culture",
+      "music",
+      "art",
+      "film"
+     ],
+     "wave": 3
+    }
+   ]
+  },
+  {
+   "city": "Tallinn",
+   "sort": 6,
+   "pieces": [
+    {
+     "title": "The 10 Best Community Groups in Tallinn (2026)",
+     "slug": "best-community-groups-in-tallinn",
+     "meta_description": "The best organised communities in Tallinn in 2026: Revive Wellness Club, Tallinn Bicycle Week and ProductTank lead a strong local scene of regular groups.",
+     "intro": "The strongest community group in Tallinn right now is Revive Wellness Club, with roughly 13,000 Instagram followers and weekly sauna and ice-bath sessions. Behind it sits Tallinn Bicycle Week and its Tour d'ÖÖ night rides, then the ProductTank product meetup. Below is our full curated ranking of the ten strongest local groups.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Revive Wellness Club",
+       "handle": "@revive.wellnessclub",
+       "summary": "A wellness and recovery community running weekly classes with sauna and ice-bath sessions. Its roughly 13,000 Instagram followers make it the largest community audience in the city."
+      },
+      {
+       "rank": 2,
+       "name": "Tallinn Bicycle Week / Tour d'ÖÖ",
+       "handle": "@tallinnbicycleweek",
+       "summary": "A cycling and culture community built around seasonal night rides, with about 3,412 Instagram followers. It is co-organised with the UIT Festival and Tartu Cyclists' Society, with design by Ruum 414."
+      },
+      {
+       "rank": 3,
+       "name": "ProductTank Tallinn",
+       "handle": "",
+       "summary": "A product and tech meetup on Meetup with 1,241 members, drawing 58 to 73 people per roughly monthly event. Part of Mind The Product, with hosts rotating across Bondora, Coolbet and Microsoft Estonia."
+      },
+      {
+       "rank": 4,
+       "name": "Ohana Tallinn",
+       "handle": "@ohanatallinn",
+       "summary": "An Old Town wellness and sauna community with around 493 Instagram followers, running wood-fired sauna and ice-bath sessions."
+      },
+      {
+       "rank": 5,
+       "name": "MRC Tallinn (Mikkeller Running Club)",
+       "handle": "@mrctallinn",
+       "summary": "A running-and-beer club with about 246 Instagram followers, meeting weekly on Tuesdays at 18:00 at BrewDog Tallinn. Organised by Inga Leetmaa, hosted at BrewDog, under the Mikkeller parent."
+      },
+      {
+       "rank": 6,
+       "name": "eChai Tallinn Startup Network",
+       "handle": "",
+       "summary": "A startup and founders network on Meetup with 220 members, drawing 2 to 4 people per periodic event. Co-founded by Jatin Chaudhary."
+      },
+      {
+       "rank": 7,
+       "name": "CFC Cycling Fan Club Racing Team",
+       "handle": "",
+       "summary": "A cycling club with 112 members on Strava (club 131468) and its own site at cfc.ee, active seasonally."
+      },
+      {
+       "rank": 8,
+       "name": "Tallinn Road Runners",
+       "handle": "",
+       "summary": "A running club on Strava (club 462807) with 100+ members and a recurring schedule."
+      },
+      {
+       "rank": 9,
+       "name": "International Friends Tallinn (expatVIBE)",
+       "handle": "",
+       "summary": "An expat and social community running on Meetup, Facebook and Instagram, with ongoing activities from rock climbing to chess to dinners. Run by Super Organizer Markus M. Milder; audience not public."
+      },
+      {
+       "rank": 10,
+       "name": "Daily Meetups",
+       "handle": "",
+       "summary": "An expat and social community on Meetup and dailymeetups.ee with a daily cadence, including Monday board games and Friday drinks. Organised by Markus M. Milder; audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Tallinn?",
+       "a": "Revive Wellness Club is the biggest by public audience, with roughly 13,000 Instagram followers. It runs weekly wellness and recovery classes with sauna and ice-bath sessions, making it Tallinn's largest organised community group."
+      },
+      {
+       "q": "What kinds of communities are most active in Tallinn?",
+       "a": "Wellness, cycling, running, startup and expat communities are the most active in Tallinn. Groups like Revive Wellness Club, Tallinn Bicycle Week, MRC Tallinn and ProductTank run regular weekly or monthly gatherings across the city."
+      },
+      {
+       "q": "Which Tallinn communities already work with venues?",
+       "a": "MRC Tallinn meets weekly at BrewDog Tallinn, and ProductTank Tallinn rotates hosts across Bondora, Coolbet and Microsoft Estonia. Both show how a venue can trade space and perks for regular community footfall."
+      }
+     ],
+     "cta": "If your community is on this list and you want a venue to host your next event, or you run a Tallinn venue and want these groups through your door, claim your listing on Kolabing.",
+     "topic": null,
+     "verticals": null,
+     "wave": 1
+    },
+    {
+     "title": "The 4 Best Startup & Tech Communities in Tallinn (2026)",
+     "slug": "best-startup-tech-communities-in-tallinn",
+     "meta_description": "The best startup and tech communities in Tallinn in 2026: ProductTank Tallinn leads on audience, alongside LIFT99, Vibe Code Atelier and eChai.",
+     "intro": "The strongest startup and tech community in Tallinn is ProductTank Tallinn, with 1,241 Meetup members and 58 to 73 people per event. Around it sits the LIFT99 Tallinn Hub, the Vibe Code Atelier demo day, and the eChai Tallinn founders network. Here is our curated ranking of the four.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "ProductTank Tallinn",
+       "handle": "",
+       "summary": "A product and tech meetup on Meetup with 1,241 members, pulling 58 to 73 people per roughly monthly event. Part of Mind The Product, run by three organisers, with hosts rotating across Bondora, Coolbet and Microsoft Estonia."
+      },
+      {
+       "rank": 2,
+       "name": "LIFT99 Tallinn Hub",
+       "handle": "@lift99co",
+       "summary": "A startup and coworking community meeting roughly weekly, hosting the Vibe Code Atelier and demo days. It partners with Startup Adventures and Skaala; audience not public."
+      },
+      {
+       "rank": 3,
+       "name": "Vibe Code Atelier",
+       "handle": "",
+       "summary": "A monthly builder and AI demo day on Luma, run by the Startup Adventures team and co-presented with Startup Adventures, Skaala and LIFT99. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "eChai Tallinn Startup Network",
+       "handle": "",
+       "summary": "A startup and founders network on Meetup and echai.ventures with 220 members, drawing 2 to 4 people per periodic event. Co-founded by Jatin Chaudhary."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest startup community in Tallinn?",
+       "a": "ProductTank Tallinn is the biggest, with 1,241 Meetup members and 58 to 73 people per event. It is part of the global Mind The Product network and rotates hosts across Bondora, Coolbet and Microsoft Estonia."
+      },
+      {
+       "q": "Where do Tallinn founders and builders meet?",
+       "a": "Tallinn founders and builders gather at ProductTank meetups, the LIFT99 Tallinn Hub, the monthly Vibe Code Atelier demo day, and eChai Tallinn events. LIFT99 hosts the Vibe Code Atelier and regular demo days."
+      },
+      {
+       "q": "Are these tech communities open to hosting at venues?",
+       "a": "Yes. ProductTank already rotates across corporate hosts, and LIFT99 runs weekly sessions and demo days. These groups regularly need space, which makes them a natural fit for venues wanting founder and builder footfall."
+      }
+     ],
+     "cta": "If you organise one of these communities and want a venue for your next demo day or meetup, or you run a Tallinn space and want founders through the door, claim your listing on Kolabing.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 4 Best Cycling Clubs in Tallinn (2026)",
+     "slug": "best-cycling-clubs-in-tallinn",
+     "meta_description": "The best cycling clubs in Tallinn in 2026: Tallinn Bicycle Week and its Tour d'ÖÖ night rides lead, with TERVISESPORT, CFC and Team Vänt.",
+     "intro": "The best-known cycling community in Tallinn is Tallinn Bicycle Week, with about 3,412 Instagram followers and its seasonal Tour d'ÖÖ night rides. Alongside it ride the amateur TERVISESPORT group, the CFC Cycling Fan Club Racing Team, and Team Vänt. Here is our curated ranking of the four.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Tallinn Bicycle Week / Tour d'ÖÖ",
+       "handle": "@tallinnbicycleweek",
+       "summary": "A cycling and culture community around seasonal night rides, with roughly 3,412 Instagram followers. Co-organised with the UIT Festival and Tartu Cyclists' Society, with design by Ruum 414."
+      },
+      {
+       "rank": 2,
+       "name": "CFC Cycling Fan Club Racing Team",
+       "handle": "",
+       "summary": "A cycling club with 112 members on Strava (club 131468) and its own site at cfc.ee, active seasonally."
+      },
+      {
+       "rank": 3,
+       "name": "TERVISESPORT",
+       "handle": "",
+       "summary": "An amateur cycling group on Strava (club 45391), running seasonally under the Biketravel.ee parent. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "Team Vänt",
+       "handle": "",
+       "summary": "A cycling club active on Strava (club 183068) and Facebook, riding seasonally. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations.",
+     "faq": [
+      {
+       "q": "What is the biggest cycling club in Tallinn?",
+       "a": "Tallinn Bicycle Week is the most visible, with about 3,412 Instagram followers and its seasonal Tour d'ÖÖ night rides. It is co-organised with the UIT Festival and the Tartu Cyclists' Society, with design by Ruum 414."
+      },
+      {
+       "q": "Which Tallinn cycling clubs are on Strava?",
+       "a": "CFC Cycling Fan Club Racing Team (112 members), TERVISESPORT and Team Vänt all run clubs on Strava. CFC also has its own site at cfc.ee, while TERVISESPORT sits under the Biketravel.ee parent."
+      },
+      {
+       "q": "When are Tallinn cycling clubs most active?",
+       "a": "Most Tallinn cycling clubs run seasonally, concentrated in the warmer months. Tallinn Bicycle Week's Tour d'ÖÖ night rides are a seasonal highlight, and CFC, TERVISESPORT and Team Vänt all ride on a seasonal cadence."
+      }
+     ],
+     "cta": "If you run one of these clubs and want a café or venue to finish a ride at, or you run a Tallinn venue and want cyclists through the door, claim your listing on Kolabing.",
+     "topic": "cycling-clubs",
+     "verticals": [
+      "cycling"
+     ],
+     "wave": 2
+    },
+    {
+     "title": "The 5 Best Expat & Social Communities in Tallinn (2026)",
+     "slug": "best-expat-social-communities-in-tallinn",
+     "meta_description": "The best expat and social communities in Tallinn in 2026: International Friends Tallinn and Daily Meetups lead, with ESN Tallinn and more.",
+     "intro": "The most active expat and social communities in Tallinn are International Friends Tallinn (expatVIBE) and Daily Meetups, both run by Markus M. Milder with ongoing weekly and daily events. Alongside them sit ESN Tallinn, Tallinn Expats Gatherings, and the annual Nomad Summit. Here is our curated ranking of the five.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "International Friends Tallinn (expatVIBE)",
+       "handle": "",
+       "summary": "An expat and social community across Meetup, Facebook and Instagram, with ongoing activities from rock climbing to chess to dinners. Run by Super Organizer Markus M. Milder; audience not public."
+      },
+      {
+       "rank": 2,
+       "name": "Daily Meetups",
+       "handle": "",
+       "summary": "An expat and social community on Meetup and dailymeetups.ee with a daily cadence, including Monday board games and Friday drinks. Organised by Markus M. Milder; audience not public."
+      },
+      {
+       "rank": 3,
+       "name": "ESN Tallinn",
+       "handle": "@esn.tallinn",
+       "summary": "A student and international community running weekly student socials, part of the Erasmus Student Network. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "Tallinn Expats Gatherings",
+       "handle": "",
+       "summary": "An expat and social community on Meetup and socialize.ee with recurring gatherings, run in partnership with Socialize.ee. Audience not public."
+      },
+      {
+       "rank": 5,
+       "name": "Nomad Summit / Nomad Week Tallinn",
+       "handle": "",
+       "summary": "An annual digital-nomad event on nomadsummit.com and Luma, drawing a pan-EU nomad audience, held at Kultuurikatel. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations.",
+     "faq": [
+      {
+       "q": "What are the best expat communities in Tallinn?",
+       "a": "International Friends Tallinn (expatVIBE) and Daily Meetups are the most active expat communities in Tallinn, both run by Markus M. Milder. ESN Tallinn, Tallinn Expats Gatherings and the annual Nomad Summit round out the scene."
+      },
+      {
+       "q": "Where can newcomers meet people in Tallinn?",
+       "a": "Newcomers can join Daily Meetups, which runs daily events including Monday board games and Friday drinks, or International Friends Tallinn, which mixes rock climbing, chess and dinners. ESN Tallinn runs weekly socials for students."
+      },
+      {
+       "q": "Is there a digital nomad community in Tallinn?",
+       "a": "Yes. The Nomad Summit, also known as Nomad Week Tallinn, is an annual digital-nomad event drawing a pan-EU audience, hosted at Kultuurikatel and listed on nomadsummit.com and Luma."
+      }
+     ],
+     "cta": "If you organise one of these communities and want a regular venue to gather at, or you run a Tallinn space and want expats and newcomers through the door, claim your listing on Kolabing.",
+     "topic": "social-expat",
+     "verticals": [
+      "expat",
+      "social",
+      "nomad",
+      "language",
+      "friend",
+      "international",
+      "couchsurf",
+      "student",
+      "erasmus"
+     ],
+     "wave": 2
+    }
+   ]
+  },
+  {
+   "city": "Warsaw",
+   "sort": 7,
+   "pieces": [
+    {
+     "title": "The Best Community Groups in Warsaw (2026)",
+     "slug": "best-community-groups-in-warsaw",
+     "meta_description": "The best community groups in Warsaw in 2026: running and cycling clubs, AI and startup meetups, and creative social scenes worth hosting.",
+     "intro": "The best community groups in Warsaw run the gamut from Warsaw Book Club (around 36,000 on Instagram) and Social Running Club (around 9,100 followers, roughly 4,500 members) to bi-weekly innovation nights at Venture Café. Below: the twelve pulling the most regulars, grouped by scene.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Warsaw Book Club",
+       "handle": "@warsawbookclub",
+       "summary": "A books and culture community with the largest public following on this list, around 36,000 on Instagram. Meets monthly."
+      },
+      {
+       "rank": 2,
+       "name": "Social Running Club",
+       "handle": "@socialrunning_club",
+       "summary": "Warsaw's biggest independent running community, around 9,100 on Instagram and roughly 4,500 members. Weekly Wednesday run at 18:30 from Skaryszewski Park, with ON Running ambassadors and Omi Athletics behind it."
+      },
+      {
+       "rank": 3,
+       "name": "Venture Café Warsaw (Thursday Gathering)",
+       "handle": "",
+       "summary": "A large, recurring business and innovation network running bi-weekly Thursday gatherings, run by the Venture Café Foundation with OVHcloud and corporate partners."
+      },
+      {
+       "rank": 4,
+       "name": "KULT Cycling",
+       "handle": "@kult.cc",
+       "summary": "A cycling club with around 2,000 on Instagram, weekly rides plus specials, based out of its shop and café at Belwederska 44. Partners include Isadore, Fingerscrossed, Sweet Protection, Alba Optics and UUA Velosport."
+      },
+      {
+       "rank": 5,
+       "name": "Warsaw.AI",
+       "handle": "",
+       "summary": "A monthly AI and tech meetup run by Fundacja Quantum AI, with Allegro Tech as strategic partner. Audience not public."
+      },
+      {
+       "rank": 6,
+       "name": "Warsaw Social (+ Language Exchange)",
+       "handle": "",
+       "summary": "A weekly expat and social night, Fridays from 17:30 at AZYL Shot & Craft Beer Bar, listed on Eventbrite and Meetup. Audience not public."
+      },
+      {
+       "rank": 7,
+       "name": "Warsaw Creative Club",
+       "handle": "",
+       "summary": "A nightlife and culture experience running roughly weekly across venues including The Social Praga, Mindspace Koszyki and Smolna 13, organised by Elliott Chapman. Audience not public."
+      },
+      {
+       "rank": 8,
+       "name": "Startup Grind Warsaw",
+       "handle": "",
+       "summary": "A monthly startup networking chapter powered by Google for Startups. Audience not public."
+      },
+      {
+       "rank": 9,
+       "name": "Founders Running Club Warsaw",
+       "handle": "@foundersrc",
+       "summary": "A running and networking crossover with 454 Meetup members, meeting Saturdays at 9:30 for a 4 to 9 km run from Klubokawiarnia Kolonia, organised by Tim Tkachenko."
+      },
+      {
+       "rank": 10,
+       "name": "CreativeTech Poland",
+       "handle": "",
+       "summary": "A creative-tech meetup drawing 165+ RSVPs, running roughly monthly at Prześwit, organised by Agnieszka Cichocka."
+      },
+      {
+       "rank": 11,
+       "name": "InterNations Warsaw",
+       "handle": "",
+       "summary": "A monthly expat networking group run by its Warsaw Ambassadors on internations.org. Audience not public."
+      },
+      {
+       "rank": 12,
+       "name": "adidas Runners Warsaw",
+       "handle": "@runnersofwarsaw",
+       "summary": "A brand-run running community, around 7,000 on Instagram, with weekly free trainings. Brand-owned, so ranked below the independents, which are more open to venue collaboration."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations; brand-owned clubs rank below independents.",
+     "faq": [
+      {
+       "q": "What is the biggest community group in Warsaw?",
+       "a": "By public following, Warsaw Book Club is the largest on this list at around 36,000 on Instagram, meeting monthly. Among running communities, Social Running Club leads with around 9,100 followers and roughly 4,500 members."
+      },
+      {
+       "q": "What community groups in Warsaw meet weekly?",
+       "a": "Several meet weekly: Social Running Club runs Wednesdays at 18:30 from Skaryszewski Park, KULT Cycling rides weekly from Belwederska 44, and Warsaw Social hosts a Friday language exchange from 17:30 at AZYL Shot & Craft Beer Bar."
+      },
+      {
+       "q": "Are these community groups open to hosting at local venues?",
+       "a": "Independent groups like Social Running Club, KULT Cycling and Warsaw Creative Club already run at cafés, bars and venues across the city, so they are the most open to a venue partnership. Brand-owned clubs are typically less available."
+      }
+     ],
+     "cta": "If your group is on this list and you want a venue to host your next event, or you run a Warsaw venue and want these communities through your door, Kolabing makes the introduction.",
+     "topic": null,
+     "verticals": null,
+     "wave": 3
+    },
+    {
+     "title": "The Best AI, Startup & Tech Communities in Warsaw (2026)",
+     "slug": "best-ai-startup-tech-communities-in-warsaw",
+     "meta_description": "The best AI, startup and tech communities in Warsaw in 2026: Warsaw.AI, Venture Café, Startup Grind and the meetups builders actually attend.",
+     "intro": "The best AI and startup communities in Warsaw are Warsaw.AI, a monthly AI meetup backed by Allegro Tech, and Venture Café Warsaw, whose bi-weekly Thursday Gathering is one of the city's largest recurring innovation nights. Below: the seven tech and founder communities worth knowing.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Venture Café Warsaw (Thursday Gathering)",
+       "handle": "",
+       "summary": "One of Warsaw's largest recurring innovation networks, running bi-weekly Thursday gatherings via the Venture Café Foundation, with OVHcloud and corporate partners."
+      },
+      {
+       "rank": 2,
+       "name": "Warsaw.AI",
+       "handle": "",
+       "summary": "A monthly AI and tech meetup run by Fundacja Quantum AI, with Allegro Tech as strategic partner. Audience not public."
+      },
+      {
+       "rank": 3,
+       "name": "Startup Grind Warsaw",
+       "handle": "",
+       "summary": "A monthly startup networking chapter powered by Google for Startups. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "Mindstone Warsaw AI Community",
+       "handle": "",
+       "summary": "A monthly AI meetup connected to the global Mindstone network, listed on Meetup and Mindstone. Audience not public."
+      },
+      {
+       "rank": 5,
+       "name": "AI Tinkerers Poland",
+       "handle": "",
+       "summary": "A recurring AI builder meetup at poland.aitinkerers.org, aimed at people making things rather than just talking about them. Audience not public."
+      },
+      {
+       "rank": 6,
+       "name": "Tech Startups in the Pub – Warsaw",
+       "handle": "",
+       "summary": "A recurring after-work startup networking meetup, organised by Rob W. Audience not public."
+      },
+      {
+       "rank": 7,
+       "name": "Warsaw Makers & Founders",
+       "handle": "",
+       "summary": "A recurring builders and founders meetup on Meetup. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations; audience figures for most of these meetups are not public, so cadence and partners carry the weight.",
+     "faq": [
+      {
+       "q": "What is the biggest AI or tech community in Warsaw?",
+       "a": "Venture Café Warsaw runs one of the city's largest recurring innovation networks through its bi-weekly Thursday Gathering. On the AI side, Warsaw.AI is a monthly meetup backed by Allegro Tech as strategic partner."
+      },
+      {
+       "q": "Which Warsaw meetups are best for AI builders?",
+       "a": "AI Tinkerers Poland runs a recurring builder-focused meetup for people shipping projects, and Mindstone Warsaw AI Community meets monthly as part of the global Mindstone network. Warsaw.AI adds a monthly AI and tech session."
+      },
+      {
+       "q": "How often do Warsaw startup communities meet?",
+       "a": "Cadence varies: Venture Café gathers bi-weekly on Thursdays, Warsaw.AI, Mindstone and Startup Grind run monthly, and Tech Startups in the Pub and Warsaw Makers & Founders run recurring after-work sessions."
+      }
+     ],
+     "cta": "Run one of these meetups and need a room? Or a Warsaw café or venue that wants a founder crowd on a quiet weeknight? Kolabing connects the two.",
+     "topic": "ai-tech",
+     "verticals": [
+      "tech",
+      "ai",
+      "startup",
+      "product",
+      "builder",
+      "web3",
+      "genai",
+      "dev"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The Best Running & Cycling Clubs in Warsaw (2026)",
+     "slug": "best-running-cycling-clubs-in-warsaw",
+     "meta_description": "The best running and cycling clubs in Warsaw in 2026: Social Running Club, KULT Cycling and the crews with the biggest weekly turnout.",
+     "intro": "The best running and cycling clubs in Warsaw are Social Running Club, the city's biggest independent run crew at around 9,100 on Instagram and roughly 4,500 members, and KULT Cycling, whose shop and café at Belwederska 44 anchors weekly rides. Below: the four crews worth joining.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Social Running Club",
+       "handle": "@socialrunning_club",
+       "summary": "Warsaw's biggest independent running community, around 9,100 on Instagram and roughly 4,500 members. Weekly Wednesday run at 18:30 from Skaryszewski Park, organised by Wiktor, Michał and Kuba, with ON Running ambassadors and Omi Athletics behind it."
+      },
+      {
+       "rank": 2,
+       "name": "KULT Cycling",
+       "handle": "@kult.cc",
+       "summary": "A cycling club with around 2,000 on Instagram, running weekly rides plus specials from its shop and café at Belwederska 44. Partners include Isadore, Fingerscrossed, Sweet Protection, Alba Optics and UUA Velosport."
+      },
+      {
+       "rank": 3,
+       "name": "Founders Running Club Warsaw",
+       "handle": "@foundersrc",
+       "summary": "A running and networking crossover with 454 Meetup members, meeting Saturdays at 9:30 for a 4 to 9 km run from Klubokawiarnia Kolonia, organised by Tim Tkachenko."
+      },
+      {
+       "rank": 4,
+       "name": "adidas Runners Warsaw",
+       "handle": "@runnersofwarsaw",
+       "summary": "A brand-run running community, around 7,000 on Instagram, with weekly free trainings. Brand-owned, so ranked below the independents, which are more open to venue collaboration."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real brand or venue collaborations; brand-owned clubs rank below independents.",
+     "faq": [
+      {
+       "q": "What is the biggest running club in Warsaw?",
+       "a": "Social Running Club is the biggest independent running crew in Warsaw, around 9,100 on Instagram and roughly 4,500 members. It runs weekly on Wednesdays at 18:30 from Skaryszewski Park, backed by ON Running ambassadors and Omi Athletics."
+      },
+      {
+       "q": "Is there a good cycling club in Warsaw?",
+       "a": "KULT Cycling runs weekly rides plus specials out of its shop and café at Belwederska 44, with around 2,000 on Instagram and partners including Isadore, Fingerscrossed, Sweet Protection, Alba Optics and UUA Velosport."
+      },
+      {
+       "q": "Which Warsaw running club is best for founders and networking?",
+       "a": "Founders Running Club Warsaw pairs a run with networking, with 454 Meetup members and a Saturday 9:30 session covering 4 to 9 km from Klubokawiarnia Kolonia, organised by Tim Tkachenko."
+      }
+     ],
+     "cta": "If you organise one of these crews and want a café or bar to host the post-run gathering, or you run a Warsaw venue near a park, Kolabing sets up the collaboration.",
+     "topic": "running-cycling",
+     "verticals": [
+      "running",
+      "cycling"
+     ],
+     "wave": 3
+    },
+    {
+     "title": "The Best Creative & Social Communities in Warsaw (2026)",
+     "slug": "best-creative-social-communities-in-warsaw",
+     "meta_description": "The best creative and social communities in Warsaw in 2026: Warsaw Book Club, Warsaw Creative Club, supper clubs and expat nights.",
+     "intro": "The best creative and social communities in Warsaw are Warsaw Book Club, the largest here at around 36,000 on Instagram, and Warsaw Creative Club, a roughly weekly nightlife and culture experience across venues like The Social Praga and Mindspace Koszyki. Below: the six creative and social scenes worth joining.",
+     "ranked": [
+      {
+       "rank": 1,
+       "name": "Warsaw Book Club",
+       "handle": "@warsawbookclub",
+       "summary": "A books and culture community with the largest public following here, around 36,000 on Instagram. Meets monthly."
+      },
+      {
+       "rank": 2,
+       "name": "Warsaw Social (+ Language Exchange)",
+       "handle": "",
+       "summary": "A weekly expat and social night, Fridays from 17:30 at AZYL Shot & Craft Beer Bar, listed on Eventbrite and Meetup. Audience not public."
+      },
+      {
+       "rank": 3,
+       "name": "Warsaw Creative Club",
+       "handle": "",
+       "summary": "A nightlife and culture experience running roughly weekly across venues including The Social Praga, Mindspace Koszyki and Smolna 13, organised by Elliott Chapman. Audience not public."
+      },
+      {
+       "rank": 4,
+       "name": "CreativeTech Poland",
+       "handle": "",
+       "summary": "A creative-tech meetup drawing 165+ RSVPs, running roughly monthly at Prześwit, organised by Agnieszka Cichocka."
+      },
+      {
+       "rank": 5,
+       "name": "InterNations Warsaw",
+       "handle": "",
+       "summary": "A monthly expat networking group run by its Warsaw Ambassadors on internations.org. Audience not public."
+      },
+      {
+       "rank": 6,
+       "name": "Warsaw Food Club",
+       "handle": "",
+       "summary": "A food and supper-club community running recurring dinners at KALBAS, co-hosted by Braavo Capital and Taige, listed on Luma. Audience not public."
+      }
+     ],
+     "how_ranked": "A curated editorial ranking weighing public audience size first, then activity and cadence, platform presence, and real venue or brand collaborations; where audience figures are not public, cadence, venues and hosts carry the weight.",
+     "faq": [
+      {
+       "q": "What is the biggest creative community in Warsaw?",
+       "a": "Warsaw Book Club has the largest public following of these communities at around 36,000 on Instagram, running as a monthly books and culture community."
+      },
+      {
+       "q": "Where can expats meet people in Warsaw?",
+       "a": "Warsaw Social runs a weekly Friday language exchange from 17:30 at AZYL Shot & Craft Beer Bar, and InterNations Warsaw hosts a monthly expat networking event run by its Warsaw Ambassadors."
+      },
+      {
+       "q": "Are there supper clubs or food communities in Warsaw?",
+       "a": "Warsaw Food Club runs recurring supper-club dinners at KALBAS, co-hosted by Braavo Capital and Taige and listed on Luma. Audience size is not public."
+      }
+     ],
+     "cta": "If you host one of these communities and want a venue for your next night, or you run a Warsaw space that fits a creative or social crowd, Kolabing makes the match.",
+     "topic": "creative-books",
+     "verticals": [
+      "book",
+      "creative",
+      "writer",
+      "drawing",
+      "art",
+      "culture"
+     ],
+     "wave": 3
+    }
+   ]
+  }
+ ]
+}

--- a/database/migrations/2026_08_18_130000_create_community_rankings.php
+++ b/database/migrations/2026_08_18_130000_create_community_rankings.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Community rankings directory (public city×topic lead-magnet pages).
+ *
+ * The ranked list is a LIVE projection of crm_accounts (type=community) ordered by
+ * the admin-managed score, so re-rank/edit/add/remove all happen in /admin/crm.
+ * This migration adds only the thin editorial + control layer:
+ *  - ranking_pages: the per-page marketing copy (curated without touching leads).
+ *  - crm_accounts.listed: the public-visibility flag on a community lead.
+ *  - listing_claims: the one-field "claim your listing" lead capture.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ranking_pages', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('city', 60);
+            $table->string('topic', 60)->nullable();      // null = the city hub page
+            $table->string('slug')->unique();
+            $table->string('title');
+            $table->string('meta_description', 320)->nullable();
+            $table->text('intro')->nullable();
+            $table->text('how_ranked')->nullable();
+            $table->json('verticals')->nullable();          // CRM vertical keywords this page pulls (null = all, for a hub)
+            $table->json('faq')->nullable();               // [{q,a}, ...]
+            $table->string('editor_name', 80)->nullable(); // named editor byline (E-E-A-T)
+            $table->boolean('published')->default(false);  // progressive-rollout guard
+            $table->integer('sort')->default(0);
+            $table->timestamps();
+
+            $table->index(['city', 'published']);
+            $table->index('topic');
+        });
+
+        Schema::table('crm_accounts', function (Blueprint $table): void {
+            // Public directory visibility. Community leads are private in the CRM until
+            // a maintainer lists them (or Maria's per-city review passes).
+            $table->boolean('listed')->default(false)->after('score');
+            $table->index(['type', 'listed']);
+        });
+
+        Schema::create('listing_claims', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('community_name');
+            $table->string('handle', 120)->nullable();
+            $table->string('email');
+            $table->string('city', 60)->nullable();
+            $table->string('source', 60)->nullable();      // which ranking page the claim came from
+            $table->foreignUuid('crm_account_id')->nullable()
+                ->constrained('crm_accounts')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('listing_claims');
+        Schema::table('crm_accounts', function (Blueprint $table): void {
+            $table->dropIndex(['type', 'listed']);
+            $table->dropColumn('listed');
+        });
+        Schema::dropIfExists('ranking_pages');
+    }
+};

--- a/database/seeders/RankingPageSeeder.php
+++ b/database/seeders/RankingPageSeeder.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\CrmAccount;
+use App\Models\RankingPage;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\File;
+
+/**
+ * Seeds the public community-rankings directory from database/data/community_rankings.json.
+ *
+ *  1. Upserts the editorial copy for each ranking page (ranking_pages), keyed on slug.
+ *     Only Wave-1 pages are published; the rest wait for a maintainer / Maria's review.
+ *  2. Best-effort: marks the ranked communities `listed` on their CRM lead and writes a
+ *     display blurb + rank_override into metrics, so the live page matches this curation.
+ *     For Barcelona (not in the PR #157 lead set) the community CRM rows are created here.
+ *
+ * Idempotent. Run AFTER KolabingCommunityLeadsSeeder (PR #157) so the 7-city leads exist:
+ *   php artisan db:seed --class=Database\Seeders\RankingPageSeeder
+ */
+class RankingPageSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $path = database_path('data/community_rankings.json');
+        if (! File::exists($path)) {
+            $this->command?->warn('RankingPageSeeder: data file missing, skipped.');
+
+            return;
+        }
+
+        /** @var array{cities: list<array<string, mixed>>} $data */
+        $data = json_decode(File::get($path), true, 512, JSON_THROW_ON_ERROR);
+        $editor = (string) config('rankings.editor_name', 'The Kolabing editorial team');
+
+        foreach ($data['cities'] as $c) {
+            $city = $c['city'];
+
+            foreach ($c['pieces'] as $sort => $p) {
+                RankingPage::query()->updateOrCreate(
+                    ['slug' => $p['slug']],
+                    [
+                        'city' => $city,
+                        'topic' => $p['topic'],
+                        'title' => $p['title'],
+                        'meta_description' => $p['meta_description'] ?? null,
+                        'intro' => $p['intro'] ?? null,
+                        'how_ranked' => $p['how_ranked'] ?? null,
+                        'verticals' => $p['verticals'] ?? null,
+                        'faq' => $p['faq'] ?? [],
+                        'editor_name' => $editor,
+                        'published' => (int) ($p['wave'] ?? 3) === 1,
+                        'sort' => (int) $sort,
+                    ],
+                );
+
+                $this->wireCommunities($city, $p);
+            }
+        }
+    }
+
+    /**
+     * Mark each ranked community `listed` on its CRM lead, with a display blurb + a
+     * hub-derived rank_override. Guarded so a CRM hiccup never breaks the copy seed.
+     *
+     * @param  array<string, mixed>  $piece
+     */
+    private function wireCommunities(string $city, array $piece): void
+    {
+        $isHub = $piece['topic'] === null;
+        $inferredVertical = $piece['verticals'][0] ?? 'community';
+
+        foreach ($piece['ranked'] as $rank => $r) {
+            try {
+                $account = CrmAccount::query()
+                    ->where('type', 'community')
+                    ->whereRaw('lower(name) = ?', [mb_strtolower(trim($r['name']))])
+                    ->where('metrics->city', $city)
+                    ->first();
+
+                if ($account === null) {
+                    // Only mint new leads for Barcelona (the researched, non-PR#157 set).
+                    if ($city !== 'Barcelona') {
+                        continue;
+                    }
+                    $account = new CrmAccount([
+                        'type' => 'community',
+                        'name' => $r['name'],
+                        'status' => 'Target',
+                        'instagram_handle' => $r['handle'] ?: null,
+                        'metrics' => [
+                            'city' => $city,
+                            'vertical' => $inferredVertical,
+                            'handle' => $r['handle'] ?: null,
+                        ],
+                    ]);
+                }
+
+                $metrics = $account->metrics ?? [];
+                $metrics['blurb'] = $r['summary'] ?? ($metrics['blurb'] ?? null);
+                if ($r['handle'] ?? null) {
+                    $metrics['handle'] = $metrics['handle'] ?? $r['handle'];
+                }
+                // The hub is the canonical citywide order; topic pages only fill gaps.
+                if ($isHub || ! isset($metrics['rank_override'])) {
+                    $metrics['rank_override'] = (int) $rank;
+                }
+
+                $account->metrics = $metrics;
+                $account->listed = true;
+                $account->save();
+            } catch (\Throwable $e) {
+                $this->command?->warn("RankingPageSeeder: could not wire '{$r['name']}' ({$e->getMessage()}).");
+            }
+        }
+    }
+}

--- a/resources/views/directory/partials/ranked-list.blade.php
+++ b/resources/views/directory/partials/ranked-list.blade.php
@@ -1,0 +1,30 @@
+{{-- The ranked list (joiner-first hero). $ranked = Collection<CrmAccount>. --}}
+<ol class="mt-8 space-y-4">
+    @foreach ($ranked as $i => $a)
+        @php
+            $m = $a->metrics ?? [];
+            $handle = $m['handle'] ?? ($a->instagram_handle ?? null);
+            $blurb = $m['blurb'] ?? trim(implode(' · ', array_filter([$m['audience'] ?? null, $m['cadence'] ?? null, $m['collab'] ?? null])));
+            $igUrl = $handle ? 'https://instagram.com/'.ltrim($handle, '@') : null;
+        @endphp
+        <li class="flex gap-4 rounded-2xl border border-off-black/10 bg-white p-5">
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-off-black text-sm font-black text-primary">{{ $i + 1 }}</div>
+            <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h3 class="font-montserrat text-lg font-bold leading-tight">{{ $a->name }}</h3>
+                    @if ($handle)
+                        <a href="{{ $igUrl }}" target="_blank" rel="noopener nofollow" class="text-sm font-medium text-off-black/50 hover:text-off-black">{{ $handle }}</a>
+                    @endif
+                    @if (! empty($m['vertical']))
+                        <span class="rounded-full bg-off-black/5 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-off-black/50">{{ $m['vertical'] }}</span>
+                    @endif
+                </div>
+                @if ($blurb)
+                    <p class="mt-1.5 text-sm leading-relaxed text-off-black/70">{{ $blurb }}</p>
+                @endif
+                <button type="button" data-claim="{{ $a->name }}" data-handle="{{ $handle }}"
+                        class="mt-2 text-xs font-semibold text-off-black/50 underline decoration-off-black/20 underline-offset-4 hover:text-off-black">Is this you? Claim or correct it</button>
+            </div>
+        </li>
+    @endforeach
+</ol>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\Admin\TypeController as AdminTypeController;
 use App\Http\Controllers\Admin\XpEarnRuleController as AdminXpEarnRuleController;
 use App\Http\Controllers\Admin\XpLevelController as AdminXpLevelController;
 use App\Http\Controllers\BlogController;
+use App\Http\Controllers\DirectoryController;
 use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\PasswordResetPageController;
 use App\Models\BlogPost;
@@ -248,6 +249,14 @@ Route::view('/es/terms', 'pages.es.terms')->name('terms.es');
 
 Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
 Route::get('/blog/{post}', [BlogController::class, 'show'])->name('blog.show');
+
+// Community rankings directory (public GTM lead-magnet pages).
+Route::get('/communities', [DirectoryController::class, 'index'])->name('directory.index');
+Route::get('/communities/how-we-rank', [DirectoryController::class, 'howWeRank'])->name('directory.how-we-rank');
+Route::post('/communities/claim', [DirectoryController::class, 'claim'])
+    ->middleware('throttle:10,1')->name('directory.claim');
+Route::get('/communities/{city}', [DirectoryController::class, 'show'])->name('directory.city');
+Route::get('/communities/{city}/{slug}', [DirectoryController::class, 'topic'])->name('directory.topic');
 
 Route::get('/sitemap.xml', function () {
     $urls = [


### PR DESCRIPTION
## Summary
Adds the public **community-rankings directory** at `/communities` — SEO/GEO lead-magnet pages that rank the real community groups in a city, drawn **live from the CRM** (`crm_accounts`, type=community, listed=true) so re-rank/edit/add/remove all happen in `/admin/crm`. Barcelona is built deep (hub + 12 category pages incl. pottery, art, life-drawing); other cities are hub-level. Includes an honest social-proof layer (vouch / verified-by-N / moderated testimonials / embeddable badge) and a static-preview exporter.

## Linked tracking item
Closes # <!-- add the Projects item id -->

## Type of change
- [x] ✨ Feature

## Changes
- **Data model:** `ranking_pages` (editorial copy) + `crm_accounts.listed` + `listing_claims` (one-field claim); social layer `listing_vouches` / `listing_testimonials` / `rank_snapshots` + claim double-opt-in (`verify_token`/`verified_at`). Additive, reversible.
- **`RankingProjection` service** — the single filter+rank code path shared by the live controller and the preview exporter (hub_rank keeps the curated hub unpolluted; rank_override drives per-category order; array-spaceship comparator replaces a silently-broken multi-key `sortBy`).
- **`DirectoryController`** — hub / category / how-we-rank pages + honest endpoints (`vouch`, `testimonial`, `claim`+verify, stateless `badge`), all mirroring the claim POST (honeypot + `RateLimiter`). **Votes never reorder the ranking.**
- **Views** (real `<x-layouts.marketing-page>` design): `directory/{index,city,topic,how-we-rank}` + rich `community-card` (avatar, member/cadence/venue/collab chips, CTA hierarchy — primary "Find them on Kolabing", secondary Luma/Meetup/Eventbrite/IG — vouch bar, verified-by-N, claim), CollectionPage/ItemList/FAQ/Breadcrumb JSON-LD + Daniel Martinez author entity.
- **Content:** `database/data/community_rankings.json` (Barcelona hub + 12 categories; the `creative-books` catch-all split into pottery/art/life-drawing/book-clubs). New category pages ship `published=false` (wave-2) pending per-city review.
- **Admin:** `/admin/rankings` — publish/unpublish pages + moderate pending testimonials.
- **Tooling:** `php artisan rankings:export-preview` renders the real Blade to static HTML for a shareable preview.

## Mobile impact (kolabing-app)
- [x] No mobile changes required

**Mobile details / kolabing-app link:** N/A — marketing-site (web host) only. All new routes are web routes under `/communities` + `/admin`, not the `/api/v1` contract the app consumes. No payload/enum/auth change.

## Database / migrations
- [x] Includes migrations — additive & reversible

**Migration notes:** Two additive migrations (`2026_08_18_130000_create_community_rankings`, `2026_08_18_140000_create_ranking_social_proof`). `RankingPageSeeder` (idempotent, registered in `DatabaseSeeder`) seeds the pages and marks CRM communities `listed`; it creates Barcelona community leads (not in the PR #157 set). Only Wave-1 pages publish; new category pages are `published=false`.

## Testing
- [ ] `php artisan test` passes — paste counts: **runs in CI** (box has no `pdo_sqlite`, so feature tests + `db:seed` execute on the Laravel Cloud pipeline, not locally).
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — full static preview rendered through the **real** marketing layout and deployed (fidelity grep gate: `#FFD560`/Montserrat/logo present, no `system-ui`); data traces JSON→seeder→render; re-rank demo reorders; `view:cache` compiles; `route:list` shows all directory + admin routes.

## Docs & rules updated
- [x] No docs impact <!-- new public marketing surface; no role/paywall/feed/onboarding or API-schema change. BACKLOG can be updated on merge. -->

## Screenshots / notes
**Reviewer guidance (Maria):** the 7 new Barcelona category pages (pottery, art, life-drawing, supper clubs, board games, book clubs, dance) are drafted from public sources and marked `needs_verify` — please confirm each community's cadence/audience/collab before flipping it live in `/admin/rankings`. `host_venues` intentionally lists commercial studios separately from ranked member-communities. No public downvote by design (private flag/moderation instead) to avoid brigading/GDPR exposure on named orgs.
