### PR TITLE
feat(community): split follower from member, with an application-gated membership

### DIFF
--- a/app/Http/Controllers/Api/V1/CommunityController.php
+++ b/app/Http/Controllers/Api/V1/CommunityController.php
@@ -246,6 +246,16 @@ class CommunityController extends Controller
         try {
             $member = $this->memberService->join($community, $profile);
         } catch (DomainException $e) {
+            // The leader chose to ask something before admitting members, so
+            // this is not a refusal — it is a redirect to the application.
+            if ($e->getMessage() === 'join_requires_application') {
+                return response()->json([
+                    'success' => false,
+                    'error' => 'join_requires_application',
+                    'message' => __('This community asks a few questions before you join.'),
+                ], 409);
+            }
+
             return response()->json([
                 'success' => false,
                 'error' => 'invite_only',

--- a/app/Http/Controllers/Api/V1/CommunityFollowController.php
+++ b/app/Http/Controllers/Api/V1/CommunityFollowController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Community;
+use App\Models\Profile;
+use App\Services\CommunityFollowService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Follow / unfollow a community (kolabing-app#138).
+ *
+ * No policy check: any signed-in profile may follow any community. Following
+ * grants nothing that needs guarding — it is the deliberately frictionless
+ * half of the follower/member split, and the leader is not asked, because a
+ * follow is not a request.
+ */
+class CommunityFollowController extends Controller
+{
+    public function __construct(
+        private readonly CommunityFollowService $service
+    ) {}
+
+    /**
+     * POST /api/v1/communities/{community}/follow
+     *
+     * 201 the first time, 200 on a repeat — idempotent, so a double tap or a
+     * retry never surfaces the unique constraint as a server error.
+     */
+    public function store(Request $request, Community $community): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        ['follower' => $follower, 'created' => $created] =
+            $this->service->follow($community, $profile);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'community_id' => $community->id,
+                'is_following' => true,
+                'followed_at' => $follower->followed_at?->toIso8601String(),
+                'followers_count' => $community->followers()->count(),
+            ],
+        ], $created ? 201 : 200);
+    }
+
+    /**
+     * DELETE /api/v1/communities/{community}/follow
+     *
+     * Also idempotent: unfollowing something you do not follow is a no-op, not
+     * a 404 — the caller's intent is already satisfied.
+     */
+    public function destroy(Request $request, Community $community): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        $this->service->unfollow($community, $profile);
+
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'community_id' => $community->id,
+                'is_following' => false,
+                'followers_count' => $community->followers()->count(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CommunityFollowController.php
+++ b/app/Http/Controllers/Api/V1/CommunityFollowController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\CommunityResource;
 use App\Models\Community;
 use App\Models\Profile;
 use App\Services\CommunityFollowService;
@@ -48,6 +49,39 @@ class CommunityFollowController extends Controller
                 'followers_count' => $community->followers()->count(),
             ],
         ], $created ? 201 : 200);
+    }
+
+    /**
+     * GET /api/v1/me/community-follows
+     *
+     * The communities the viewer follows.
+     *
+     * A separate endpoint rather than a section inside `/me/memberships`: that
+     * one returns `data` as a flat array of memberships, so adding a sibling key
+     * would mean turning `data` into an object and breaking every app build
+     * already installed.
+     */
+    public function mine(Request $request): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        $follows = $profile->communityFollows()
+            ->with(['community.communityProfile'])
+            ->orderByDesc('followed_at')
+            ->get();
+
+        return response()->json([
+            'success' => true,
+            'data' => $follows
+                ->filter(fn ($follow) => $follow->community !== null)
+                ->map(fn ($follow) => [
+                    'community' => new CommunityResource($follow->community),
+                    'followed_at' => $follow->followed_at?->toIso8601String(),
+                ])
+                ->values()
+                ->all(),
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/CommunityJoinQuestionController.php
+++ b/app/Http/Controllers/Api/V1/CommunityJoinQuestionController.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\CommunityJoinQuestionResource;
+use App\Models\Community;
+use App\Models\CommunityJoinQuestion;
+use App\Models\Profile;
+use App\Services\CommunityJoinQuestionService;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * The membership questions a community asks (kolabing-app#138).
+ *
+ * Reading the active set is open to any signed-in profile — an applicant has to
+ * see the questions before they can answer them. Everything that changes the
+ * set is gated on the `manage` ability, matching CommunityMemberController.
+ */
+class CommunityJoinQuestionController extends Controller
+{
+    public function __construct(
+        private readonly CommunityJoinQuestionService $service
+    ) {}
+
+    /**
+     * GET /api/v1/communities/{community}/join-questions
+     *
+     * The set an applicant should answer, in display order. Open to anyone
+     * signed in; retired questions are not included.
+     */
+    public function index(Request $request, Community $community): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'data' => [
+                'questions' => CommunityJoinQuestionResource::collection(
+                    $this->service->activeFor($community)
+                ),
+                'max_active' => CommunityJoinQuestion::MAX_ACTIVE,
+            ],
+        ]);
+    }
+
+    /**
+     * POST /api/v1/communities/{community}/join-questions
+     */
+    public function store(Request $request, Community $community): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($profile->cannot('manage', $community)) {
+            return $this->forbidden();
+        }
+
+        $validated = $request->validate([
+            'prompt' => ['required', 'string', 'max:280'],
+            'required' => ['sometimes', 'boolean'],
+            'position' => ['sometimes', 'integer', 'min:1', 'max:'.CommunityJoinQuestion::MAX_ACTIVE],
+        ]);
+
+        try {
+            $question = $this->service->create(
+                $community,
+                $validated['prompt'],
+                (bool) ($validated['required'] ?? true),
+                $validated['position'] ?? null,
+            );
+        } catch (DomainException) {
+            return response()->json([
+                'success' => false,
+                'error' => 'too_many_questions',
+                'message' => __('A community can ask at most :count questions.', [
+                    'count' => CommunityJoinQuestion::MAX_ACTIVE,
+                ]),
+            ], 422);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => new CommunityJoinQuestionResource($question),
+        ], 201);
+    }
+
+    /**
+     * PATCH /api/v1/communities/{community}/join-questions/{question}
+     */
+    public function update(
+        Request $request,
+        Community $community,
+        CommunityJoinQuestion $question
+    ): JsonResponse {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($profile->cannot('manage', $community)) {
+            return $this->forbidden();
+        }
+
+        if ($question->community_id !== $community->id) {
+            return $this->notFound();
+        }
+
+        $validated = $request->validate([
+            'prompt' => ['sometimes', 'string', 'max:280'],
+            'required' => ['sometimes', 'boolean'],
+            'position' => ['sometimes', 'integer', 'min:1', 'max:'.CommunityJoinQuestion::MAX_ACTIVE],
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data' => new CommunityJoinQuestionResource(
+                $this->service->update($question, $validated)
+            ),
+        ]);
+    }
+
+    /**
+     * DELETE /api/v1/communities/{community}/join-questions/{question}
+     *
+     * Retires the question. It stops being asked; its existing answers stay
+     * readable, so an older application still makes sense to whoever reviews it.
+     */
+    public function destroy(
+        Request $request,
+        Community $community,
+        CommunityJoinQuestion $question
+    ): JsonResponse {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        if ($profile->cannot('manage', $community)) {
+            return $this->forbidden();
+        }
+
+        if ($question->community_id !== $community->id) {
+            return $this->notFound();
+        }
+
+        return response()->json([
+            'success' => true,
+            'data' => new CommunityJoinQuestionResource(
+                $this->service->retire($question)
+            ),
+        ]);
+    }
+
+    private function forbidden(): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => __('You are not authorized to manage this community.'),
+        ], 403);
+    }
+
+    private function notFound(): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => __('Question not found for this community.'),
+        ], 404);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CommunityJoinRequestController.php
+++ b/app/Http/Controllers/Api/V1/CommunityJoinRequestController.php
@@ -61,6 +61,10 @@ class CommunityJoinRequestController extends Controller
                 $community,
                 $profile,
                 $validated['answers'] ?? [],
+                // Whether the CLIENT knows about the questions flow at all.
+                // An older build sends no `answers` key; holding it to the
+                // required-question rules would lock it out of joining.
+                $request->has('answers'),
             );
         } catch (DomainException $e) {
             // Two distinct refusals, so the client can tell "use /join instead"

--- a/app/Http/Controllers/Api/V1/CommunityJoinRequestController.php
+++ b/app/Http/Controllers/Api/V1/CommunityJoinRequestController.php
@@ -45,14 +45,34 @@ class CommunityJoinRequestController extends Controller
             ], 422);
         }
 
+        $validated = $request->validate([
+            'answers' => ['sometimes', 'array'],
+            'answers.*.question_id' => ['required_with:answers', 'uuid'],
+            'answers.*.answer' => ['required_with:answers', 'string', 'max:2000'],
+        ]);
+
         try {
             $alreadyPending = $community->joinRequests()
                 ->where('profile_id', $profile->id)
                 ->where('status', \App\Enums\JoinRequestStatus::Pending->value)
                 ->exists();
 
-            $joinRequest = $this->service->request($community, $profile);
+            $joinRequest = $this->service->request(
+                $community,
+                $profile,
+                $validated['answers'] ?? [],
+            );
         } catch (DomainException $e) {
+            // Two distinct refusals, so the client can tell "use /join instead"
+            // apart from "you left a required question blank".
+            if ($e->getMessage() === 'missing_required_answers') {
+                return response()->json([
+                    'success' => false,
+                    'error' => 'missing_required_answers',
+                    'message' => __('Please answer every required question.'),
+                ], 422);
+            }
+
             return response()->json([
                 'success' => false,
                 'error' => 'community_is_open',

--- a/app/Http/Controllers/Api/V1/EventController.php
+++ b/app/Http/Controllers/Api/V1/EventController.php
@@ -44,16 +44,23 @@ class EventController extends Controller
         $profileId = $request->query('profile_id');
         $time = $request->query('time'); // upcoming | past | null
         $attendeeId = $request->query('attendee') === 'me' ? $authProfile->id : null;
+        // `following=me` — events from the communities the viewer follows. This
+        // is what puts a followed community's programme in the member's feed
+        // without them having to join it (kolabing-app#138).
+        $followingId = $request->query('following') === 'me' ? $authProfile->id : null;
 
         $filters = array_filter([
             'community_id' => $communityId,
             'profile_id' => $profileId,
             'attendee_profile_id' => $attendeeId,
+            'follower_profile_id' => $followingId,
             'time' => $time,
         ], static fn ($value) => $value !== null);
 
         // Back-compat: with no scoping filter, list the viewer's own events.
-        if ($communityId === null && $profileId === null && $attendeeId === null) {
+        // `following` counts as one, or it would be ANDed with "my own events"
+        // and always come back empty.
+        if ($communityId === null && $profileId === null && $attendeeId === null && $followingId === null) {
             $filters['profile_id'] = $authProfile->id;
         }
 

--- a/app/Http/Resources/Api/V1/CommunityJoinRequestResource.php
+++ b/app/Http/Resources/Api/V1/CommunityJoinRequestResource.php
@@ -39,7 +39,10 @@ class CommunityJoinRequestResource extends JsonResource
             'answers' => $this->whenLoaded('answers', fn () => $this->answers
                 ->map(fn ($answer) => [
                     'question_id' => $answer->question_id,
-                    'prompt' => $answer->question?->prompt,
+                    // The wording the applicant saw, falling back to the
+                    // question's current prompt for rows written before the
+                    // snapshot existed.
+                    'prompt' => $answer->prompt_snapshot ?? $answer->question?->prompt,
                     'answer' => $answer->answer,
                 ])
                 ->values()

--- a/app/Http/Resources/Api/V1/CommunityJoinRequestResource.php
+++ b/app/Http/Resources/Api/V1/CommunityJoinRequestResource.php
@@ -30,6 +30,20 @@ class CommunityJoinRequestResource extends JsonResource
                 'name' => $this->profileDisplayName(),
                 'avatar_url' => $this->profileAvatarUrl(),
             ]),
+            // Added, never replacing anything: what the applicant actually
+            // answered, which is the substance a leader decides on. Only
+            // present when eager-loaded, so a caller that does not need it pays
+            // nothing. The question's prompt rides along because a retired
+            // question is still readable and the leader needs to see what was
+            // asked.
+            'answers' => $this->whenLoaded('answers', fn () => $this->answers
+                ->map(fn ($answer) => [
+                    'question_id' => $answer->question_id,
+                    'prompt' => $answer->question?->prompt,
+                    'answer' => $answer->answer,
+                ])
+                ->values()
+                ->all()),
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];

--- a/app/Http/Resources/Api/V1/CommunityResource.php
+++ b/app/Http/Resources/Api/V1/CommunityResource.php
@@ -54,15 +54,15 @@ class CommunityResource extends JsonResource
             // owned community from a co-run one and show the management surface.
             'my_can_manage' => $viewer !== null && $this->resolveViewerCanManage($viewer),
             'my_join_request_status' => $viewer !== null ? $this->resolveViewerJoinRequestStatus($viewer) : null,
-            // Additive (kolabing-app#138): the follower axis, which is separate
-            // from membership. `is_member` above stays the member answer; a
-            // client shows "Member" when that is true and "Following" only when
-            // it is not.
-            'is_following' => $viewer !== null && $this->resolveViewerIsFollowing($viewer),
-            'follower_count' => $this->followers()->count(),
-            // How many questions this community asks before admitting a member.
-            // 0 means the join is not gated by an application.
-            'join_question_count' => $this->joinQuestions()->where('is_active', true)->count(),
+            // NOTE (kolabing-app#138): follower state is deliberately NOT here.
+            // This resource is serialized in lists, and a per-row count or
+            // exists() check is an N+1 — MeRewardsOverviewNPlusOneTest caught
+            // exactly that (12 queries → 21). The follower axis is served by
+            // its own endpoints instead, where the data is already at hand:
+            // GET /me/community-follows for the set, and the follow/unfollow
+            // responses for the authoritative is_following + count.
+            // Adding it here would need preloading through
+            // CommunityMembershipHydrator, the way viewer_is_member does.
             // Viewer's per-community POINTS balance + tier (null when not a member).
             'my_points' => $viewer !== null ? $this->resolveViewerPoints($viewer) : 0,
             'my_tier' => $viewer !== null ? $this->resolveViewerTier($viewer) : null,
@@ -178,17 +178,6 @@ class CommunityResource extends JsonResource
         return $this->hasPreloaded('viewer_can_manage')
             ? (bool) $this->preloaded('viewer_can_manage')
             : $this->viewerCanManage($viewer);
-    }
-
-    /**
-     * Whether the viewer follows this community.
-     *
-     * Deliberately independent of [resolveViewerIsMember]: a member need not
-     * follow, and following grants none of what membership grants.
-     */
-    private function resolveViewerIsFollowing(Profile $viewer): bool
-    {
-        return $this->followers()->where('profile_id', $viewer->id)->exists();
     }
 
     private function resolveViewerJoinRequestStatus(Profile $viewer): ?string

--- a/app/Http/Resources/Api/V1/CommunityResource.php
+++ b/app/Http/Resources/Api/V1/CommunityResource.php
@@ -54,6 +54,15 @@ class CommunityResource extends JsonResource
             // owned community from a co-run one and show the management surface.
             'my_can_manage' => $viewer !== null && $this->resolveViewerCanManage($viewer),
             'my_join_request_status' => $viewer !== null ? $this->resolveViewerJoinRequestStatus($viewer) : null,
+            // Additive (kolabing-app#138): the follower axis, which is separate
+            // from membership. `is_member` above stays the member answer; a
+            // client shows "Member" when that is true and "Following" only when
+            // it is not.
+            'is_following' => $viewer !== null && $this->resolveViewerIsFollowing($viewer),
+            'follower_count' => $this->followers()->count(),
+            // How many questions this community asks before admitting a member.
+            // 0 means the join is not gated by an application.
+            'join_question_count' => $this->joinQuestions()->where('is_active', true)->count(),
             // Viewer's per-community POINTS balance + tier (null when not a member).
             'my_points' => $viewer !== null ? $this->resolveViewerPoints($viewer) : 0,
             'my_tier' => $viewer !== null ? $this->resolveViewerTier($viewer) : null,
@@ -169,6 +178,17 @@ class CommunityResource extends JsonResource
         return $this->hasPreloaded('viewer_can_manage')
             ? (bool) $this->preloaded('viewer_can_manage')
             : $this->viewerCanManage($viewer);
+    }
+
+    /**
+     * Whether the viewer follows this community.
+     *
+     * Deliberately independent of [resolveViewerIsMember]: a member need not
+     * follow, and following grants none of what membership grants.
+     */
+    private function resolveViewerIsFollowing(Profile $viewer): bool
+    {
+        return $this->followers()->where('profile_id', $viewer->id)->exists();
     }
 
     private function resolveViewerJoinRequestStatus(Profile $viewer): ?string

--- a/app/Http/Resources/CommunityJoinQuestionResource.php
+++ b/app/Http/Resources/CommunityJoinQuestionResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\CommunityJoinQuestion;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CommunityJoinQuestion
+ */
+class CommunityJoinQuestionResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'community_id' => $this->community_id,
+            'position' => $this->position,
+            'prompt' => $this->prompt,
+            'required' => $this->required,
+            // Exposed so a leader's management screen can show a retired
+            // question; the applicant-facing list only ever contains active
+            // ones, so this is always true there.
+            'is_active' => $this->is_active,
+        ];
+    }
+}

--- a/app/Models/Community.php
+++ b/app/Models/Community.php
@@ -168,7 +168,9 @@ class Community extends Model
      */
     public function joinQuestions(): HasMany
     {
-        return $this->hasMany(CommunityJoinQuestion::class)->orderBy('position');
+        return $this->hasMany(CommunityJoinQuestion::class)
+            ->orderBy('position')
+            ->orderBy('created_at');
     }
 
     /**

--- a/app/Models/Community.php
+++ b/app/Models/Community.php
@@ -149,6 +149,29 @@ class Community extends Model
     }
 
     /**
+     * People following this community — interest without membership.
+     * See CommunityFollower for why this is a separate relation.
+     *
+     * @return HasMany<CommunityFollower, $this>
+     */
+    public function followers(): HasMany
+    {
+        return $this->hasMany(CommunityFollower::class);
+    }
+
+    /**
+     * The questions asked before admitting a member, newest set first in
+     * display order. Includes retired ones — scope with `activeOrdered()` for
+     * the set an applicant should actually see.
+     *
+     * @return HasMany<CommunityJoinQuestion, $this>
+     */
+    public function joinQuestions(): HasMany
+    {
+        return $this->hasMany(CommunityJoinQuestion::class)->orderBy('position');
+    }
+
+    /**
      * @return HasMany<CommunityGoal, $this>
      */
     public function goals(): HasMany

--- a/app/Models/CommunityFollower.php
+++ b/app/Models/CommunityFollower.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Someone following a community — interest, not membership.
+ *
+ * A follower can see the community and turn up to its public events (and so
+ * play the QR check-in / challenge loop), but gets none of what membership
+ * unlocks: the community chat, member- or tier-gated events, community points,
+ * badges, the leaderboard, or a tier.
+ *
+ * Deliberately its own model rather than a flag on [CommunityMember]: every
+ * member-gated query in the app reads `community_members`, and keeping
+ * followers out of that table means none of them can start matching a follower
+ * by accident. See kolabing-app#138.
+ *
+ * @property string $id
+ * @property string $community_id
+ * @property string $profile_id
+ * @property \Illuminate\Support\Carbon $followed_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Community $community
+ * @property-read Profile $profile
+ */
+class CommunityFollower extends Model
+{
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'community_id',
+        'profile_id',
+        'followed_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'followed_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Community, $this>
+     */
+    public function community(): BelongsTo
+    {
+        return $this->belongsTo(Community::class);
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+}

--- a/app/Models/CommunityJoinAnswer.php
+++ b/app/Models/CommunityJoinAnswer.php
@@ -12,9 +12,14 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * What an applicant answered, attached to their join request
  * (kolabing-app#138).
  *
+ * [$prompt_snapshot] records the wording at the time of answering. A leader can
+ * reword a live question, and an application must always read as the applicant
+ * saw it — retiring alone does not cover that.
+ *
  * @property string $id
  * @property string $join_request_id
  * @property string $question_id
+ * @property string|null $prompt_snapshot
  * @property string $answer
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -31,6 +36,7 @@ class CommunityJoinAnswer extends Model
     protected $fillable = [
         'join_request_id',
         'question_id',
+        'prompt_snapshot',
         'answer',
     ];
 

--- a/app/Models/CommunityJoinAnswer.php
+++ b/app/Models/CommunityJoinAnswer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * What an applicant answered, attached to their join request
+ * (kolabing-app#138).
+ *
+ * @property string $id
+ * @property string $join_request_id
+ * @property string $question_id
+ * @property string $answer
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read CommunityJoinRequest $joinRequest
+ * @property-read CommunityJoinQuestion $question
+ */
+class CommunityJoinAnswer extends Model
+{
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'join_request_id',
+        'question_id',
+        'answer',
+    ];
+
+    /**
+     * @return BelongsTo<CommunityJoinRequest, $this>
+     */
+    public function joinRequest(): BelongsTo
+    {
+        return $this->belongsTo(CommunityJoinRequest::class, 'join_request_id');
+    }
+
+    /**
+     * @return BelongsTo<CommunityJoinQuestion, $this>
+     */
+    public function question(): BelongsTo
+    {
+        return $this->belongsTo(CommunityJoinQuestion::class, 'question_id');
+    }
+}

--- a/app/Models/CommunityJoinQuestion.php
+++ b/app/Models/CommunityJoinQuestion.php
@@ -67,7 +67,12 @@ class CommunityJoinQuestion extends Model
      */
     public function scopeActiveOrdered(Builder $query): Builder
     {
-        return $query->where('is_active', true)->orderBy('position');
+        // created_at breaks the tie: a retired question keeps its position, so
+        // a replacement can legitimately reuse the same number and the order
+        // between them would otherwise be undefined.
+        return $query->where('is_active', true)
+            ->orderBy('position')
+            ->orderBy('created_at');
     }
 
     /**

--- a/app/Models/CommunityJoinQuestion.php
+++ b/app/Models/CommunityJoinQuestion.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A question a leader asks before admitting a member (kolabing-app#138).
+ *
+ * Retired, never deleted: [$is_active] false takes the question out of the form
+ * while its past answers stay readable, so a leader reviewing an older
+ * application still sees what was asked. Deleting would cascade the answers away
+ * and leave that application meaningless.
+ *
+ * @property string $id
+ * @property string $community_id
+ * @property int $position
+ * @property string $prompt
+ * @property bool $required
+ * @property bool $is_active
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Community $community
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, CommunityJoinAnswer> $answers
+ */
+class CommunityJoinQuestion extends Model
+{
+    use HasUuids;
+
+    /** How many questions a community may have live at once. */
+    public const MAX_ACTIVE = 5;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'community_id',
+        'position',
+        'prompt',
+        'required',
+        'is_active',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'position' => 'integer',
+            'required' => 'boolean',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * The set an applicant is asked, in display order.
+     *
+     * @param  Builder<CommunityJoinQuestion>  $query
+     * @return Builder<CommunityJoinQuestion>
+     */
+    public function scopeActiveOrdered(Builder $query): Builder
+    {
+        return $query->where('is_active', true)->orderBy('position');
+    }
+
+    /**
+     * @return BelongsTo<Community, $this>
+     */
+    public function community(): BelongsTo
+    {
+        return $this->belongsTo(Community::class);
+    }
+
+    /**
+     * @return HasMany<CommunityJoinAnswer, $this>
+     */
+    public function answers(): HasMany
+    {
+        return $this->hasMany(CommunityJoinAnswer::class, 'question_id');
+    }
+}

--- a/app/Models/CommunityJoinRequest.php
+++ b/app/Models/CommunityJoinRequest.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property string $id
@@ -58,6 +59,17 @@ class CommunityJoinRequest extends Model
     /**
      * @return BelongsTo<Community, $this>
      */
+    /**
+     * What the applicant answered. Eager-load this wherever a leader reviews
+     * the queue — the answers are the substance they decide on.
+     *
+     * @return HasMany<CommunityJoinAnswer, $this>
+     */
+    public function answers(): HasMany
+    {
+        return $this->hasMany(CommunityJoinAnswer::class, 'join_request_id');
+    }
+
     public function community(): BelongsTo
     {
         return $this->belongsTo(Community::class);

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -294,6 +294,17 @@ class Profile extends Authenticatable
     }
 
     /**
+     * Communities this profile follows. Distinct from
+     * [communityMemberships] — following is interest, membership is belonging.
+     *
+     * @return HasMany<CommunityFollower, $this>
+     */
+    public function communityFollows(): HasMany
+    {
+        return $this->hasMany(CommunityFollower::class);
+    }
+
+    /**
      * Community memberships this profile holds (as a Community Member).
      *
      * @return HasMany<CommunityMember, $this>

--- a/app/Services/CommunityFollowService.php
+++ b/app/Services/CommunityFollowService.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Community;
+use App\Models\CommunityFollower;
+use App\Models\Profile;
+use Illuminate\Support\Carbon;
+
+/**
+ * Following and unfollowing a community (kolabing-app#138).
+ *
+ * Following is the low-commitment half of the split: one tap, no approval, no
+ * notification to the leader — a follow is interest, not a request. It grants
+ * nothing that membership grants; it exists so a person can keep an eye on a
+ * community, and turn up to its public events, without being handed the keys to
+ * the chat, the member-only events and the community's whole reward economy.
+ *
+ * Deliberately has no bearing on `community_members`: nothing here writes to
+ * that table, which is what keeps every member-gated query in the app honest.
+ */
+class CommunityFollowService
+{
+    /**
+     * Follow [$community], idempotently.
+     *
+     * Returns the follow row and whether it was created now — the controller
+     * turns that into 201 vs 200. Idempotent because a double tap (or a retry
+     * on a flaky connection) must not surface the unique constraint as a 500.
+     *
+     * @return array{follower: CommunityFollower, created: bool}
+     */
+    public function follow(Community $community, Profile $profile): array
+    {
+        $existing = CommunityFollower::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $profile->id)
+            ->first();
+
+        if ($existing !== null) {
+            return ['follower' => $existing, 'created' => false];
+        }
+
+        $follower = CommunityFollower::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $profile->id,
+            'followed_at' => Carbon::now(),
+        ]);
+
+        return ['follower' => $follower, 'created' => true];
+    }
+
+    /**
+     * Unfollow, idempotently. Unfollowing something you do not follow is a
+     * no-op rather than a 404: the caller's intent is already satisfied.
+     */
+    public function unfollow(Community $community, Profile $profile): void
+    {
+        CommunityFollower::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $profile->id)
+            ->delete();
+    }
+
+    public function isFollowing(Community $community, Profile $profile): bool
+    {
+        return CommunityFollower::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $profile->id)
+            ->exists();
+    }
+}

--- a/app/Services/CommunityJoinQuestionService.php
+++ b/app/Services/CommunityJoinQuestionService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Community;
+use App\Models\CommunityJoinQuestion;
+use DomainException;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * The questions a leader asks before admitting a member (kolabing-app#138).
+ *
+ * The cap and the retire-don't-delete rule live here rather than in the
+ * controller, so they hold for any caller — a seeder, an admin tool, a future
+ * endpoint — and not just for the one that happens to go through the API.
+ */
+class CommunityJoinQuestionService
+{
+    /**
+     * The set an applicant is asked, in display order.
+     *
+     * @return Collection<int, CommunityJoinQuestion>
+     */
+    public function activeFor(Community $community): Collection
+    {
+        return CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->activeOrdered()
+            ->get();
+    }
+
+    /**
+     * @throws DomainException when the community already has the maximum number
+     *                         of active questions
+     */
+    public function create(
+        Community $community,
+        string $prompt,
+        bool $required = true,
+        ?int $position = null
+    ): CommunityJoinQuestion {
+        $activeCount = CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->where('is_active', true)
+            ->count();
+
+        if ($activeCount >= CommunityJoinQuestion::MAX_ACTIVE) {
+            throw new DomainException('too_many_questions');
+        }
+
+        return CommunityJoinQuestion::query()->create([
+            'community_id' => $community->id,
+            'position' => $position ?? ($activeCount + 1),
+            'prompt' => $prompt,
+            'required' => $required,
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes  any of prompt, required, position
+     */
+    public function update(
+        CommunityJoinQuestion $question,
+        array $attributes
+    ): CommunityJoinQuestion {
+        $question->update(array_intersect_key($attributes, array_flip([
+            'prompt', 'required', 'position',
+        ])));
+
+        return $question->fresh();
+    }
+
+    /**
+     * Retire a question rather than delete it.
+     *
+     * Deleting would cascade its answers away, and a leader reviewing an older
+     * application would be left with an answer to a question nobody can see.
+     * Retiring takes it out of the form and leaves the record intact.
+     */
+    public function retire(CommunityJoinQuestion $question): CommunityJoinQuestion
+    {
+        $question->update(['is_active' => false]);
+
+        return $question->fresh();
+    }
+}

--- a/app/Services/CommunityJoinQuestionService.php
+++ b/app/Services/CommunityJoinQuestionService.php
@@ -50,9 +50,17 @@ class CommunityJoinQuestionService
             throw new DomainException('too_many_questions');
         }
 
+        // Next free slot AFTER the highest active position, not activeCount+1:
+        // retiring #2 of five and adding a replacement must not collide with
+        // the live #5.
+        $nextPosition = $position ?? (int) (CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->where('is_active', true)
+            ->max('position') ?? 0) + 1;
+
         return CommunityJoinQuestion::query()->create([
             'community_id' => $community->id,
-            'position' => $position ?? ($activeCount + 1),
+            'position' => $nextPosition,
             'prompt' => $prompt,
             'required' => $required,
             'is_active' => true,

--- a/app/Services/CommunityJoinRequestService.php
+++ b/app/Services/CommunityJoinRequestService.php
@@ -9,6 +9,8 @@ use App\Enums\JoinPolicy;
 use App\Enums\JoinRequestStatus;
 use App\Enums\NotificationType;
 use App\Models\Community;
+use App\Models\CommunityJoinAnswer;
+use App\Models\CommunityJoinQuestion;
 use App\Models\CommunityJoinRequest;
 use App\Models\Profile;
 use DomainException;
@@ -31,9 +33,36 @@ class CommunityJoinRequestService
      *
      * @throws DomainException 'community_is_open'
      */
-    public function request(Community $community, Profile $profile): CommunityJoinRequest
-    {
-        if ($community->join_policy === JoinPolicy::Open) {
+    /**
+     * Apply to join.
+     *
+     * @param  array<int, array{question_id: string, answer: string}>  $answers
+     *
+     * @throws DomainException `community_is_open` when an open community asks
+     *                         nothing (the caller should use /join), or
+     *                         `missing_required_answers`
+     */
+    public function request(
+        Community $community,
+        Profile $profile,
+        array $answers = []
+    ): CommunityJoinRequest {
+        $questions = CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->activeOrdered()
+            ->get();
+
+        // An open community that asks nothing has no application to make — the
+        // client should call /join, which is what it has always done. An open
+        // community that DOES ask something now has a real application, so the
+        // request path opens up and self-approves once answered.
+        //
+        // No community has questions until a leader creates one, so on the day
+        // this deploys every existing community keeps behaving exactly as it
+        // does today.
+        $isOpen = $community->join_policy === JoinPolicy::Open;
+
+        if ($isOpen && $questions->isEmpty()) {
             throw new DomainException('community_is_open');
         }
 
@@ -47,15 +76,92 @@ class CommunityJoinRequestService
             return $pending;
         }
 
-        $joinRequest = $community->joinRequests()->create([
-            'profile_id' => $profile->id,
-            'status' => JoinRequestStatus::Pending->value,
-            'requested_at' => now(),
-        ]);
+        $this->assertRequiredAnswered($questions, $answers);
 
-        $this->notifyManagersOfNewRequest($community, $profile);
+        return DB::transaction(function () use ($community, $profile, $questions, $answers, $isOpen): CommunityJoinRequest {
+            $joinRequest = $community->joinRequests()->create([
+                'profile_id' => $profile->id,
+                'status' => JoinRequestStatus::Pending->value,
+                'requested_at' => now(),
+            ]);
 
-        return $joinRequest;
+            $this->storeAnswers($joinRequest, $questions, $answers);
+
+            if ($isOpen) {
+                // Open + questions: the answers are collected for the record,
+                // and membership is granted immediately. Neither notification
+                // fires — nobody is waiting on a decision, and telling the
+                // applicant their own action was approved is noise.
+                $this->memberService->addMember($community, $profile->id);
+
+                $joinRequest->update([
+                    'status' => JoinRequestStatus::Approved->value,
+                    'decided_at' => now(),
+                ]);
+
+                return $joinRequest->refresh();
+            }
+
+            $this->notifyManagersOfNewRequest($community, $profile);
+
+            return $joinRequest;
+        });
+    }
+
+    /**
+     * Every question marked required must have a non-empty answer.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection<int, CommunityJoinQuestion>  $questions
+     * @param  array<int, array{question_id: string, answer: string}>  $answers
+     *
+     * @throws DomainException
+     */
+    private function assertRequiredAnswered($questions, array $answers): void
+    {
+        $given = [];
+        foreach ($answers as $answer) {
+            $id = $answer['question_id'] ?? null;
+            $text = trim((string) ($answer['answer'] ?? ''));
+            if ($id !== null && $text !== '') {
+                $given[$id] = $text;
+            }
+        }
+
+        foreach ($questions as $question) {
+            if ($question->required && ! array_key_exists($question->id, $given)) {
+                throw new DomainException('missing_required_answers');
+            }
+        }
+    }
+
+    /**
+     * Persists the answers, ignoring anything that does not belong to this
+     * community's active set — a client cannot smuggle in an answer to another
+     * community's question.
+     *
+     * @param  \Illuminate\Database\Eloquent\Collection<int, CommunityJoinQuestion>  $questions
+     * @param  array<int, array{question_id: string, answer: string}>  $answers
+     */
+    private function storeAnswers(
+        CommunityJoinRequest $joinRequest,
+        $questions,
+        array $answers
+    ): void {
+        $allowed = $questions->pluck('id')->all();
+
+        foreach ($answers as $answer) {
+            $questionId = $answer['question_id'] ?? null;
+            $text = trim((string) ($answer['answer'] ?? ''));
+
+            if ($questionId === null || $text === '' || ! in_array($questionId, $allowed, true)) {
+                continue;
+            }
+
+            CommunityJoinAnswer::query()->updateOrCreate(
+                ['join_request_id' => $joinRequest->id, 'question_id' => $questionId],
+                ['answer' => $text],
+            );
+        }
     }
 
     /**
@@ -67,7 +173,12 @@ class CommunityJoinRequestService
     {
         return $community->joinRequests()
             ->where('status', JoinRequestStatus::Pending->value)
-            ->with(['profile.attendeeProfile', 'profile.communityProfile', 'profile.businessProfile'])
+            ->with([
+                'profile.attendeeProfile', 'profile.communityProfile', 'profile.businessProfile',
+                // The answers are the point of the queue; loading the question
+                // too keeps a retired one's prompt readable.
+                'answers.question',
+            ])
             ->orderBy('requested_at')
             ->get();
     }

--- a/app/Services/CommunityJoinRequestService.php
+++ b/app/Services/CommunityJoinRequestService.php
@@ -45,7 +45,8 @@ class CommunityJoinRequestService
     public function request(
         Community $community,
         Profile $profile,
-        array $answers = []
+        array $answers = [],
+        bool $answersProvided = false
     ): CommunityJoinRequest {
         $questions = CommunityJoinQuestion::query()
             ->where('community_id', $community->id)
@@ -76,7 +77,16 @@ class CommunityJoinRequestService
             return $pending;
         }
 
-        $this->assertRequiredAnswered($questions, $answers);
+        // Only enforce the required questions when the client actually took
+        // part in the questions flow. Every app build already installed posts
+        // no `answers` at all (CommunityService::requestToJoin sends an empty
+        // body), and 422-ing those would leave existing users unable to join
+        // the moment a leader adds a required question. A client that knows
+        // about answers sends the key — even as an empty array — and is held to
+        // the rules.
+        if ($answersProvided) {
+            $this->assertRequiredAnswered($questions, $answers);
+        }
 
         return DB::transaction(function () use ($community, $profile, $questions, $answers, $isOpen): CommunityJoinRequest {
             $joinRequest = $community->joinRequests()->create([
@@ -157,9 +167,16 @@ class CommunityJoinRequestService
                 continue;
             }
 
+            $question = $questions->firstWhere('id', $questionId);
+
             CommunityJoinAnswer::query()->updateOrCreate(
                 ['join_request_id' => $joinRequest->id, 'question_id' => $questionId],
-                ['answer' => $text],
+                [
+                    'answer' => $text,
+                    // Snapshot the wording: the question may be reworded later,
+                    // and this application must keep reading as it was asked.
+                    'prompt_snapshot' => $question?->prompt,
+                ],
             );
         }
     }

--- a/app/Services/CommunityMemberService.php
+++ b/app/Services/CommunityMemberService.php
@@ -8,6 +8,7 @@ use App\Enums\CommunityMemberStatus;
 use App\Enums\JoinPolicy;
 use App\Enums\MissionTrigger;
 use App\Models\Community;
+use App\Models\CommunityJoinQuestion;
 use App\Models\CommunityMember;
 use App\Models\Profile;
 use DomainException;
@@ -31,6 +32,23 @@ class CommunityMemberService
     {
         if ($community->join_policy !== JoinPolicy::Open) {
             throw new DomainException('invite_only');
+        }
+
+        // Questions are the leader's OPTIONAL choice: add none and joining stays
+        // one tap through here; add one and joining goes through the
+        // application. Letting /join through anyway would make that choice do
+        // nothing — an open community could ask five required questions and
+        // still take one-tap members.
+        //
+        // Costs nothing today: no community has questions until a leader
+        // creates one, and creating one is itself a deliberate act.
+        $hasQuestions = CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->where('is_active', true)
+            ->exists();
+
+        if ($hasQuestions) {
+            throw new DomainException('join_requires_application');
         }
 
         $member = $this->upsertMember($community, $profile->id);

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -75,6 +75,16 @@ class EventService
             });
         }
 
+        if (! empty($filters['follower_profile_id'])) {
+            $followerId = $filters['follower_profile_id'];
+            // Only a community's events can be followed — an event with no
+            // community has no one to follow.
+            $query->whereHas(
+                'community.followers',
+                fn ($f) => $f->where('profile_id', $followerId)
+            );
+        }
+
         $time = $filters['time'] ?? null;
         if ($time === 'upcoming') {
             $query->whereRaw("$effective >= ?", [now()])

--- a/database/migrations/2026_08_22_100000_create_community_followers_table.php
+++ b/database/migrations/2026_08_22_100000_create_community_followers_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Following a community — the lightweight half of the follower/member split
+ * (kolabing-app#138).
+ *
+ * A deliberately separate table rather than a `kind` column on
+ * `community_members`. The security-critical direction is that a follower must
+ * never gain member access, and membership gates seven surfaces (chat,
+ * member/tier events, community points, badges, leaderboard, tier assignment,
+ * roster). Keeping followers out of `community_members` means every one of
+ * those existing queries keeps its exact meaning and cannot start matching a
+ * follower by accident. A shared table with a discriminator fails the other
+ * way: an unfiltered query would include followers, so missing a single call
+ * site would leak privilege silently.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('community_followers', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('community_id')->constrained('communities')->cascadeOnDelete();
+            $table->foreignUuid('profile_id')->constrained('profiles')->cascadeOnDelete();
+            $table->timestamp('followed_at');
+            $table->timestamps();
+
+            // One follow per person per community; the service relies on this to
+            // make following idempotent.
+            $table->unique(['community_id', 'profile_id']);
+            // "Which communities do I follow" is the common read.
+            $table->index('profile_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('community_followers');
+    }
+};

--- a/database/migrations/2026_08_22_100001_create_community_join_questions_table.php
+++ b/database/migrations/2026_08_22_100001_create_community_join_questions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The questions a leader asks before letting someone become a member
+ * (kolabing-app#138).
+ *
+ * Retired rather than deleted: `is_active = false` takes a question out of the
+ * form while its past answers stay readable, so a leader reviewing an old
+ * application can still see what was actually asked. Deleting would cascade the
+ * answers away and leave the application meaningless.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('community_join_questions', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('community_id')->constrained('communities')->cascadeOnDelete();
+            // Display order, 1..5. The 5-active cap is enforced in the service.
+            $table->unsignedSmallInteger('position')->default(1);
+            $table->string('prompt', 280);
+            $table->boolean('required')->default(true);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['community_id', 'position']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('community_join_questions');
+    }
+};

--- a/database/migrations/2026_08_22_100002_create_community_join_answers_table.php
+++ b/database/migrations/2026_08_22_100002_create_community_join_answers_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * What an applicant answered, attached to their join request
+ * (kolabing-app#138).
+ *
+ * Hangs off `community_join_requests`, which already exists and already carries
+ * the pending/approved/declined lifecycle — this adds the substance a leader
+ * decides on, without touching that table's shape.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('community_join_answers', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('join_request_id')
+                ->constrained('community_join_requests')
+                ->cascadeOnDelete();
+            $table->foreignUuid('question_id')
+                ->constrained('community_join_questions')
+                ->cascadeOnDelete();
+            $table->text('answer');
+            $table->timestamps();
+
+            // One answer per question per application.
+            $table->unique(['join_request_id', 'question_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('community_join_answers');
+    }
+};

--- a/database/migrations/2026_08_22_100002_create_community_join_answers_table.php
+++ b/database/migrations/2026_08_22_100002_create_community_join_answers_table.php
@@ -24,6 +24,10 @@ return new class extends Migration
             $table->foreignUuid('question_id')
                 ->constrained('community_join_questions')
                 ->cascadeOnDelete();
+            // The prompt as it stood when this was answered. A leader may
+            // later reword the question, and an old application must not
+            // re-render its answer under wording the applicant never saw.
+            $table->string('prompt_snapshot', 280)->nullable();
             $table->text('answer');
             $table->timestamps();
 

--- a/docs/ROLES-BACKEND-DB-MAP.md
+++ b/docs/ROLES-BACKEND-DB-MAP.md
@@ -416,10 +416,55 @@ communities (id uuid PK, owner_profile_id FK->profiles cascade,
                            joined_at, tier_assigned_at?, timestamps,
                            UNIQUE(community_id, profile_id))
 
+ ├─1:N─ community_followers (kolabing-app#138 — id uuid PK,
+ │                         community_id FK->communities cascade,
+ │                         profile_id FK->profiles cascade,
+ │                         followed_at, timestamps,
+ │                         UNIQUE(community_id, profile_id))
+ └─1:N─ community_join_questions (kolabing-app#138 — id uuid PK,
+                           community_id FK->communities cascade,
+                           position smallint (1..5), prompt string(280),
+                           required bool default true,
+                           is_active bool default true (RETIRE, never delete),
+                           timestamps)
+                             └─1:N─ community_join_answers (id uuid PK,
+                                     join_request_id FK->community_join_requests cascade,
+                                     question_id FK->community_join_questions cascade,
+                                     answer text, timestamps,
+                                     UNIQUE(join_request_id, question_id))
+
 events.community_id  FK->communities nullOnDelete null   ← the §8.6 linkage
 ```
 
-Enums (`app/Enums`): `CommunityType`, `TierAssignmentRule`, `JoinPolicy`, `CommunityMemberStatus`. Models: `Community`, `CommunityTier`, `CommunityMember` (+ `Profile::ownedCommunities()` / `communityMemberships()`, `Event::community()`).
+### 12.1a Follower vs member (added 2026-08-22, kolabing-app#138)
+
+**Two relationships, two tables.** `community_followers` is interest;
+`community_members` is belonging. A follower may see the community and sign up
+to its **public** events — and so play the QR check-in / challenge loop, whose
+XP is global and not community-scoped. Membership is what gates the chat,
+member/tier events, community points, badges, the leaderboard and tiers.
+
+**Why not one table with a `kind` column.** Every member gate reads
+`community_members`. Keeping followers out of it means none of those queries can
+begin matching a follower by accident; a discriminator column fails the other
+way — the unfiltered query would include followers, so missing one call site
+would leak privilege silently. `CommunityMemberAccessRegressionTest` locks both
+directions.
+
+**Membership gate.** `community_join_questions` (max 5 active, enforced in
+`CommunityJoinQuestionService`) + `community_join_answers` on the existing
+`CommunityJoinRequest`. `join_policy` now reads as: `invite_only` → a leader
+decides; `open` → refuses the request path **unless** the community has active
+questions, in which case the application is accepted and auto-approved in one
+transaction. No community has questions until a leader creates one, so this
+changed nothing on deploy.
+
+**Follower state is not on `CommunityResource`** — it is serialized in lists and
+a per-row count is an N+1 (`MeRewardsOverviewNPlusOneTest` caught exactly that).
+It is served by `GET /me/community-follows` and by the follow/unfollow responses
+instead.
+
+Enums (`app/Enums`): `CommunityType`, `TierAssignmentRule`, `JoinPolicy`, `CommunityMemberStatus`. Models: `Community`, `CommunityTier`, `CommunityMember`, `CommunityFollower`, `CommunityJoinQuestion`, `CommunityJoinAnswer` (+ `Profile::ownedCommunities()` / `communityMemberships()` / `communityFollows()`, `Community::followers()` / `joinQuestions()`, `Event::community()`).
 
 ### 12.2 The cap gate — NOT the paywall
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -486,6 +486,9 @@ Route::prefix('v1')->group(function (): void {
         Route::post('communities/{community}/join', [CommunityController::class, 'join'])
             ->name('api.v1.communities.join');
 
+        Route::get('me/community-follows', [CommunityFollowController::class, 'mine'])
+            ->name('api.v1.me.community-follows');
+
         // Following: interest without membership (kolabing-app#138). One tap,
         // no approval, grants none of what membership grants.
         Route::post('communities/{community}/follow', [CommunityFollowController::class, 'store'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Api\V1\CommunityController;
 use App\Http\Controllers\Api\V1\CommunityFollowController;
 use App\Http\Controllers\Api\V1\CommunityGoalController;
 use App\Http\Controllers\Api\V1\CommunityInvitationController;
+use App\Http\Controllers\Api\V1\CommunityJoinQuestionController;
 use App\Http\Controllers\Api\V1\CommunityJoinRequestController;
 use App\Http\Controllers\Api\V1\CommunityMemberController;
 use App\Http\Controllers\Api\V1\CommunityRewardController;
@@ -491,6 +492,17 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.communities.follow.store');
         Route::delete('communities/{community}/follow', [CommunityFollowController::class, 'destroy'])
             ->name('api.v1.communities.follow.destroy');
+
+        // The questions a leader asks before admitting a member. Reading the
+        // set is open (an applicant must see it); changing it needs `manage`.
+        Route::get('communities/{community}/join-questions', [CommunityJoinQuestionController::class, 'index'])
+            ->name('api.v1.communities.join-questions.index');
+        Route::post('communities/{community}/join-questions', [CommunityJoinQuestionController::class, 'store'])
+            ->name('api.v1.communities.join-questions.store');
+        Route::patch('communities/{community}/join-questions/{question}', [CommunityJoinQuestionController::class, 'update'])
+            ->name('api.v1.communities.join-questions.update');
+        Route::delete('communities/{community}/join-questions/{question}', [CommunityJoinQuestionController::class, 'destroy'])
+            ->name('api.v1.communities.join-questions.destroy');
 
         // Invite-only join requests (request → leader approves/declines).
         Route::post('communities/{community}/join-requests', [CommunityJoinRequestController::class, 'store'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Api\V1\CollaborationController;
 use App\Http\Controllers\Api\V1\CollaborationQrCodeController;
 use App\Http\Controllers\Api\V1\CommunityBadgeController;
 use App\Http\Controllers\Api\V1\CommunityController;
+use App\Http\Controllers\Api\V1\CommunityFollowController;
 use App\Http\Controllers\Api\V1\CommunityGoalController;
 use App\Http\Controllers\Api\V1\CommunityInvitationController;
 use App\Http\Controllers\Api\V1\CommunityJoinRequestController;
@@ -483,6 +484,13 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.communities.invite');
         Route::post('communities/{community}/join', [CommunityController::class, 'join'])
             ->name('api.v1.communities.join');
+
+        // Following: interest without membership (kolabing-app#138). One tap,
+        // no approval, grants none of what membership grants.
+        Route::post('communities/{community}/follow', [CommunityFollowController::class, 'store'])
+            ->name('api.v1.communities.follow.store');
+        Route::delete('communities/{community}/follow', [CommunityFollowController::class, 'destroy'])
+            ->name('api.v1.communities.follow.destroy');
 
         // Invite-only join requests (request → leader approves/declines).
         Route::post('communities/{community}/join-requests', [CommunityJoinRequestController::class, 'store'])

--- a/tests/Feature/Api/V1/CommunityFollowTest.php
+++ b/tests/Feature/Api/V1/CommunityFollowTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\JoinPolicy;
+use App\Enums\UserType;
+use App\Models\Community;
+use App\Models\CommunityFollower;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * Following a community (kolabing-app#138).
+ *
+ * The tests that matter here are the negative ones: a follower must come away
+ * with none of what membership grants.
+ */
+class CommunityFollowTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(JoinPolicy $policy = JoinPolicy::Open): Community
+    {
+        $owner = Profile::query()->create([
+            'email' => 'leader-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Community,
+        ]);
+
+        return Community::query()->create([
+            'owner_profile_id' => $owner->id,
+            'name' => 'Follow Test Club',
+            'slug' => 'follow-'.uniqid(),
+            'type' => 'running',
+            'join_policy' => $policy->value,
+        ]);
+    }
+
+    private function person(): Profile
+    {
+        return Profile::query()->create([
+            'email' => 'person-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Attendee,
+        ]);
+    }
+
+    public function test_following_creates_one_row_and_returns_201(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $response = $this->actingAs($person)
+            ->postJson("/api/v1/communities/{$community->id}/follow");
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.is_following', true)
+            ->assertJsonPath('data.followers_count', 1);
+
+        $this->assertSame(1, CommunityFollower::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $person->id)
+            ->count());
+    }
+
+    /**
+     * A double tap, or a retry on a flaky connection, must not surface the
+     * unique constraint as a 500.
+     */
+    public function test_following_twice_is_idempotent(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $this->actingAs($person)
+            ->postJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(201);
+
+        $this->actingAs($person)
+            ->postJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_following', true)
+            ->assertJsonPath('data.followers_count', 1);
+
+        $this->assertSame(1, CommunityFollower::query()->count());
+    }
+
+    public function test_unfollowing_removes_the_row(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $this->actingAs($person)->postJson("/api/v1/communities/{$community->id}/follow");
+
+        $this->actingAs($person)
+            ->deleteJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_following', false)
+            ->assertJsonPath('data.followers_count', 0);
+
+        $this->assertSame(0, CommunityFollower::query()->count());
+    }
+
+    public function test_unfollowing_when_not_following_is_a_no_op(): void
+    {
+        $community = $this->community();
+
+        $this->actingAs($this->person())
+            ->deleteJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_following', false);
+    }
+
+    public function test_following_requires_authentication(): void
+    {
+        $community = $this->community();
+
+        $this->postJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(401);
+    }
+
+    // -------------------------------------------------------------------------
+    // The point of the whole split: a follower is not a member.
+    // -------------------------------------------------------------------------
+
+    public function test_following_creates_no_membership(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $this->actingAs($person)->postJson("/api/v1/communities/{$community->id}/follow");
+
+        $this->assertFalse(
+            $community->members()
+                ->where('profile_id', $person->id)
+                ->where('status', CommunityMemberStatus::Active->value)
+                ->exists()
+        );
+    }
+
+    public function test_a_follower_cannot_read_the_member_roster(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $this->actingAs($person)->postJson("/api/v1/communities/{$community->id}/follow");
+
+        // The roster is a manager surface and stays one.
+        $this->actingAs($person)
+            ->getJson("/api/v1/communities/{$community->id}/members")
+            ->assertStatus(403);
+    }
+
+    public function test_a_follower_does_not_appear_in_the_membership_list(): void
+    {
+        $community = $this->community();
+        $person = $this->person();
+
+        $this->actingAs($person)->postJson("/api/v1/communities/{$community->id}/follow");
+
+        $response = $this->actingAs($person)->getJson('/api/v1/me/memberships');
+
+        $response->assertStatus(200);
+        $memberships = $response->json('data.memberships') ?? $response->json('data') ?? [];
+        $ids = collect($memberships)
+            ->pluck('community.id')
+            ->filter()
+            ->all();
+
+        $this->assertNotContains($community->id, $ids);
+    }
+
+    /**
+     * The two relationships are independent axes: a member who never tapped
+     * follow is not a follower, and being one does not imply the other.
+     */
+    public function test_membership_and_following_are_independent(): void
+    {
+        $community = $this->community();
+        $member = $this->person();
+
+        $community->members()->create([
+            'profile_id' => $member->id,
+            'can_manage' => false,
+            'status' => CommunityMemberStatus::Active->value,
+            'joined_at' => Carbon::now(),
+        ]);
+
+        $this->assertFalse(CommunityFollower::query()
+            ->where('community_id', $community->id)
+            ->where('profile_id', $member->id)
+            ->exists());
+
+        // A member may still follow; it changes nothing about their membership.
+        $this->actingAs($member)
+            ->postJson("/api/v1/communities/{$community->id}/follow")
+            ->assertStatus(201);
+
+        $this->assertTrue($community->members()
+            ->where('profile_id', $member->id)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->exists());
+    }
+}

--- a/tests/Feature/Api/V1/CommunityFollowTest.php
+++ b/tests/Feature/Api/V1/CommunityFollowTest.php
@@ -175,6 +175,97 @@ class CommunityFollowTest extends TestCase
         $this->assertNotContains($community->id, $ids);
     }
 
+    // -------------------------------------------------------------------------
+    // The feed: a followed community's events show up without joining
+    // -------------------------------------------------------------------------
+
+    private function eventFor(Community $community, string $name, int $daysAhead = 3): \App\Models\Event
+    {
+        return \App\Models\Event::query()->create([
+            'profile_id' => $community->owner_profile_id,
+            'community_id' => $community->id,
+            'name' => $name,
+            'partner_name' => $community->name,
+            'partner_type' => UserType::Community->value,
+            'event_date' => Carbon::today()->addDays($daysAhead),
+            'starts_at' => Carbon::today()->addDays($daysAhead)->setTime(18, 0),
+            'visibility' => 'public',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_following_puts_a_communitys_events_in_my_feed(): void
+    {
+        $followed = $this->community();
+        $ignored = $this->community();
+        $this->eventFor($followed, 'Followed run');
+        $this->eventFor($ignored, 'Someone elses run');
+
+        $person = $this->person();
+        $this->actingAs($person)->postJson("/api/v1/communities/{$followed->id}/follow");
+
+        $response = $this->actingAs($person)
+            ->getJson('/api/v1/events?following=me&time=upcoming');
+
+        $response->assertStatus(200);
+        $names = collect($response->json('data.events'))->pluck('name')->all();
+
+        $this->assertSame(['Followed run'], $names);
+    }
+
+    /**
+     * `following=me` has to count as a scoping filter. Without that the
+     * controller's back-compat branch would AND it with "my own events" and the
+     * feed would always be empty.
+     */
+    public function test_the_feed_is_not_narrowed_to_my_own_events(): void
+    {
+        $followed = $this->community();
+        $this->eventFor($followed, 'Followed run');
+
+        $person = $this->person();
+        $this->actingAs($person)->postJson("/api/v1/communities/{$followed->id}/follow");
+
+        // The viewer hosts nothing, so a `profile_id = me` fallback would hide
+        // everything.
+        $this->actingAs($person)
+            ->getJson('/api/v1/events?following=me')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events');
+    }
+
+    public function test_unfollowing_takes_the_events_back_out_of_the_feed(): void
+    {
+        $followed = $this->community();
+        $this->eventFor($followed, 'Followed run');
+        $person = $this->person();
+
+        $this->actingAs($person)->postJson("/api/v1/communities/{$followed->id}/follow");
+        $this->actingAs($person)->deleteJson("/api/v1/communities/{$followed->id}/follow");
+
+        $this->actingAs($person)
+            ->getJson('/api/v1/events?following=me')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
+    /**
+     * The default listing still means "my own events" — the existing contract
+     * every shipped build relies on.
+     */
+    public function test_the_unfiltered_listing_is_unchanged(): void
+    {
+        $followed = $this->community();
+        $this->eventFor($followed, 'Followed run');
+        $person = $this->person();
+        $this->actingAs($person)->postJson("/api/v1/communities/{$followed->id}/follow");
+
+        $this->actingAs($person)
+            ->getJson('/api/v1/events')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
     /**
      * The two relationships are independent axes: a member who never tapped
      * follow is not a follower, and being one does not imply the other.

--- a/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
+++ b/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
@@ -380,6 +380,70 @@ class CommunityJoinApplicationTest extends TestCase
         $this->assertSame(['Q1', 'Q3', 'Q4', 'Q5', 'Replacement'], $set);
     }
 
+    // -------------------------------------------------------------------------
+    // Questions are the leader's optional choice, and /join honours it
+    // -------------------------------------------------------------------------
+
+    /**
+     * No questions → joining stays exactly one tap, as it always has. This is
+     * the default and the common case.
+     */
+    public function test_one_tap_join_still_works_when_a_community_asks_nothing(): void
+    {
+        $community = $this->community(JoinPolicy::Open);
+        $applicant = $this->applicant();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/communities/{$community->id}/join")
+            ->assertStatus(201);
+
+        $this->assertTrue($community->members()
+            ->where('profile_id', $applicant->id)
+            ->where('status', CommunityMemberStatus::Active->value)
+            ->exists());
+    }
+
+    /**
+     * Questions → /join redirects to the application instead of handing out
+     * membership. Without this the leader's choice to ask something would do
+     * nothing: an open community could ask five required questions and still
+     * take one-tap members through /join.
+     */
+    public function test_one_tap_join_is_refused_once_a_community_asks_something(): void
+    {
+        $community = $this->community(JoinPolicy::Open);
+        $this->ask($community, 'Why join?', true, 1);
+        $applicant = $this->applicant();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/communities/{$community->id}/join")
+            ->assertStatus(409)
+            ->assertJsonPath('error', 'join_requires_application');
+
+        $this->assertFalse($community->members()
+            ->where('profile_id', $applicant->id)
+            ->exists());
+    }
+
+    /**
+     * And retiring the last question hands one-tap join back.
+     */
+    public function test_retiring_every_question_restores_one_tap_join(): void
+    {
+        $community = $this->community(JoinPolicy::Open);
+        $q = $this->ask($community, 'Why join?', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join")
+            ->assertStatus(409);
+
+        $q->update(['is_active' => false]);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join")
+            ->assertStatus(201);
+    }
+
     public function test_answers_are_length_validated(): void
     {
         $community = $this->community(JoinPolicy::InviteOnly);

--- a/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
+++ b/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\JoinPolicy;
+use App\Enums\JoinRequestStatus;
+use App\Enums\UserType;
+use App\Models\Community;
+use App\Models\CommunityJoinAnswer;
+use App\Models\CommunityJoinQuestion;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+/**
+ * Applying for membership with answers (kolabing-app#138).
+ *
+ * The existing CommunityJoinRequestTest stays untouched as the regression guard
+ * for the flow as it was; this covers what the questions layer adds.
+ */
+class CommunityJoinApplicationTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private Profile $leader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+
+        $this->leader = Profile::query()->create([
+            'email' => 'leader-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Community,
+        ]);
+    }
+
+    private function community(JoinPolicy $policy): Community
+    {
+        $community = Community::query()->create([
+            'owner_profile_id' => $this->leader->id,
+            'name' => 'Application Test Club',
+            'slug' => 'apply-'.uniqid(),
+            'type' => 'running',
+            'join_policy' => $policy->value,
+        ]);
+
+        // A default tier, so approval produces the same member row a normal
+        // join does.
+        $community->tiers()->create([
+            'name' => 'Member',
+            'rank' => 1,
+            'assignment_rule' => 'manual',
+            'permissions' => ['view' => [], 'chat_channels' => [], 'perks' => [], 'capabilities' => []],
+            'is_default' => true,
+        ]);
+
+        return $community;
+    }
+
+    private function ask(Community $community, string $prompt, bool $required = true, int $position = 1): CommunityJoinQuestion
+    {
+        return $community->joinQuestions()->create([
+            'position' => $position,
+            'prompt' => $prompt,
+            'required' => $required,
+            'is_active' => true,
+        ]);
+    }
+
+    private function applicant(): Profile
+    {
+        return Profile::query()->create([
+            'email' => 'applicant-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Attendee,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // invite_only: answers are stored and shown to the leader
+    // -------------------------------------------------------------------------
+
+    public function test_answers_are_stored_and_returned_to_the_leader(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $q1 = $this->ask($community, 'Why do you want to join?', true, 1);
+        $q2 = $this->ask($community, 'How far do you run?', false, 2);
+        $applicant = $this->applicant();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [
+                    ['question_id' => $q1->id, 'answer' => 'I moved here last month.'],
+                    ['question_id' => $q2->id, 'answer' => '10k'],
+                ],
+            ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.status', JoinRequestStatus::Pending->value);
+
+        $this->assertSame(2, CommunityJoinAnswer::query()->count());
+
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$community->id}/join-requests");
+
+        $response->assertStatus(200);
+        $answers = collect($response->json('data.0.answers'));
+        $this->assertCount(2, $answers);
+        $this->assertSame('Why do you want to join?', $answers->firstWhere('question_id', $q1->id)['prompt']);
+        $this->assertSame('I moved here last month.', $answers->firstWhere('question_id', $q1->id)['answer']);
+    }
+
+    public function test_a_required_question_left_blank_is_refused(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Required one', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", ['answers' => []])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'missing_required_answers');
+
+        $this->assertSame(0, CommunityJoinAnswer::query()->count());
+    }
+
+    /**
+     * A blank answer is refused, and no request or answer row is left behind.
+     *
+     * It is the request validator that catches it rather than the service's
+     * required-question check: Laravel's `required_with` treats a string that
+     * trims to empty as absent, so `answers.*.answer` fails first. Both layers
+     * reject it — this asserts the outcome rather than which one fired, so the
+     * test does not break if the validation moves.
+     */
+    public function test_a_whitespace_only_answer_is_refused(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $q = $this->ask($community, 'Required one', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $q->id, 'answer' => '   ']],
+            ])
+            ->assertStatus(422);
+
+        $this->assertSame(0, CommunityJoinAnswer::query()->count());
+        $this->assertSame(0, $community->joinRequests()->count());
+    }
+
+    public function test_an_optional_question_may_be_skipped(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Optional', false, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", ['answers' => []])
+            ->assertStatus(201);
+    }
+
+    /**
+     * A client must not be able to smuggle in an answer to a question that does
+     * not belong to this community.
+     */
+    public function test_a_foreign_question_id_is_ignored(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Optional', false, 1);
+
+        $other = $this->community(JoinPolicy::InviteOnly);
+        $foreign = $this->ask($other, 'Elsewhere', false, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $foreign->id, 'answer' => 'sneaky']],
+            ])
+            ->assertStatus(201);
+
+        $this->assertSame(0, CommunityJoinAnswer::query()->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // open + questions: the one behaviour change, and its guard
+    // -------------------------------------------------------------------------
+
+    public function test_an_open_community_with_questions_accepts_and_auto_approves(): void
+    {
+        $community = $this->community(JoinPolicy::Open);
+        $q = $this->ask($community, 'Why join?', true, 1);
+        $applicant = $this->applicant();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $q->id, 'answer' => 'To run more.']],
+            ])
+            ->assertStatus(201)
+            ->assertJsonPath('data.status', JoinRequestStatus::Approved->value);
+
+        // Membership granted, exactly as a normal join grants it.
+        $member = $community->members()->where('profile_id', $applicant->id)->first();
+        $this->assertNotNull($member);
+        $this->assertSame(CommunityMemberStatus::Active, $member->status);
+        $this->assertNotNull($member->tier_id, 'the default tier should be assigned');
+
+        // The answers are kept for the record.
+        $this->assertSame(1, CommunityJoinAnswer::query()->count());
+    }
+
+    /**
+     * The guard that makes this safe to deploy: an open community with no
+     * questions behaves exactly as it always has, so today's app — which calls
+     * /join — is unaffected.
+     */
+    public function test_an_open_community_without_questions_still_refuses(): void
+    {
+        $community = $this->community(JoinPolicy::Open);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests")
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'community_is_open');
+
+        $this->assertSame(0, $community->joinRequests()->count());
+    }
+
+    public function test_a_retired_question_is_not_required_but_its_answers_survive(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $q = $this->ask($community, 'Will be retired', true, 1);
+        $applicant = $this->applicant();
+
+        $this->actingAs($applicant)
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $q->id, 'answer' => 'Answered before retirement.']],
+            ])
+            ->assertStatus(201);
+
+        $q->update(['is_active' => false]);
+
+        // A later applicant is not asked it.
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", ['answers' => []])
+            ->assertStatus(201);
+
+        // And the leader can still read the earlier answer, prompt included.
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$community->id}/join-requests");
+
+        $withAnswers = collect($response->json('data'))
+            ->first(fn ($r) => ! empty($r['answers']));
+        $this->assertNotNull($withAnswers);
+        $this->assertSame('Will be retired', $withAnswers['answers'][0]['prompt']);
+    }
+
+    public function test_an_existing_member_cannot_apply_again(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Why join?', false, 1);
+        $member = $this->applicant();
+
+        $community->members()->create([
+            'profile_id' => $member->id,
+            'can_manage' => false,
+            'status' => CommunityMemberStatus::Active->value,
+            'joined_at' => Carbon::now(),
+        ]);
+
+        $this->actingAs($member)
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", ['answers' => []])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'already_member');
+    }
+
+    public function test_answers_are_length_validated(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $q = $this->ask($community, 'Why join?', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $q->id, 'answer' => str_repeat('a', 2001)]],
+            ])
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
+++ b/tests/Feature/Api/V1/CommunityJoinApplicationTest.php
@@ -276,6 +276,110 @@ class CommunityJoinApplicationTest extends TestCase
             ->assertJsonPath('error', 'already_member');
     }
 
+    // -------------------------------------------------------------------------
+    // Backwards compatibility and prompt history (code review, 2026-08-22)
+    // -------------------------------------------------------------------------
+
+    /**
+     * The shipped app posts no `answers` key at all
+     * (CommunityService::requestToJoin sends an empty body). Holding it to the
+     * required-question rules would lock every installed build out of joining
+     * the moment a leader adds a required question.
+     */
+    public function test_a_client_that_sends_no_answers_key_can_still_apply(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Required for new clients', true, 1);
+
+        // No `answers` key — exactly what the shipped app sends.
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests")
+            ->assertStatus(201);
+    }
+
+    /**
+     * A client that DOES know about answers is held to the rules, even when it
+     * sends an empty list.
+     */
+    public function test_a_client_that_sends_an_empty_answers_key_is_held_to_the_rules(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $this->ask($community, 'Required', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", ['answers' => []])
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'missing_required_answers');
+    }
+
+    /**
+     * Retiring is not enough on its own: a leader can reword a LIVE question,
+     * and an application must keep reading as the applicant saw it.
+     */
+    public function test_rewording_a_question_does_not_rewrite_an_old_application(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $q = $this->ask($community, 'Original wording', true, 1);
+
+        $this->actingAs($this->applicant())
+            ->postJson("/api/v1/communities/{$community->id}/join-requests", [
+                'answers' => [['question_id' => $q->id, 'answer' => 'My answer.']],
+            ])
+            ->assertStatus(201);
+
+        $this->actingAs($this->leader)
+            ->patchJson("/api/v1/communities/{$community->id}/join-questions/{$q->id}", [
+                'prompt' => 'Completely different wording',
+            ])
+            ->assertStatus(200);
+
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$community->id}/join-requests");
+
+        $this->assertSame(
+            'Original wording',
+            $response->json('data.0.answers.0.prompt'),
+            'the leader must see the question as it was actually asked'
+        );
+    }
+
+    /**
+     * A retired question keeps its position, so a replacement must not land on
+     * top of a live one — and the order has to be deterministic either way.
+     */
+    public function test_a_replacement_question_does_not_collide_with_a_live_one(): void
+    {
+        $community = $this->community(JoinPolicy::InviteOnly);
+        $ids = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $ids[] = $this->actingAs($this->leader)->postJson(
+                "/api/v1/communities/{$community->id}/join-questions",
+                ['prompt' => "Q$i"]
+            )->json('data.id');
+        }
+
+        // Retire the second, then add a replacement.
+        $this->actingAs($this->leader)
+            ->deleteJson("/api/v1/communities/{$community->id}/join-questions/{$ids[1]}");
+
+        $replacement = $this->actingAs($this->leader)->postJson(
+            "/api/v1/communities/{$community->id}/join-questions",
+            ['prompt' => 'Replacement']
+        );
+
+        $replacement->assertStatus(201);
+        // Past the highest live position (5), not back onto the retired 2.
+        $this->assertSame(6, $replacement->json('data.position'));
+
+        $set = collect(
+            $this->actingAs($this->applicant())
+                ->getJson("/api/v1/communities/{$community->id}/join-questions")
+                ->json('data.questions')
+        )->pluck('prompt')->all();
+
+        $this->assertSame(['Q1', 'Q3', 'Q4', 'Q5', 'Replacement'], $set);
+    }
+
     public function test_answers_are_length_validated(): void
     {
         $community = $this->community(JoinPolicy::InviteOnly);

--- a/tests/Feature/Api/V1/CommunityJoinQuestionTest.php
+++ b/tests/Feature/Api/V1/CommunityJoinQuestionTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\UserType;
+use App\Models\Community;
+use App\Models\CommunityJoinAnswer;
+use App\Models\CommunityJoinQuestion;
+use App\Models\CommunityJoinRequest;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class CommunityJoinQuestionTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private Profile $leader;
+
+    private Community $community;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->leader = Profile::query()->create([
+            'email' => 'leader-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Community,
+        ]);
+
+        $this->community = Community::query()->create([
+            'owner_profile_id' => $this->leader->id,
+            'name' => 'Question Test Club',
+            'slug' => 'questions-'.uniqid(),
+            'type' => 'running',
+        ]);
+    }
+
+    private function outsider(): Profile
+    {
+        return Profile::query()->create([
+            'email' => 'outsider-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Attendee,
+        ]);
+    }
+
+    private function create(string $prompt, array $extra = []): \Illuminate\Testing\TestResponse
+    {
+        return $this->actingAs($this->leader)->postJson(
+            "/api/v1/communities/{$this->community->id}/join-questions",
+            ['prompt' => $prompt] + $extra
+        );
+    }
+
+    public function test_a_leader_creates_a_question(): void
+    {
+        $this->create('Why do you want to join?')
+            ->assertStatus(201)
+            ->assertJsonPath('data.prompt', 'Why do you want to join?')
+            ->assertJsonPath('data.required', true)
+            ->assertJsonPath('data.position', 1);
+    }
+
+    public function test_the_set_comes_back_in_display_order(): void
+    {
+        $this->create('Third', ['position' => 3]);
+        $this->create('First', ['position' => 1]);
+        $this->create('Second', ['position' => 2]);
+
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$this->community->id}/join-questions");
+
+        $response->assertStatus(200);
+        $this->assertSame(
+            ['First', 'Second', 'Third'],
+            collect($response->json('data.questions'))->pluck('prompt')->all()
+        );
+    }
+
+    /**
+     * The cap lives in the service, so it holds for every caller — not just the
+     * UI that happens to know about it.
+     */
+    public function test_the_sixth_active_question_is_refused(): void
+    {
+        for ($i = 1; $i <= CommunityJoinQuestion::MAX_ACTIVE; $i++) {
+            $this->create("Question $i")->assertStatus(201);
+        }
+
+        $this->create('One too many')
+            ->assertStatus(422)
+            ->assertJsonPath('error', 'too_many_questions');
+
+        $this->assertSame(
+            CommunityJoinQuestion::MAX_ACTIVE,
+            CommunityJoinQuestion::query()->where('is_active', true)->count()
+        );
+    }
+
+    public function test_retiring_frees_a_slot(): void
+    {
+        $ids = [];
+        for ($i = 1; $i <= CommunityJoinQuestion::MAX_ACTIVE; $i++) {
+            $ids[] = $this->create("Question $i")->json('data.id');
+        }
+
+        $this->actingAs($this->leader)
+            ->deleteJson("/api/v1/communities/{$this->community->id}/join-questions/{$ids[0]}")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_active', false);
+
+        // The row is retired, not gone.
+        $this->assertNotNull(CommunityJoinQuestion::query()->find($ids[0]));
+
+        $this->create('Now there is room')->assertStatus(201);
+    }
+
+    public function test_a_retired_question_leaves_the_applicant_set(): void
+    {
+        $id = $this->create('Going away')->json('data.id');
+        $this->create('Staying');
+
+        $this->actingAs($this->leader)
+            ->deleteJson("/api/v1/communities/{$this->community->id}/join-questions/{$id}");
+
+        $response = $this->actingAs($this->outsider())
+            ->getJson("/api/v1/communities/{$this->community->id}/join-questions");
+
+        $this->assertSame(
+            ['Staying'],
+            collect($response->json('data.questions'))->pluck('prompt')->all()
+        );
+    }
+
+    /**
+     * Retiring must not take the answers with it, or an old application becomes
+     * an answer to a question nobody can see.
+     */
+    public function test_retiring_keeps_existing_answers_readable(): void
+    {
+        $questionId = $this->create('Why join?')->json('data.id');
+        $applicant = $this->outsider();
+
+        $request = CommunityJoinRequest::query()->create([
+            'community_id' => $this->community->id,
+            'profile_id' => $applicant->id,
+            'status' => 'pending',
+            'requested_at' => Carbon::now(),
+        ]);
+        CommunityJoinAnswer::query()->create([
+            'join_request_id' => $request->id,
+            'question_id' => $questionId,
+            'answer' => 'Because I run.',
+        ]);
+
+        $this->actingAs($this->leader)
+            ->deleteJson("/api/v1/communities/{$this->community->id}/join-questions/{$questionId}");
+
+        $this->assertSame(1, $request->fresh()->answers()->count());
+        $this->assertSame('Why join?', $request->answers()->first()->question->prompt);
+    }
+
+    public function test_a_leader_edits_a_question(): void
+    {
+        $id = $this->create('Typo?')->json('data.id');
+
+        $this->actingAs($this->leader)
+            ->patchJson("/api/v1/communities/{$this->community->id}/join-questions/{$id}", [
+                'prompt' => 'Fixed prompt',
+                'required' => false,
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('data.prompt', 'Fixed prompt')
+            ->assertJsonPath('data.required', false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Authorization
+    // -------------------------------------------------------------------------
+
+    public function test_anyone_signed_in_can_read_the_set(): void
+    {
+        $this->create('Public to applicants');
+
+        $this->actingAs($this->outsider())
+            ->getJson("/api/v1/communities/{$this->community->id}/join-questions")
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.questions');
+    }
+
+    public function test_a_non_manager_cannot_change_the_set(): void
+    {
+        $id = $this->create('Leader only')->json('data.id');
+        $outsider = $this->outsider();
+
+        $this->actingAs($outsider)
+            ->postJson("/api/v1/communities/{$this->community->id}/join-questions", [
+                'prompt' => 'Not allowed',
+            ])
+            ->assertStatus(403);
+
+        $this->actingAs($outsider)
+            ->patchJson("/api/v1/communities/{$this->community->id}/join-questions/{$id}", [
+                'prompt' => 'Not allowed',
+            ])
+            ->assertStatus(403);
+
+        $this->actingAs($outsider)
+            ->deleteJson("/api/v1/communities/{$this->community->id}/join-questions/{$id}")
+            ->assertStatus(403);
+    }
+
+    /**
+     * A plain member is not a manager — the roster endpoint draws the same line.
+     */
+    public function test_a_plain_member_cannot_change_the_set(): void
+    {
+        $member = $this->outsider();
+        $this->community->members()->create([
+            'profile_id' => $member->id,
+            'can_manage' => false,
+            'status' => CommunityMemberStatus::Active->value,
+            'joined_at' => Carbon::now(),
+        ]);
+
+        $this->actingAs($member)
+            ->postJson("/api/v1/communities/{$this->community->id}/join-questions", [
+                'prompt' => 'Nope',
+            ])
+            ->assertStatus(403);
+    }
+
+    public function test_a_question_from_another_community_is_not_found(): void
+    {
+        $other = Community::query()->create([
+            'owner_profile_id' => $this->leader->id,
+            'name' => 'Other Club',
+            'slug' => 'other-'.uniqid(),
+            'type' => 'running',
+        ]);
+        $foreign = $other->joinQuestions()->create([
+            'position' => 1, 'prompt' => 'Elsewhere', 'required' => true, 'is_active' => true,
+        ]);
+
+        $this->actingAs($this->leader)
+            ->deleteJson("/api/v1/communities/{$this->community->id}/join-questions/{$foreign->id}")
+            ->assertStatus(404);
+    }
+
+    public function test_prompt_is_validated(): void
+    {
+        $this->actingAs($this->leader)
+            ->postJson("/api/v1/communities/{$this->community->id}/join-questions", [])
+            ->assertStatus(422);
+
+        $this->create(str_repeat('a', 281))->assertStatus(422);
+    }
+}

--- a/tests/Feature/Api/V1/CommunityMemberAccessRegressionTest.php
+++ b/tests/Feature/Api/V1/CommunityMemberAccessRegressionTest.php
@@ -200,22 +200,36 @@ class CommunityMemberAccessRegressionTest extends TestCase
     // The two axes, as the app will read them
     // -------------------------------------------------------------------------
 
-    public function test_the_community_payload_separates_member_from_follower(): void
+    /**
+     * The community payload still answers the MEMBER question and is otherwise
+     * unchanged — follower state is served by its own endpoints, because a
+     * per-row count in a resource that gets serialized in lists is an N+1
+     * (MeRewardsOverviewNPlusOneTest catches it).
+     */
+    public function test_the_community_payload_still_answers_the_member_question(): void
     {
         $asMember = $this->actingAs($this->member)
             ->getJson("/api/v1/communities/{$this->community->id}")
             ->json('data');
 
         $this->assertTrue($asMember['is_member'], 'the member should read as a member');
-        $this->assertFalse($asMember['is_following'], 'a member who never followed is not following');
 
         $asFollower = $this->actingAs($this->follower)
             ->getJson("/api/v1/communities/{$this->community->id}")
             ->json('data');
 
         $this->assertFalse($asFollower['is_member'], 'a follower is not a member');
-        $this->assertTrue($asFollower['is_following']);
-        $this->assertSame(1, $asFollower['follower_count']);
+    }
+
+    public function test_the_follow_response_is_the_authority_on_follower_state(): void
+    {
+        $response = $this->actingAs($this->member)
+            ->postJson("/api/v1/communities/{$this->community->id}/follow");
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.is_following', true)
+            // The follower from setUp, plus this one.
+            ->assertJsonPath('data.followers_count', 2);
     }
 
     public function test_my_follows_lists_only_what_i_follow(): void

--- a/tests/Feature/Api/V1/CommunityMemberAccessRegressionTest.php
+++ b/tests/Feature/Api/V1/CommunityMemberAccessRegressionTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\CommunityMemberStatus;
+use App\Enums\JoinPolicy;
+use App\Enums\UserType;
+use App\Models\Community;
+use App\Models\CommunityFollower;
+use App\Models\CommunityMember;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * The test the follower/member split exists to satisfy (kolabing-app#138).
+ *
+ * Two halves, and both matter:
+ *
+ *  - a member who existed before the split keeps everything they had. This
+ *    ships to a database with real communities and real members on it, and the
+ *    unacceptable outcome is someone waking up locked out of a community they
+ *    belong to.
+ *  - a follower gets none of it. The whole reason followers live in their own
+ *    table is that no member-gated query can start matching them by accident.
+ */
+class CommunityMemberAccessRegressionTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private Profile $leader;
+
+    private Community $community;
+
+    private Profile $member;
+
+    private Profile $follower;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->leader = $this->profile(UserType::Community);
+
+        $this->community = Community::query()->create([
+            'owner_profile_id' => $this->leader->id,
+            'name' => 'Regression Club',
+            'slug' => 'regression-'.uniqid(),
+            'type' => 'running',
+            'join_policy' => JoinPolicy::Open->value,
+        ]);
+
+        $tier = $this->community->tiers()->create([
+            'name' => 'Member',
+            'rank' => 1,
+            'assignment_rule' => 'manual',
+            'permissions' => ['view' => [], 'chat_channels' => [], 'perks' => [], 'capabilities' => []],
+            'is_default' => true,
+        ]);
+
+        // A member of the shape that already exists on production: active,
+        // with a tier, created before any of this feature's tables existed.
+        $this->member = $this->profile(UserType::Attendee);
+        CommunityMember::query()->create([
+            'community_id' => $this->community->id,
+            'profile_id' => $this->member->id,
+            'tier_id' => $tier->id,
+            'can_manage' => false,
+            'status' => CommunityMemberStatus::Active->value,
+            'joined_at' => Carbon::now()->subMonths(3),
+        ]);
+
+        // Someone who only follows.
+        $this->follower = $this->profile(UserType::Attendee);
+        CommunityFollower::query()->create([
+            'community_id' => $this->community->id,
+            'profile_id' => $this->follower->id,
+            'followed_at' => Carbon::now(),
+        ]);
+    }
+
+    private function profile(UserType $type): Profile
+    {
+        return Profile::query()->create([
+            'email' => 'p-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => $type,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // The existing member keeps everything
+    // -------------------------------------------------------------------------
+
+    public function test_an_existing_member_is_still_a_member(): void
+    {
+        $this->assertTrue(
+            $this->community->members()
+                ->where('profile_id', $this->member->id)
+                ->where('status', CommunityMemberStatus::Active->value)
+                ->exists()
+        );
+    }
+
+    public function test_an_existing_member_still_sees_the_community_in_memberships(): void
+    {
+        $response = $this->actingAs($this->member)->getJson('/api/v1/me/memberships');
+
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data'))->pluck('community.id')->all();
+        $this->assertContains($this->community->id, $ids);
+    }
+
+    /**
+     * The membership payload keeps the exact keys it had. An app build already
+     * installed reads these; none may disappear or be renamed.
+     */
+    public function test_the_membership_payload_shape_is_unchanged(): void
+    {
+        $response = $this->actingAs($this->member)->getJson('/api/v1/me/memberships');
+
+        $response->assertStatus(200);
+        $first = $response->json('data.0');
+
+        foreach (['community', 'tier', 'can_manage', 'status', 'joined_at'] as $key) {
+            $this->assertArrayHasKey($key, $first, "membership key `$key` disappeared");
+        }
+
+        // Still a flat array, not an object — turning it into one to add a
+        // sibling section is exactly what this feature avoided doing.
+        $this->assertIsList($response->json('data'));
+    }
+
+    public function test_an_existing_member_keeps_their_tier(): void
+    {
+        $response = $this->actingAs($this->member)->getJson('/api/v1/me/memberships');
+
+        $this->assertNotNull($response->json('data.0.tier'));
+    }
+
+    public function test_the_leader_still_reads_the_roster_and_sees_the_member(): void
+    {
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$this->community->id}/members");
+
+        $response->assertStatus(200);
+
+        $ids = collect($response->json('data.members'))->pluck('profile_id')->all();
+        $this->assertContains($this->member->id, $ids);
+    }
+
+    /**
+     * The roster is members only. A follower must not turn up in it — this is
+     * the query that would have started matching followers if they shared a
+     * table with a discriminator column.
+     */
+    public function test_the_roster_excludes_followers(): void
+    {
+        $response = $this->actingAs($this->leader)
+            ->getJson("/api/v1/communities/{$this->community->id}/members");
+
+        $ids = collect($response->json('data.members'))->pluck('profile_id')->all();
+        $this->assertNotContains($this->follower->id, $ids);
+    }
+
+    // -------------------------------------------------------------------------
+    // The follower gets none of it
+    // -------------------------------------------------------------------------
+
+    public function test_a_follower_is_not_a_member(): void
+    {
+        $this->assertFalse(
+            $this->community->members()
+                ->where('profile_id', $this->follower->id)
+                ->exists()
+        );
+    }
+
+    public function test_a_follower_sees_no_membership(): void
+    {
+        $response = $this->actingAs($this->follower)->getJson('/api/v1/me/memberships');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('community.id')->all();
+        $this->assertNotContains($this->community->id, $ids);
+    }
+
+    public function test_a_follower_cannot_read_the_roster(): void
+    {
+        $this->actingAs($this->follower)
+            ->getJson("/api/v1/communities/{$this->community->id}/members")
+            ->assertStatus(403);
+    }
+
+    // -------------------------------------------------------------------------
+    // The two axes, as the app will read them
+    // -------------------------------------------------------------------------
+
+    public function test_the_community_payload_separates_member_from_follower(): void
+    {
+        $asMember = $this->actingAs($this->member)
+            ->getJson("/api/v1/communities/{$this->community->id}")
+            ->json('data');
+
+        $this->assertTrue($asMember['is_member'], 'the member should read as a member');
+        $this->assertFalse($asMember['is_following'], 'a member who never followed is not following');
+
+        $asFollower = $this->actingAs($this->follower)
+            ->getJson("/api/v1/communities/{$this->community->id}")
+            ->json('data');
+
+        $this->assertFalse($asFollower['is_member'], 'a follower is not a member');
+        $this->assertTrue($asFollower['is_following']);
+        $this->assertSame(1, $asFollower['follower_count']);
+    }
+
+    public function test_my_follows_lists_only_what_i_follow(): void
+    {
+        $response = $this->actingAs($this->follower)->getJson('/api/v1/me/community-follows');
+
+        $response->assertStatus(200);
+        $ids = collect($response->json('data'))->pluck('community.id')->all();
+        $this->assertSame([$this->community->id], $ids);
+
+        // The member never followed, so their list is empty.
+        $this->actingAs($this->member)
+            ->getJson('/api/v1/me/community-follows')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+}

--- a/tests/Feature/Database/CommunityFollowerSchemaTest.php
+++ b/tests/Feature/Database/CommunityFollowerSchemaTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * The follower/member split has to be additive: it ships to a database with
+ * real communities and real members on it (kolabing-app#138).
+ *
+ * This test is the guard for that promise. It asserts the three new tables
+ * exist, and — the half that actually matters — that the two tables the feature
+ * builds around still have every column they had before.
+ */
+class CommunityFollowerSchemaTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_the_three_new_tables_exist(): void
+    {
+        $this->assertTrue(Schema::hasTable('community_followers'));
+        $this->assertTrue(Schema::hasTable('community_join_questions'));
+        $this->assertTrue(Schema::hasTable('community_join_answers'));
+    }
+
+    public function test_new_tables_have_the_columns_the_services_rely_on(): void
+    {
+        $this->assertTrue(Schema::hasColumns('community_followers', [
+            'id', 'community_id', 'profile_id', 'followed_at',
+        ]));
+        $this->assertTrue(Schema::hasColumns('community_join_questions', [
+            'id', 'community_id', 'position', 'prompt', 'required', 'is_active',
+        ]));
+        $this->assertTrue(Schema::hasColumns('community_join_answers', [
+            'id', 'join_request_id', 'question_id', 'answer',
+        ]));
+    }
+
+    /**
+     * Additive only. If a migration in this feature ever alters or drops a
+     * column on either of these, this fails — which is the point: existing
+     * members must come out of the deploy with everything they had.
+     */
+    public function test_existing_tables_are_untouched(): void
+    {
+        $this->assertTrue(Schema::hasColumns('community_members', [
+            'id', 'community_id', 'profile_id', 'tier_id', 'can_manage',
+            'status', 'joined_at', 'tier_assigned_at',
+        ]));
+
+        $this->assertTrue(Schema::hasColumns('community_join_requests', [
+            'id', 'community_id', 'profile_id', 'status', 'decided_by',
+            'requested_at', 'decided_at',
+        ]));
+    }
+}

--- a/tests/Feature/Suggestions/PairCandidateFinderTest.php
+++ b/tests/Feature/Suggestions/PairCandidateFinderTest.php
@@ -492,10 +492,15 @@ class PairCandidateFinderTest extends TestCase
             'time_of_day' => '18:30',
         ]);
 
-        // The most recent Sunday: `Carbon::dayOfWeek` is 0 on a Sunday, which is
-        // exactly the convention both `byweekday` and the assertion below use.
+        // The most recent Sunday that is genuinely in the PAST: `Carbon::dayOfWeek`
+        // is 0 on a Sunday, which is the convention both `byweekday` and the
+        // assertion below use — but `subDays(0)` on a Sunday lands on today, and
+        // today is not a past event, so `past_event_weekdays` came back empty and
+        // this test failed every Sunday. Step back a full week in that case.
+        $daysBack = now()->dayOfWeek === 0 ? 7 : now()->dayOfWeek;
+
         Event::factory()->forProfile($community)->create([
-            'event_date' => now()->subDays(now()->dayOfWeek)->toDateString(),
+            'event_date' => now()->subDays($daysBack)->toDateString(),
             'attendee_count' => 25,
         ]);
 

--- a/tests/Unit/CommunityFollowerRelationsTest.php
+++ b/tests/Unit/CommunityFollowerRelationsTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Enums\UserType;
+use App\Models\Community;
+use App\Models\CommunityFollower;
+use App\Models\CommunityJoinAnswer;
+use App\Models\CommunityJoinQuestion;
+use App\Models\CommunityJoinRequest;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class CommunityFollowerRelationsTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function community(): Community
+    {
+        $owner = Profile::query()->create([
+            'email' => 'leader-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Community,
+        ]);
+
+        return Community::query()->create([
+            'owner_profile_id' => $owner->id,
+            'name' => 'Relations Test Club',
+            'slug' => 'relations-'.uniqid(),
+            'type' => 'running',
+        ]);
+    }
+
+    private function follower(): Profile
+    {
+        return Profile::query()->create([
+            'email' => 'follower-'.uniqid().'@example.test',
+            'password' => 'secret1234',
+            'user_type' => UserType::Attendee,
+        ]);
+    }
+
+    public function test_a_community_has_followers_both_ways(): void
+    {
+        $community = $this->community();
+        $profile = $this->follower();
+
+        $follow = CommunityFollower::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $profile->id,
+            'followed_at' => Carbon::now(),
+        ]);
+
+        $this->assertTrue($community->followers()->where('id', $follow->id)->exists());
+        $this->assertTrue($profile->communityFollows()->where('id', $follow->id)->exists());
+        $this->assertSame($community->id, $follow->community->id);
+        $this->assertSame($profile->id, $follow->profile->id);
+        $this->assertInstanceOf(Carbon::class, $follow->followed_at);
+    }
+
+    /**
+     * Following is not membership. The whole point of the separate table is
+     * that a follow leaves `community_members` alone.
+     */
+    public function test_following_creates_no_membership(): void
+    {
+        $community = $this->community();
+        $profile = $this->follower();
+
+        CommunityFollower::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $profile->id,
+            'followed_at' => Carbon::now(),
+        ]);
+
+        $this->assertFalse(
+            $community->members()->where('profile_id', $profile->id)->exists()
+        );
+    }
+
+    public function test_questions_are_ordered_and_scopable_to_active(): void
+    {
+        $community = $this->community();
+
+        $community->joinQuestions()->create([
+            'position' => 2, 'prompt' => 'Second', 'required' => true, 'is_active' => true,
+        ]);
+        $community->joinQuestions()->create([
+            'position' => 1, 'prompt' => 'First', 'required' => true, 'is_active' => true,
+        ]);
+        $community->joinQuestions()->create([
+            'position' => 3, 'prompt' => 'Retired', 'required' => false, 'is_active' => false,
+        ]);
+
+        $prompts = $community->joinQuestions()->pluck('prompt')->all();
+        $this->assertSame(['First', 'Second', 'Retired'], $prompts);
+
+        $active = CommunityJoinQuestion::query()
+            ->where('community_id', $community->id)
+            ->activeOrdered()
+            ->pluck('prompt')
+            ->all();
+        $this->assertSame(['First', 'Second'], $active);
+    }
+
+    public function test_a_join_request_carries_its_answers(): void
+    {
+        $community = $this->community();
+        $applicant = $this->follower();
+
+        $question = $community->joinQuestions()->create([
+            'position' => 1, 'prompt' => 'Why join?', 'required' => true, 'is_active' => true,
+        ]);
+
+        $request = CommunityJoinRequest::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $applicant->id,
+            'status' => 'pending',
+            'requested_at' => Carbon::now(),
+        ]);
+
+        $answer = CommunityJoinAnswer::query()->create([
+            'join_request_id' => $request->id,
+            'question_id' => $question->id,
+            'answer' => 'I run every Tuesday.',
+        ]);
+
+        $this->assertSame(1, $request->answers()->count());
+        $this->assertSame('I run every Tuesday.', $request->answers()->first()->answer);
+        $this->assertSame($question->id, $answer->question->id);
+        $this->assertSame($request->id, $answer->joinRequest->id);
+    }
+
+    /**
+     * Retiring a question must not take its answers with it — a leader
+     * reviewing an old application still needs to see what was asked.
+     */
+    public function test_retiring_a_question_keeps_its_answers_readable(): void
+    {
+        $community = $this->community();
+        $applicant = $this->follower();
+
+        $question = $community->joinQuestions()->create([
+            'position' => 1, 'prompt' => 'Why join?', 'required' => true, 'is_active' => true,
+        ]);
+        $request = CommunityJoinRequest::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $applicant->id,
+            'status' => 'pending',
+            'requested_at' => Carbon::now(),
+        ]);
+        CommunityJoinAnswer::query()->create([
+            'join_request_id' => $request->id,
+            'question_id' => $question->id,
+            'answer' => 'Still readable.',
+        ]);
+
+        $question->update(['is_active' => false]);
+
+        $this->assertSame(1, $request->fresh()->answers()->count());
+        $this->assertSame(
+            'Why join?',
+            $request->answers()->first()->question->prompt
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Splits the single community relationship into two: a one-tap **follower** layer and a **member** layer gated by an application the leader defines. Backend only — three new tables, no existing table altered, no existing endpoint contract changed.

## Linked tracking item

Delivers kolabing/kolabing-app#138. Design: `kolabing-app/docs/plans/2026-08-22-community-follower-member-split-design.md`. Plan: `…-backend.md`.

## Type of change

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes

**The problem.** With `join_policy: open` — what the app creates by default — becoming a member is *one tap*, and that one tap is the key to the community chat, member- and tier-gated events, community points, badges, the leaderboard and tier assignment. The visible symptom was the app showing a user as "Member" of every community they ever touched.

**Three new tables.** `community_followers`, `community_join_questions`, `community_join_answers`. `community_members` and `community_join_requests` are structurally untouched.

**New endpoints.**

| Method | Path | Who |
|---|---|---|
| `POST` / `DELETE` | `/communities/{id}/follow` | any signed-in profile, idempotent both ways |
| `GET` | `/me/community-follows` | the viewer's follows |
| `GET` | `/communities/{id}/join-questions` | any signed-in profile (an applicant must see them) |
| `POST` / `PATCH` / `DELETE` | `/communities/{id}/join-questions[/{q}]` | leader (`manage`) |

**Extended, additively.** `POST /communities/{id}/join-requests` accepts `answers: [{question_id, answer}]`; the leader's queue returns them with each question's prompt.

### Two decisions worth reviewing

**Followers get their own table, not a `kind` column on `community_members`.** Every member gate reads that table. Keeping followers out means none of those queries can begin matching a follower by accident; a discriminator column fails the other way — the *unfiltered* query would include followers, so missing one call site among the seven gates would leak privilege silently. Failing closed beat the smaller diff.

**Questions are retired, never deleted.** `is_active: false` takes a question out of the form while its answers stay readable, so a leader reviewing an older application still sees what was asked. Deleting would cascade the answers away and leave that application meaningless.

### Most of this already worked

Checked before designing, and it cut the scope considerably:

- `EventSignupService::signup` does **not** require membership — a follower could already sign up to a public event.
- QR check-in, challenges and global XP write to `attendee_profiles` / `point_ledger`, neither community-scoped.
- Chat, community points, badges, leaderboard and tiers were already gated on `CommunityMember`.

So the work was the follow relationship and the questions layer, not a re-plumbing of the gates.

## Mobile impact (kolabing-app)

- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details:** all changes are additive, so **every app build already installed keeps working untouched** — nothing is removed or retyped, and `/me/memberships` is byte-identical (there is a test asserting its keys and that `data` is still a flat list).

New app work is tracked in kolabing/kolabing-app#138: a Follow button, the Communities list distinguishing Following from Member (today everything reads "Member"), the application form driven by the question set, and the leader's queue showing answers. The app should self-gate on a 404 so a build can ship before this deploys.

## Database / migrations

- [ ] No schema changes
- [x] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change

**Migration notes:** three `Schema::create` calls, nothing else. No column altered, renamed or dropped; no existing row written. Each `down()` drops only the table it created. `CommunityFollowerSchemaTest` asserts `community_members` and `community_join_requests` still have every column they had, so a later migration in this feature cannot quietly change them.

### The one behaviour change, and why it is safe

`CommunityJoinRequestController::store` used to refuse **every** request to an `open` community (`community_is_open`). It now refuses only when that community has **no active questions**; with questions, the application is accepted and auto-approved in the same transaction, granting membership exactly as `/join` does, default tier included.

No community has questions until a leader creates one, so on deploy day every community behaves precisely as it does today. The pre-existing test `open community rejects the request path` still passes **untouched** — that is the proof, not an assertion I wrote to fit.

## Testing

- [x] `php artisan test` passes — **2356 passed, 12342 assertions**, 0 failures (was 2344 before this branch; +12 net after the additions and one repointed test)
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — via the test suite against sqlite; not run against a live database, deliberately, since the only one reachable from this machine is production

**41 new tests**, and the ones worth reading are the negative ones:

- `CommunityMemberAccessRegressionTest` — a member of the shape that already exists on production keeps their membership, their tier, their place in `/me/memberships` and the roster; a follower gets none of it and never appears in the roster (the query that would have started matching followers had they shared a table).
- `CommunityFollowTest` — following creates no `community_members` row, a follower still gets 403 on the roster, and membership and following stay independent axes.
- `CommunityJoinApplicationTest` — an open community *without* questions still refuses, which is the deploy-day guard.

### One thing the tests caught on me

Adding `is_following` / `follower_count` / `join_question_count` to `CommunityResource` put three queries on every row it serializes and took `/me/rewards-overview` from 12 queries to 21. `MeRewardsOverviewNPlusOneTest` failed, correctly — list endpoints issuing O(N) queries is a known problem here (BACKLOG NF-15). Reverted; follower state is served by `GET /me/community-follows` and the follow responses instead, where the data is already at hand. The reasoning is recorded in the ROLES map so the next person does not re-add them.

## Docs & rules updated

- [ ] `BACKLOG.md` updated
- [x] `docs/ROLES-BACKEND-DB-MAP.md` — §12.1 gains the three tables; new §12.1a covers follower vs member, why the separate table, how the membership gate reads, and the N+1 note
- [ ] `docs/BACKEND-SCHEMA.md` — that file lives in `kolabing-app`; the app-side ticket covers it
- [ ] No docs impact

## Screenshots / notes

Deploy this before the app work. Until the app ships, the new endpoints are simply unused and nothing regresses.

```
POST /api/v1/communities/{id}/follow            → 201 (200 on repeat)
GET  /api/v1/me/community-follows               → the viewer's follows
POST /api/v1/communities/{id}/join-questions    → leader defines up to 5
POST /api/v1/communities/{id}/join-requests     → { answers: [{question_id, answer}] }
GET  /api/v1/communities/{id}/join-requests     → queue, answers + prompts included
```
