### PR TITLE
feat(events): discover the events of communities you follow — and stop leaking their member-only ones

### DIFF
--- a/app/Http/Controllers/Api/V1/EventDiscoveryController.php
+++ b/app/Http/Controllers/Api/V1/EventDiscoveryController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\DiscoverEventsRequest;
 use App\Http\Resources\Api\V1\EventResource;
+use App\Models\Profile;
 use App\Services\EventDiscoveryService;
 use App\Services\EventSignupService;
 use Illuminate\Http\JsonResponse;
@@ -27,15 +28,25 @@ class EventDiscoveryController extends Controller
         $radius = (float) ($request->validated('radius_km') ?? 50);
         $perPage = (int) ($request->validated('limit') ?? 10);
 
-        /** @var array{city_id?: string, date?: string, type?: string} $filters */
+        // `following` is scoped to the VIEWER, so the profile id comes from the
+        // token and never from the query string — a caller cannot ask for
+        // someone else's follows (kolabing-app#142). A falsy `following` is
+        // stripped in the request, so its presence here means true.
+        /** @var Profile|null $viewer */
+        $viewer = $request->user();
+        $following = $request->boolean('following');
+
+        /** @var array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string} $filters */
         $filters = [
             'city_id' => $request->validated('city_id'),
             'date' => $request->validated('date'),
             'type' => $request->validated('type'),
+            'following' => $following,
+            'viewer_profile_id' => $following ? $viewer?->id : null,
         ];
 
         $paginator = $this->discoveryService->discover($lat, $lng, $radius, $perPage, $filters);
-        $this->eventSignupService->hydrateSummaries($paginator->items(), $request->user());
+        $this->eventSignupService->hydrateSummaries($paginator->items(), $viewer);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Requests/Api/V1/DiscoverEventsRequest.php
+++ b/app/Http/Requests/Api/V1/DiscoverEventsRequest.php
@@ -16,8 +16,38 @@ class DiscoverEventsRequest extends FormRequest
     }
 
     /**
-     * Geo params (lat/lng) are only required when no city_id is supplied — the
-     * endpoint supports both a city-scoped query and the legacy radius query.
+     * Drop a falsy `following` before validation.
+     *
+     * `following` relaxes the lat/lng requirement (see rules()), and
+     * `required_without_all` tests PRESENCE, not truthiness — so leaving a
+     * `following=0` in the input would let a caller skip both the city and the
+     * coordinates and get every public event on the platform, which no caller
+     * is asking for and no caller could get before. Removing the key makes
+     * `following=0` behave exactly like omitting it.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('following')) {
+            return;
+        }
+
+        $following = filter_var($this->input('following'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($following !== true) {
+            // Both bags on purpose. This arrives as a query string, and
+            // `Request::input()` unions the input source with the query bag —
+            // `replace()` alone writes to the request bag and leaves the query
+            // untouched, so on a GET the key survives and the rule still sees
+            // it.
+            $this->query->remove('following');
+            $this->request->remove('following');
+        }
+    }
+
+    /**
+     * Geo params (lat/lng) are only required when the caller gives us no other
+     * way to scope the query — a city_id, or `following` (the communities the
+     * viewer follows). The endpoint supports all three.
      *
      * @return array<string, array<int, mixed>>
      */
@@ -25,9 +55,10 @@ class DiscoverEventsRequest extends FormRequest
     {
         return [
             // lat/lng remain required for the geo path, but become optional when a
-            // city_id is given so the city filter can drive discovery on its own.
-            'lat' => ['required_without:city_id', 'numeric', 'between:-90,90'],
-            'lng' => ['required_without:city_id', 'numeric', 'between:-180,180'],
+            // city_id or `following` is given so either can drive discovery on
+            // its own.
+            'lat' => ['required_without_all:city_id,following', 'numeric', 'between:-90,90'],
+            'lng' => ['required_without_all:city_id,following', 'numeric', 'between:-180,180'],
             'radius_km' => ['sometimes', 'numeric', 'min:1', 'max:200'],
             'limit' => ['sometimes', 'integer', 'min:1', 'max:50'],
             // Filter to events whose host community sits in this city.
@@ -39,6 +70,10 @@ class DiscoverEventsRequest extends FormRequest
             // (community_types table, falling back to the COMMUNITY_TYPES constant);
             // NEVER the 5-value App\Enums\CommunityType placeholder.
             'type' => ['sometimes', 'string', Rule::in(CommunityTypeVocabulary::slugs())],
+            // Only events hosted by a community the VIEWER follows
+            // (kolabing-app#142). Needs no city: following is an explicit
+            // relationship, and a city is only ever a guess at relevance.
+            'following' => ['sometimes', 'boolean'],
         ];
     }
 
@@ -48,9 +83,9 @@ class DiscoverEventsRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'lat.required_without' => 'Latitude is required unless a city_id is provided.',
+            'lat.required_without_all' => 'Latitude is required unless a city_id or following is provided.',
             'lat.between' => 'Latitude must be between -90 and 90.',
-            'lng.required_without' => 'Longitude is required unless a city_id is provided.',
+            'lng.required_without_all' => 'Longitude is required unless a city_id or following is provided.',
             'lng.between' => 'Longitude must be between -180 and 180.',
             'radius_km.min' => 'Radius must be at least 1 km.',
             'radius_km.max' => 'Radius cannot exceed 200 km.',
@@ -59,6 +94,7 @@ class DiscoverEventsRequest extends FormRequest
             'city_id.exists' => 'The selected city does not exist.',
             'date.in' => 'The date filter must be one of: today, week, weekend, month, upcoming.',
             'type.in' => 'The community type is not valid.',
+            'following.boolean' => 'The following filter must be true or false.',
         ];
     }
 }

--- a/app/Services/EventDiscoveryService.php
+++ b/app/Services/EventDiscoveryService.php
@@ -39,12 +39,13 @@ class EventDiscoveryService
 
     /**
      * Discover active events, optionally near a lat/lng and optionally filtered by
-     * the host community's city / type, and by date (today | upcoming).
+     * the host community's city / type, by date (today | upcoming), and by
+     * whether the viewer follows the host community.
      *
      * Geo filtering is applied only when both $lat and $lng are provided; a
      * city_id alone (no coordinates) drives a non-geo, city-scoped query.
      *
-     * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
      * @return LengthAwarePaginator<Event>
      */
     public function discover(
@@ -83,7 +84,7 @@ class EventDiscoveryService
      * only ever applied within one page, and `total` counted bounding-box corners
      * that were never returned.
      *
-     * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
      * @return LengthAwarePaginator<Event>
      */
     public function discoverNearby(
@@ -115,7 +116,7 @@ class EventDiscoveryService
     /**
      * Non-geo discovery: city / date / type filters only, ordered by start.
      *
-     * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
      * @return LengthAwarePaginator<Event>
      */
     private function discoverFiltered(int $perPage, array $filters): LengthAwarePaginator
@@ -140,7 +141,7 @@ class EventDiscoveryService
      * artefact of the old geo "active now" path; the public/city upcoming surface
      * is governed entirely by visibility + date, so dropping it here is safe.
      *
-     * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
      * @return Builder<Event>
      */
     private function baseQuery(array $filters): Builder
@@ -170,9 +171,12 @@ class EventDiscoveryService
      * - date     → restricts on the effective start date COALESCE(starts_at,
      *   event_date) — the same column the resource exposes. See applyDateFilter
      *   for the exact range boundaries.
+     * - following → only events whose host community the VIEWER follows. See
+     *   applyFollowingFilter; it composes with the filters above rather than
+     *   replacing them.
      *
      * @param  Builder<Event>  $query
-     * @param  array{city_id?: ?string, date?: ?string, type?: ?string}  $filters
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
      */
     private function applyFilters(Builder $query, array $filters): void
     {
@@ -202,6 +206,50 @@ class EventDiscoveryService
         }
 
         $this->applyDateFilter($query, $filters['date'] ?? null);
+        $this->applyFollowingFilter($query, $filters);
+    }
+
+    /**
+     * Restrict to events hosted by a community the viewer FOLLOWS
+     * (kolabing-app#142).
+     *
+     * This is the payoff for following: the follow was recorded and then used
+     * nowhere, so the tap had no consequence. Following needs no city — it is
+     * an explicit relationship, where a city is only ever a guess at relevance
+     * — which is why the request makes lat/lng optional once it is set.
+     *
+     * A follower is NOT a member, and this changes nothing about that. The
+     * visibility gate stays where baseQuery() puts it: `visibility = public`.
+     * A followed community's member- or tier-only event stays invisible here,
+     * exactly as it is for a stranger. See kolabing-app#138 for why the two
+     * relationships are separate tables in the first place.
+     *
+     * With `following` asked for but no viewer to resolve it against, this
+     * matches NOTHING rather than falling through. Falling through would turn
+     * "the communities I follow" into "every public event on the platform" —
+     * the failure that looks like success, and the one worth being explicit
+     * about.
+     *
+     * @param  Builder<Event>  $query
+     * @param  array{city_id?: ?string, date?: ?string, type?: ?string, following?: ?bool, viewer_profile_id?: ?string}  $filters
+     */
+    private function applyFollowingFilter(Builder $query, array $filters): void
+    {
+        if (($filters['following'] ?? false) !== true) {
+            return;
+        }
+
+        $viewerProfileId = $filters['viewer_profile_id'] ?? null;
+
+        if (! is_string($viewerProfileId) || $viewerProfileId === '') {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->whereHas('community.followers', function (Builder $sub) use ($viewerProfileId): void {
+            $sub->where('profile_id', $viewerProfileId);
+        });
     }
 
     /**

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -82,7 +82,20 @@ class EventService
             $query->whereHas(
                 'community.followers',
                 fn ($f) => $f->where('profile_id', $followerId)
-            );
+            )
+                // A follower is NOT a member (kolabing-app#138). Without this,
+                // following a community — one tap, no approval, nobody asked —
+                // returned its member- and tier-only events too, ids included,
+                // which is the exact privilege the split exists to withhold.
+                // The gate lives on this branch alone: `profile_id` (a leader
+                // listing their OWN events) and `attendee_profile_id` (events
+                // they were admitted to) must keep seeing everything.
+                //
+                // Someone who is both a member and a follower sees a little
+                // less here than they are entitled to; their member events are
+                // on the community's own surfaces. Under-showing to a member
+                // beats over-showing to a follower.
+                ->where('visibility', EventVisibility::Public->value);
         }
 
         $time = $filters['time'] ?? null;

--- a/tests/Feature/Api/V1/CommunityFollowTest.php
+++ b/tests/Feature/Api/V1/CommunityFollowTest.php
@@ -234,6 +234,56 @@ class CommunityFollowTest extends TestCase
             ->assertJsonCount(1, 'data.events');
     }
 
+    /**
+     * The one that was wrong. `following=me` scoped by follow and nothing else,
+     * so following a community — one tap, no approval, nobody asked — handed
+     * over its member-only events, ids included. That is the precise privilege
+     * the follower/member split exists to withhold (kolabing-app#138), and this
+     * listing is worse than the signup gap in BACKLOG IF-28, because it is what
+     * hands out the ids in the first place.
+     */
+    public function test_the_feed_does_not_include_a_followed_communitys_member_only_events(): void
+    {
+        $followed = $this->community();
+        $person = $this->person();
+
+        $this->eventFor($followed, 'Open to all');
+        $this->eventFor($followed, 'Members only')->update(['visibility' => 'members']);
+
+        $this->actingAs($person)
+            ->postJson("/api/v1/communities/{$followed->id}/follow")
+            ->assertSuccessful();
+
+        $names = collect(
+            $this->actingAs($person)
+                ->getJson('/api/v1/events?following=me&time=upcoming')
+                ->json('data.events')
+        )->pluck('name')->all();
+
+        $this->assertContains('Open to all', $names);
+        $this->assertNotContains('Members only', $names, 'a follower is not a member');
+    }
+
+    /**
+     * The gate belongs to the follows branch alone: a leader listing their OWN
+     * events must still see the member-only ones.
+     */
+    public function test_the_public_only_gate_does_not_narrow_a_leaders_own_listing(): void
+    {
+        $community = $this->community();
+        $this->eventFor($community, 'Members only')->update(['visibility' => 'members']);
+
+        $owner = Profile::query()->findOrFail($community->owner_profile_id);
+
+        $names = collect(
+            $this->actingAs($owner)
+                ->getJson('/api/v1/events?time=upcoming')
+                ->json('data.events')
+        )->pluck('name')->all();
+
+        $this->assertContains('Members only', $names);
+    }
+
     public function test_unfollowing_takes_the_events_back_out_of_the_feed(): void
     {
         $followed = $this->community();

--- a/tests/Feature/Api/V1/EventDiscoveryFollowingTest.php
+++ b/tests/Feature/Api/V1/EventDiscoveryFollowingTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\EventVisibility;
+use App\Models\City;
+use App\Models\Community;
+use App\Models\CommunityFollower;
+use App\Models\CommunityProfile;
+use App\Models\Event;
+use App\Models\Profile;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * `GET /events/discover?following=1` — the events of communities the VIEWER
+ * follows (kolabing-app#142).
+ *
+ * This is what makes following mean something: before it, a follow was recorded
+ * and then read by nothing, so the tap had no consequence anywhere in the app.
+ *
+ * The two properties worth guarding are here as tests, not comments: a follower
+ * still does not see member-only events (following is not membership —
+ * kolabing-app#138), and asking for "my follows" with nothing to resolve the
+ * viewer against returns NOTHING rather than everything.
+ */
+class EventDiscoveryFollowingTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * A community that hosts events, in $city.
+     */
+    private function createCommunity(City $city, string $name = 'Real Run Club', string $type = 'run_club'): Community
+    {
+        $communityProfile = CommunityProfile::factory()->create([
+            'city_id' => $city->id,
+            'community_type' => $type,
+        ]);
+
+        return Community::factory()->create([
+            'name' => $name,
+            'type' => $type,
+            'community_profile_id' => $communityProfile->id,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createEvent(Community $community, array $attributes = []): Event
+    {
+        $owner = Profile::factory()->business()->create();
+
+        return Event::factory()->forProfile($owner)->create(array_merge([
+            'community_id' => $community->id,
+            'location_lat' => 41.3900,
+            'location_lng' => 2.1700,
+            'is_active' => true,
+            'visibility' => EventVisibility::Public->value,
+            'event_date' => now()->addDays(10)->toDateString(),
+            'starts_at' => now()->addDays(10),
+            'ends_at' => now()->addDays(10)->addHours(2),
+        ], $attributes));
+    }
+
+    private function follow(Profile $profile, Community $community): void
+    {
+        CommunityFollower::query()->create([
+            'community_id' => $community->id,
+            'profile_id' => $profile->id,
+            'followed_at' => Carbon::now(),
+        ]);
+    }
+
+    public function test_following_returns_only_events_of_followed_communities(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        $followed = $this->createCommunity($city, 'Followed Club');
+        $stranger = $this->createCommunity($city, 'Some Other Club');
+
+        $this->follow($attendee, $followed);
+
+        $mine = $this->createEvent($followed);
+        $this->createEvent($stranger);
+
+        $response = $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $mine->id);
+    }
+
+    /**
+     * The point of making lat/lng optional: a community you followed is
+     * relevant wherever it is, and a city is only ever a guess at relevance.
+     */
+    public function test_following_needs_no_city_or_coordinates(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $madrid = City::factory()->create(['name' => 'Madrid']);
+
+        $followed = $this->createCommunity($madrid, 'Madrid Run Club');
+        $this->follow($attendee, $followed);
+        $event = $this->createEvent($followed);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $event->id);
+    }
+
+    public function test_following_composes_with_the_date_filter(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        $followed = $this->createCommunity($city);
+        $this->follow($attendee, $followed);
+
+        $today = $this->createEvent($followed, [
+            'event_date' => now()->toDateString(),
+            'starts_at' => now()->setTime(18, 0),
+            'ends_at' => now()->setTime(20, 0),
+        ]);
+        // Also the followed community's, but not today.
+        $this->createEvent($followed);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1&date=today')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $today->id);
+    }
+
+    /**
+     * The security-critical one. Following is not membership: a member-only
+     * event of a community you follow is exactly as invisible as it is to a
+     * stranger (kolabing-app#138).
+     */
+    public function test_a_followed_communitys_member_only_event_stays_hidden(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        $followed = $this->createCommunity($city);
+        $this->follow($attendee, $followed);
+
+        $public = $this->createEvent($followed);
+        $this->createEvent($followed, ['visibility' => EventVisibility::Members->value]);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $public->id);
+    }
+
+    public function test_following_nothing_returns_an_empty_page_not_every_event(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        // Two events exist; the attendee follows neither host.
+        $this->createEvent($this->createCommunity($city, 'A'));
+        $this->createEvent($this->createCommunity($city, 'B'));
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events')
+            ->assertJsonPath('data.pagination.total_count', 0);
+    }
+
+    /**
+     * `following` reads the token, never the query string — so it cannot be
+     * pointed at someone else's follows.
+     */
+    public function test_one_attendees_follows_do_not_leak_into_anothers_feed(): void
+    {
+        $mine = Profile::factory()->attendee()->create();
+        $theirs = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        $theirCommunity = $this->createCommunity($city, 'Their Club');
+        $this->follow($theirs, $theirCommunity);
+        $this->createEvent($theirCommunity);
+
+        $this->actingAs($mine)
+            ->getJson('/api/v1/events/discover?following=1')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data.events');
+    }
+
+    /**
+     * `following` relaxes the lat/lng requirement, and `required_without_all`
+     * tests presence rather than truthiness — so a falsy `following` is
+     * stripped before validation. Without that, `following=0` would be a way to
+     * ask for every public event on the platform with no scope at all.
+     */
+    public function test_a_falsy_following_still_requires_a_city_or_coordinates(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=0')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['lat', 'lng']);
+    }
+
+    /**
+     * An event with no host community cannot be followed, and must not sneak
+     * into the followed feed.
+     */
+    public function test_an_event_without_a_host_community_is_not_in_the_following_feed(): void
+    {
+        $attendee = Profile::factory()->attendee()->create();
+        $city = City::factory()->create();
+
+        $followed = $this->createCommunity($city);
+        $this->follow($attendee, $followed);
+        $mine = $this->createEvent($followed);
+
+        $owner = Profile::factory()->business()->create();
+        Event::factory()->forProfile($owner)->create([
+            'community_id' => null,
+            'is_active' => true,
+            'visibility' => EventVisibility::Public->value,
+            'event_date' => now()->addDays(4)->toDateString(),
+            'starts_at' => now()->addDays(4),
+            'ends_at' => now()->addDays(4)->addHours(2),
+        ]);
+
+        $this->actingAs($attendee)
+            ->getJson('/api/v1/events/discover?following=1')
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'data.events')
+            ->assertJsonPath('data.events.0.id', $mine->id);
+    }
+}


### PR DESCRIPTION
## Summary

`GET /events/discover?following=1` returns only events whose host community the **viewer** follows, so following a community finally shows up somewhere (kolabing-app#142). Building it turned up a privilege leak in `GET /events?following=me` — merged in #211 — which handed a follower the member-only events of any community they followed; that is fixed here too.

## Linked tracking item
Closes kolabing/kolabing-app#142

## Type of change
- [x] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes

- `DiscoverEventsRequest`: accepts `following` (boolean); `lat`/`lng` become `required_without_all:city_id,following` so the follows feed needs no city. A **falsy `following` is stripped in `prepareForValidation`** — `required_without_all` tests presence, not truthiness, so `?following=0` would otherwise have been a way to skip both the city and the coordinates and list every public event on the platform, which no caller could do before. Both parameter bags are cleared, because this arrives as a query string and `Request::input()` unions the input source with the query bag.
- `EventDiscoveryService::applyFollowingFilter`: `whereHas('community.followers', profile_id = viewer)`, composing with `city_id` / `date` / `type`. Asked for with **no viewer to resolve it against it matches nothing**, never everything — the failure that would look like success.
- `EventDiscoveryController`: the profile id comes from the token, never the query string, so `following` cannot be pointed at someone else's follows.
- **`EventService::list`** — the leak. The `follower_profile_id` branch is now gated to `visibility = public`. On that branch alone: `profile_id` (a leader listing their own events) and `attendee_profile_id` (events they were admitted to) must keep seeing everything.

### The leak, in full

`GET /events?following=me` scoped by follow and nothing else. Following a community is one tap, no approval, and the leader is not asked — and it was returning that community's **member- and tier-only events, ids included**. That is precisely the privilege the follower/member split exists to withhold (kolabing-app#138), and it is worse than the signup gap logged in BACKLOG IF-28, because a listing is what hands out the ids that gap needs.

Never reachable from the app (nothing has ever called `following=me`), but reachable with any valid token since #211 merged.

Tradeoff worth a reviewer's eye: someone who is both a member **and** a follower now sees slightly less in the follows feed than they are entitled to — their member events are on the community's own surfaces. Under-showing to a member beats over-showing to a follower.

### Why add this to discover when `/events?following=me` exists

`/events` is the listing primitive (my events, a community's, an attendee's, a follower's). `/events/discover` is the feed, and it is the better home for this one:

- it already eager-loads `community.communityProfile.city`, which is what `community_name` / `community_type` / the effective city need — `/events` loads `photos` only, so those come back **null** there and a Following card would have no host community on it;
- its public-visibility gate is structural (`baseQuery`), not a bolted-on where clause;
- it already has the date ranges the app's feed chips use.

The listing stays, now gated.

## Mobile impact (kolabing-app)
- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** kolabing/kolabing-app#143 adds the All / Following toggle to the attendee feed and sends `following=1`. **Additive only** — no existing response key changes, no param renamed. Deploy this first: against an undeployed API, `following=1` with no city is a 422 (the old rules require `lat` without `city_id`), which the app surfaces as its feed error state.

## Database / migrations
- [x] No schema changes

**Migration notes:** N/A — `community_followers` shipped in #211.

## Testing
- [x] `php artisan test` passes — **2377 passed** (12394 assertions), 0 failures
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — via the tests below; not hand-curled

`tests/Feature/Api/V1/EventDiscoveryFollowingTest.php` (8 new):

| Test | What it pins down |
| --- | --- |
| returns only events of followed communities | the basic contract |
| needs no city or coordinates | why `lat`/`lng` were relaxed |
| composes with the date filter | `following` + `date=today` |
| a followed community's member-only event stays hidden | a follower is not a member |
| following nothing returns an empty page, not every event | the no-viewer / no-follows fallback |
| one attendee's follows do not leak into another's feed | viewer scoping |
| a falsy `following` still requires a city or coordinates | the `prepareForValidation` strip |
| an event without a host community is not in the feed | nothing to follow |

`CommunityFollowTest` (2 new): the member-only leak, and that the gate does not narrow a leader's own listing. **The leak test fails against the pre-fix code** — verified by stashing the `EventService` change and re-running it.

## Docs & rules updated
- [ ] `BACKLOG.md` updated
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [ ] `docs/BACKEND-SCHEMA.md`
- [x] No docs impact

**Flagging rather than pretending:** no schema or role-rule change, so those two are genuinely N/A. `BACKLOG.md` is **not** updated — IF-28's note that "a follower can still reach member events" is now half-fixed (the listing is closed; the signup hole is still open) and that entry deserves rewording once the pair of PRs lands.

## Screenshots / notes

```
GET /api/v1/events/discover?following=1&date=today
Authorization: Bearer <attendee token>

{ "success": true, "data": { "events": [ … ], "pagination": { … } } }
```

Same response shape as every other discover call — the app needed no new parser.
