### PR TITLE
feat(crm): surface Challenge-A verification columns (B/F1)

### DIFF
--- a/app/Http/Controllers/Admin/CrmController.php
+++ b/app/Http/Controllers/Admin/CrmController.php
@@ -68,6 +68,14 @@ class CrmController extends Controller
                 'founder_instagram' => ['Founder IG', false, true],
                 'ambassador_potential' => ['Ambassador', true, true],
                 'founding_partner' => ['Founding partner', false, true],
+                // Challenge-A verification metadata (from the verified-leads seed).
+                'city' => ['City', true, true],
+                'classification' => ['Type', true, true],
+                'audience' => ['Audience', true, true],
+                'audience_source' => ['Audience src', false, true],
+                'confidence' => ['Confidence', true, true],
+                'last_active_date' => ['Last active', false, true],
+                'evidence_url' => ['Evidence', false, true],
             ],
         };
     }

--- a/tests/Feature/Admin/CrmAdminTest.php
+++ b/tests/Feature/Admin/CrmAdminTest.php
@@ -53,6 +53,16 @@ class CrmAdminTest extends TestCase
             ->assertDontSee('Berlin Runners XT');
     }
 
+    public function test_community_catalog_exposes_verification_columns(): void
+    {
+        $catalog = app(\App\Http\Controllers\Admin\CrmController::class)->columnsFor('community');
+
+        foreach (['city', 'classification', 'audience', 'confidence', 'last_active_date', 'evidence_url'] as $key) {
+            $this->assertArrayHasKey($key, $catalog, "community CRM should expose the {$key} verification column");
+            $this->assertTrue($catalog[$key][2], "{$key} should be a metric column");
+        }
+    }
+
     public function test_create_and_edit_pages_render_for_each_type(): void
     {
         (new CrmSeeder)->run();


### PR DESCRIPTION
## Summary
Surfaces the Challenge-A **verified metadata** as pickable columns on `/admin/crm` (community): City, Type (classification), Audience, Audience src, Confidence, Last active, Evidence. Reads the `metrics` JSON written by `KolabingVerifiedLeadsSeeder` (PR #162).

## Linked tracking item
Closes #163

## Type of change
- [x] ✨ Feature

## Changes
- `CrmController::columnsFor()` community branch: +7 metric columns (city/classification/audience/audience_source/confidence/last_active_date/evidence_url).
- Test asserts the catalog exposes them as metric columns.

## Mobile impact (kolabing-app)
- [x] No mobile changes required — admin-only Blade surface, no /api/v1 change.

## Database / migrations
- [x] No schema changes — reads existing `crm_accounts.metrics`.

## Testing
- [x] `php artisan test` — `CrmAdminTest::test_community_catalog_exposes_verification_columns` added (CI; box lacks pdo_sqlite).
- [x] `vendor/bin/pint` clean.

## Docs & rules updated
- [x] No docs impact — read-only admin column surface, no role/paywall/schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
