### PR TITLE
feat(gamification): a peer challenge pays both people who did it

### DIFF
--- a/app/Services/ChallengeCompletionService.php
+++ b/app/Services/ChallengeCompletionService.php
@@ -142,11 +142,22 @@ class ChallengeCompletionService
                 'points_earned' => $points,
             ]);
 
-            // Increment attendee profile stats
-            $challengerProfile = $completion->challenger;
-            if ($challengerProfile->isAttendee() && $challengerProfile->attendeeProfile) {
-                $challengerProfile->attendeeProfile->increment('total_points', $points);
-                $challengerProfile->attendeeProfile->increment('total_challenges_completed');
+            // BOTH participants earn (kolabing-app#140).
+            //
+            // Previously only the challenger was credited, which made
+            // confirming unpaid labour: the second time you asked someone to
+            // verify you, you were asking a favour, and the natural equilibrium
+            // was people avoiding the verifier role. A challenge is something
+            // two people did together, so it pays both. `points_earned` on the
+            // completion is therefore what EACH side earned, not a total.
+            foreach ([$completion->challenger, $completion->verifier] as $participant) {
+                if ($participant === null) {
+                    continue;
+                }
+                if ($participant->isAttendee() && $participant->attendeeProfile) {
+                    $participant->attendeeProfile->increment('total_points', $points);
+                    $participant->attendeeProfile->increment('total_challenges_completed');
+                }
             }
 
             return $completion->load(['challenge', 'event', 'challenger', 'verifier']);
@@ -155,9 +166,14 @@ class ChallengeCompletionService
         // Send challenge verified notification (after transaction)
         $this->notificationService->notifyChallengeVerified($result);
 
-        // Check for badge milestones (after transaction)
-        $result->challenger->attendeeProfile?->refresh();
-        $this->badgeService->checkAndAwardBadges($result->challenger);
+        // Badge milestones for both, since both totals moved.
+        foreach ([$result->challenger, $result->verifier] as $participant) {
+            if ($participant === null) {
+                continue;
+            }
+            $participant->attendeeProfile?->refresh();
+            $this->badgeService->checkAndAwardBadges($participant);
+        }
 
         // Per-community POINTS earn (+ mirrored global XP) when the challenge's
         // event is community-linked and the challenger is an active member.
@@ -171,9 +187,15 @@ class ChallengeCompletionService
         }
 
         // Progress the attendee challenge missions (e.g. "complete N event
-        // challenges"). The challenger is the earner; verification is the
-        // source action for the `challenge_completed` mission trigger.
-        $this->missionService->recordSafely($result->challenger, MissionTrigger::ChallengeCompleted);
+        // challenges") for both — they both completed a challenge.
+        foreach ([$result->challenger, $result->verifier] as $participant) {
+            if ($participant !== null) {
+                $this->missionService->recordSafely(
+                    $participant,
+                    MissionTrigger::ChallengeCompleted
+                );
+            }
+        }
 
         return $result;
     }

--- a/app/Services/CommunityPointsService.php
+++ b/app/Services/CommunityPointsService.php
@@ -147,18 +147,8 @@ class CommunityPointsService
         }
 
         $community = Community::query()->find($event->community_id);
-        $profileId = $completion->challenger_profile_id;
 
-        if ($community === null || ! $this->isActiveMember($community, $profileId)) {
-            return;
-        }
-
-        $already = CommunityPointLedger::query()
-            ->where('source', CommunityPointSource::ChallengeVerified->value)
-            ->where('reference_id', $completion->id)
-            ->exists();
-
-        if ($already) {
+        if ($community === null) {
             return;
         }
 
@@ -168,17 +158,44 @@ class CommunityPointsService
             $points = PointEventType::CommunityChallengeVerified->defaultPoints();
         }
 
-        $this->award(
-            $community,
-            $profileId,
-            $points,
-            CommunityPointSource::ChallengeVerified,
-            PointEventType::CommunityChallengeVerified,
-            $completion->id,
-            'Challenge verified',
-        );
+        // Both participants earn (kolabing-app#140) — a challenge is something
+        // the two of them did. Each is gated on their own membership, so a
+        // follower playing alongside a member does not get community points.
+        $participants = array_unique(array_filter([
+            $completion->challenger_profile_id,
+            $completion->verifier_profile_id,
+        ]));
 
-        $this->completeGoals($community, $profileId);
+        foreach ($participants as $profileId) {
+            if (! $this->isActiveMember($community, $profileId)) {
+                continue;
+            }
+
+            // Dedupe PER PROFILE: one completion now legitimately produces two
+            // ledger rows, so the reference id alone can no longer identify a
+            // duplicate.
+            $already = CommunityPointLedger::query()
+                ->where('source', CommunityPointSource::ChallengeVerified->value)
+                ->where('reference_id', $completion->id)
+                ->where('profile_id', $profileId)
+                ->exists();
+
+            if ($already) {
+                continue;
+            }
+
+            $this->award(
+                $community,
+                $profileId,
+                $points,
+                CommunityPointSource::ChallengeVerified,
+                PointEventType::CommunityChallengeVerified,
+                $completion->id,
+                'Challenge verified',
+            );
+
+            $this->completeGoals($community, $profileId);
+        }
     }
 
     /**

--- a/tests/Feature/Api/V1/ChallengeCompletionTest.php
+++ b/tests/Feature/Api/V1/ChallengeCompletionTest.php
@@ -357,6 +357,103 @@ class ChallengeCompletionTest extends TestCase
             ->assertJsonPath('success', false);
     }
 
+    /**
+     * The point of kolabing-app#140: a challenge is something two people did,
+     * so it pays both of them.
+     *
+     * Before this, only the challenger was credited — which made confirming
+     * unpaid labour and gave the other person no reason to take part beyond
+     * politeness.
+     */
+    public function test_both_participants_earn_points(): void
+    {
+        $setup = $this->setupCheckedInPair();
+        $points = $setup['challenge']->points;
+
+        $this->assertEquals(0, $setup['challenger']->attendeeProfile->total_points);
+        $this->assertEquals(0, $setup['verifier']->attendeeProfile->total_points);
+
+        $completion = ChallengeCompletion::factory()->create([
+            'challenge_id' => $setup['challenge']->id,
+            'event_id' => $setup['event']->id,
+            'challenger_profile_id' => $setup['challenger']->id,
+            'verifier_profile_id' => $setup['verifier']->id,
+            'status' => ChallengeCompletionStatus::Pending,
+            'points_earned' => 0,
+        ]);
+
+        $response = $this->actingAs($setup['verifier'])
+            ->postJson("/api/v1/challenge-completions/{$completion->id}/verify");
+
+        $response->assertStatus(200);
+
+        // `points_earned` is what EACH side earned, not a total to split.
+        $this->assertSame($points, $response->json('data.points_earned'));
+
+        $this->assertEquals(
+            $points,
+            $setup['challenger']->attendeeProfile->fresh()->total_points,
+            'the challenger earns'
+        );
+        $this->assertEquals(
+            $points,
+            $setup['verifier']->attendeeProfile->fresh()->total_points,
+            'and so does the person who did it with them'
+        );
+    }
+
+    public function test_both_participants_completed_count_moves(): void
+    {
+        $setup = $this->setupCheckedInPair();
+
+        $completion = ChallengeCompletion::factory()->create([
+            'challenge_id' => $setup['challenge']->id,
+            'event_id' => $setup['event']->id,
+            'challenger_profile_id' => $setup['challenger']->id,
+            'verifier_profile_id' => $setup['verifier']->id,
+            'status' => ChallengeCompletionStatus::Pending,
+            'points_earned' => 0,
+        ]);
+
+        $this->actingAs($setup['verifier'])
+            ->postJson("/api/v1/challenge-completions/{$completion->id}/verify")
+            ->assertStatus(200);
+
+        $this->assertEquals(
+            1,
+            $setup['challenger']->attendeeProfile->fresh()->total_challenges_completed
+        );
+        $this->assertEquals(
+            1,
+            $setup['verifier']->attendeeProfile->fresh()->total_challenges_completed
+        );
+    }
+
+    /**
+     * Paying both must not become a way to pay twice: a rejected challenge
+     * pays nobody, and a second verify is already blocked.
+     */
+    public function test_a_rejected_challenge_pays_nobody(): void
+    {
+        $setup = $this->setupCheckedInPair();
+
+        $completion = ChallengeCompletion::factory()->create([
+            'challenge_id' => $setup['challenge']->id,
+            'event_id' => $setup['event']->id,
+            'challenger_profile_id' => $setup['challenger']->id,
+            'verifier_profile_id' => $setup['verifier']->id,
+            'status' => ChallengeCompletionStatus::Pending,
+            'points_earned' => 0,
+        ]);
+
+        $this->actingAs($setup['verifier'])
+            ->postJson("/api/v1/challenge-completions/{$completion->id}/reject")
+            ->assertStatus(200);
+
+        $this->assertEquals(0, $setup['challenger']->attendeeProfile->fresh()->total_points);
+        $this->assertEquals(0, $setup['verifier']->attendeeProfile->fresh()->total_points);
+    }
+
     public function test_points_added_to_attendee_profile(): void
     {
         $setup = $this->setupCheckedInPair();

--- a/tests/Feature/Gamification/MissionTriggerWiringTest.php
+++ b/tests/Feature/Gamification/MissionTriggerWiringTest.php
@@ -427,7 +427,7 @@ class MissionTriggerWiringTest extends TestCase
 
     // --- Peer challenge verification → challenge_completed (attendee) ---
 
-    public function test_verifying_peer_challenge_progresses_challenge_completed_mission_for_challenger(): void
+    public function test_verifying_peer_challenge_progresses_challenge_completed_mission_for_both(): void
     {
         $mission = $this->mission(MissionTrigger::ChallengeCompleted, ChallengeAudience::Attendee, 1, 20);
 
@@ -457,13 +457,14 @@ class MissionTriggerWiringTest extends TestCase
 
         $service->verify($verifier, $completion);
 
-        // The challenger (earner) progresses the challenge_completed mission.
+        // BOTH participants progress the mission (kolabing-app#140). A
+        // challenge is something the two of them did together, so since the
+        // change that pays both sides, both of them completed one.
+        //
+        // This assertion used to read "the verifier does not earn the
+        // challenger's mission". The rule changed deliberately; the test was
+        // not wrong before.
         $this->assertCompletedOnce($mission, $challenger, 20);
-
-        // The verifier does not earn the challenger's mission.
-        $this->assertDatabaseMissing('challenge_progress', [
-            'challenge_id' => $mission->id,
-            'profile_id' => $verifier->id,
-        ]);
+        $this->assertCompletedOnce($mission, $verifier, 20);
     }
 }


### PR DESCRIPTION
## Summary

A peer challenge now pays **both** people who did it. Until now `verify()` credited only the challenger; the other person did the confirming and earned nothing.

## Linked tracking item

Delivers the backend half of kolabing/kolabing-app#140. Reasoning: `kolabing-app/docs/reviews/2026-08-23-challenge-flow-social-review.md` §2.1 and §4.1.

## Type of change

- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [x] ⚠️ Breaking change *(a behavioural one — see below)*

## Changes

- `ChallengeCompletionService::verify` credits **both** participants: `total_points` and `total_challenges_completed` for each, badge milestones checked for each, and the `challenge_completed` mission progressed for each.
- `CommunityPointsService::awardChallengeVerified` awards both, each gated on **their own** membership — so a follower playing alongside a member does not get community points.
- The community-points duplicate guard now keys on **(source, reference_id, profile)** rather than `reference_id` alone. One completion legitimately produces two ledger rows now, so the reference id can no longer identify a duplicate by itself. *This is the change most worth a second pair of eyes.*

`points_earned` on the completion is now **what each side earned**, not a total to split. The app renders "15 XP each" from it.

### Why

The loop exists to make people socialise, and it was paying one person and taxing the other. Confirming was unpaid labour: the second time you asked someone to verify you, you were asking a favour, and the equilibrium of that is people avoiding the verifier role.

Reference patterns: Duolingo Friend Quests (the pair is the unit, both earn), Pokémon GO (co-presence pays both sides).

## Mobile impact (kolabing-app)

- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details:** no contract change — same endpoints, same response shape. What changed is the *meaning* of `points_earned` (per participant rather than the challenger's total) and the fact that the verifier's own totals now move.

The app work for #140 is the other two decisions from the same review: collapsing three scans to one, and a shared screen on both devices once the challenge is agreed. Tracked in kolabing/kolabing-app#140. It does not depend on this deploying first — an app that still shows the old copy simply understates what the partner got.

## Database / migrations

- [x] No schema changes
- [ ] Includes migrations
- [ ] Includes data backfill / destructive change

**Migration notes:** N/A. Existing `community_point_ledger` rows are untouched; the widened dedupe key only affects rows written from now on. Completions already verified are not retro-credited — the partner in a past challenge stays uncredited, which is the honest reading of "this is how it works from here".

## Testing

- [x] `php artisan test` passes — **2370 passed, 12379 assertions**
- [x] `vendor/bin/pint` clean
- [ ] Manually verified the happy path — not against a live database; the suite covers it and the only DB reachable from this machine is production

New tests: both participants earn; both completed-counts move; a **rejected** challenge pays nobody. The existing rules are still asserted by the tests that were already there — both must be checked in, a pair cannot repeat the same challenge, the per-event cap holds, a second verify is blocked.

### One existing assertion changed

`MissionTriggerWiringTest` asserted that the verifier does **not** progress the `challenge_completed` mission. That encoded the old one-sided rule. It now asserts both progress it, and the test is renamed accordingly. Flagging it explicitly: the rule changed deliberately — the test was not wrong before, and this is the sort of edit that should never pass unremarked.

## Docs & rules updated

- [ ] `BACKLOG.md` updated
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [ ] `docs/BACKEND-SCHEMA.md`
- [x] No docs impact

No schema, no endpoint, no role change. The product reasoning lives in the review doc in `kolabing-app`.

## Screenshots / notes

Deploy order does not matter for this one. It is worth deciding whether the partner should earn the **same** points or a share — same is what shipped, because it is the easiest thing to explain and to draw ("15 XP each"), and the per-event cap already bounds the economy. Changing it later is a one-line change.
