### PR TITLE
feat(gamification): two challenge engines, and somewhere to keep the photo

### DIFF
--- a/app/Enums/ChallengeProofType.php
+++ b/app/Enums/ChallengeProofType.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * How a challenge is played (kolabing-v2#216).
+ *
+ * This is an **engine selector, not a gate**. It tells the app which surface to
+ * open once a pair agrees on a challenge; it does not make the server refuse a
+ * verification that arrives with no photo attached.
+ *
+ * Deliberate. A hard requirement means a pair who cannot get a photo up — no
+ * signal in a basement gym, a denied camera permission, a failed upload — cannot
+ * earn what they just did together. The person confirming is already the check
+ * on honesty, and that is the check the whole loop is built on. The photo is a
+ * memento and a nudge; the moment it is mandatory it becomes a way to lose
+ * points to a bad connection.
+ */
+enum ChallengeProofType: string
+{
+    /**
+     * The instruction is the game. A photo may be attached at the end, and
+     * usually is not. The default, and what every challenge that predates this
+     * column reports.
+     */
+    case Text = 'text';
+
+    /**
+     * Open the camera as soon as the pair agrees. "Take a selfie together"
+     * should not present itself as a reading exercise.
+     */
+    case Photo = 'photo';
+
+    /**
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/FileUploadType.php
+++ b/app/Enums/FileUploadType.php
@@ -17,6 +17,14 @@ enum FileUploadType: string
     case EventPhoto = 'event_photo';
 
     /**
+     * The photo two attendees took while completing a challenge together
+     * (kolabing-v2#216). Images only — a proof photo is a photo, and allowing
+     * video here would put 50 MB uploads behind a button people press at events
+     * on venue wifi.
+     */
+    case ChallengeProof = 'challenge_proof';
+
+    /**
      * Get the storage directory for this upload type.
      *
      * @return string The directory path within the public disk
@@ -29,6 +37,7 @@ enum FileUploadType: string
             self::OpportunityPhoto => 'opportunities',
             self::GalleryPhoto => 'gallery',
             self::EventPhoto => 'events',
+            self::ChallengeProof => 'challenge-proofs',
         };
     }
 
@@ -45,6 +54,7 @@ enum FileUploadType: string
             self::OpportunityPhoto => 5 * 1024 * 1024, // 5MB
             self::GalleryPhoto => 5 * 1024 * 1024, // 5MB
             self::EventPhoto => 5 * 1024 * 1024, // 5MB
+            self::ChallengeProof => 5 * 1024 * 1024, // 5MB
         };
     }
 
@@ -56,7 +66,7 @@ enum FileUploadType: string
     public function getAllowedMimeTypes(): array
     {
         return match ($this) {
-            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto => [
+            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
                 'image/jpeg',
                 'image/jpg',
                 'image/png',
@@ -84,7 +94,7 @@ enum FileUploadType: string
     public function getAllowedExtensions(): array
     {
         return match ($this) {
-            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto => [
+            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
                 'jpeg',
                 'jpg',
                 'png',

--- a/app/Http/Controllers/Api/V1/ChallengeCompletionController.php
+++ b/app/Http/Controllers/Api/V1/ChallengeCompletionController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\AttachChallengeProofRequest;
 use App\Http\Requests\Api\V1\InitiateChallengeRequest;
 use App\Http\Resources\Api\V1\ChallengeCompletionResource;
 use App\Models\ChallengeCompletion;
@@ -78,6 +79,76 @@ class ChallengeCompletionController extends Controller
                 'success' => false,
                 'message' => $e->getMessage(),
             ], 409);
+        }
+    }
+
+    /**
+     * Attach or replace the photo the pair took (#216).
+     *
+     * POST /api/v1/challenge-completions/{challengeCompletion}/photo
+     *
+     * multipart/form-data, field `photo`.
+     */
+    public function attachPhoto(
+        AttachChallengeProofRequest $request,
+        ChallengeCompletion $challengeCompletion
+    ): JsonResponse {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        /** @var \Illuminate\Http\UploadedFile $photo */
+        $photo = $request->file('photo');
+
+        try {
+            $completion = $this->challengeCompletionService->attachProofPhoto(
+                $profile,
+                $challengeCompletion,
+                $photo
+            );
+
+            return response()->json([
+                'success' => true,
+                'message' => __('Photo added.'),
+                'data' => new ChallengeCompletionResource($completion),
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => 'not_a_participant',
+                'message' => $e->getMessage(),
+            ], 403);
+        } catch (\LogicException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => 'photo_not_allowed',
+                'message' => $e->getMessage(),
+            ], 409);
+        }
+    }
+
+    /**
+     * Remove the photo.
+     *
+     * DELETE /api/v1/challenge-completions/{challengeCompletion}/photo
+     */
+    public function removePhoto(Request $request, ChallengeCompletion $challengeCompletion): JsonResponse
+    {
+        /** @var Profile $profile */
+        $profile = $request->user();
+
+        try {
+            $completion = $this->challengeCompletionService->removeProofPhoto($profile, $challengeCompletion);
+
+            return response()->json([
+                'success' => true,
+                'data' => new ChallengeCompletionResource($completion),
+            ]);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'error' => 'not_a_participant',
+                'message' => $e->getMessage(),
+            ], 403);
         }
     }
 

--- a/app/Http/Requests/Api/V1/AttachChallengeProofRequest.php
+++ b/app/Http/Requests/Api/V1/AttachChallengeProofRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\FileUploadType;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * The photo two people took while completing a challenge (kolabing-v2#216).
+ *
+ * Authorization is NOT here: whether the caller is one of the two participants
+ * is the service's decision, so the same rule holds for every future caller of
+ * attachProofPhoto() and not just this route.
+ */
+class AttachChallengeProofRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        $type = FileUploadType::ChallengeProof;
+
+        return [
+            'photo' => [
+                'required',
+                'file',
+                'image',
+                'mimetypes:'.implode(',', $type->getAllowedMimeTypes()),
+                // Laravel's `max` is in kilobytes; the enum is the one place the
+                // limit lives, so derive it rather than repeating a number.
+                'max:'.(int) ($type->getMaxFileSize() / 1024),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'photo.required' => 'A photo is required.',
+            'photo.image' => 'That file is not an image.',
+            'photo.mimetypes' => 'Use a JPEG, PNG, GIF or WebP image.',
+            'photo.max' => 'Photos must be 5 MB or smaller.',
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreChallengeRequest.php
+++ b/app/Http/Requests/Api/V1/StoreChallengeRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\V1;
 
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -24,6 +25,7 @@ class StoreChallengeRequest extends FormRequest
             'name' => ['required', 'string', 'min:3', 'max:150'],
             'description' => ['nullable', 'string', 'max:500'],
             'difficulty' => ['required', 'string', Rule::in(ChallengeDifficulty::values())],
+            'proof_type' => ['sometimes', 'string', Rule::in(ChallengeProofType::values())],
             'points' => ['sometimes', 'integer', 'min:1', 'max:100'],
         ];
     }
@@ -39,6 +41,7 @@ class StoreChallengeRequest extends FormRequest
             'name.max' => 'Challenge name cannot exceed 150 characters.',
             'difficulty.required' => 'Difficulty level is required.',
             'difficulty.in' => 'Difficulty must be easy, medium, or hard.',
+            'proof_type.in' => 'How it is played must be text or photo.',
             'points.min' => 'Points must be at least 1.',
             'points.max' => 'Points cannot exceed 100.',
         ];

--- a/app/Http/Requests/Api/V1/UpdateChallengeRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateChallengeRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Api\V1;
 
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -24,6 +25,7 @@ class UpdateChallengeRequest extends FormRequest
             'name' => ['sometimes', 'string', 'min:3', 'max:150'],
             'description' => ['nullable', 'string', 'max:500'],
             'difficulty' => ['sometimes', 'string', Rule::in(ChallengeDifficulty::values())],
+            'proof_type' => ['sometimes', 'string', Rule::in(ChallengeProofType::values())],
             'points' => ['sometimes', 'integer', 'min:1', 'max:100'],
         ];
     }
@@ -37,6 +39,7 @@ class UpdateChallengeRequest extends FormRequest
             'name.min' => 'Challenge name must be at least 3 characters.',
             'name.max' => 'Challenge name cannot exceed 150 characters.',
             'difficulty.in' => 'Difficulty must be easy, medium, or hard.',
+            'proof_type.in' => 'How it is played must be text or photo.',
             'points.min' => 'Points must be at least 1.',
             'points.max' => 'Points cannot exceed 100.',
         ];

--- a/app/Http/Resources/Api/V1/ChallengeCompletionResource.php
+++ b/app/Http/Resources/Api/V1/ChallengeCompletionResource.php
@@ -26,6 +26,8 @@ class ChallengeCompletionResource extends JsonResource
             'verifier_profile_id' => $this->verifier_profile_id,
             'status' => $this->status->value,
             'points_earned' => $this->points_earned,
+            // Already absolute — FileUploadService returns a URL on upload (#216).
+            'proof_photo_url' => $this->proof_photo_url,
             'completed_at' => $this->completed_at?->toIso8601String(),
             'created_at' => $this->created_at?->toIso8601String(),
         ];

--- a/app/Http/Resources/Api/V1/ChallengeResource.php
+++ b/app/Http/Resources/Api/V1/ChallengeResource.php
@@ -23,6 +23,9 @@ class ChallengeResource extends JsonResource
             'name' => $this->name,
             'description' => $this->description,
             'difficulty' => $this->difficulty->value,
+            // How it is played (#216). An engine selector for the client, never
+            // a server-side gate — see ChallengeProofType.
+            'proof_type' => $this->proof_type?->value ?? 'text',
             'points' => $this->points,
             'is_system' => $this->is_system,
             'category' => $this->category?->value,

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Enums\ChallengeAudience;
 use App\Enums\ChallengeCategory;
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Enums\MissionRepeat;
 use App\Enums\MissionTrigger;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -50,6 +51,7 @@ class Challenge extends Model
         'name',
         'description',
         'difficulty',
+        'proof_type',
         'points',
         'is_system',
         'category',
@@ -67,6 +69,7 @@ class Challenge extends Model
     protected function casts(): array
     {
         return [
+            'proof_type' => ChallengeProofType::class,
             'difficulty' => ChallengeDifficulty::class,
             'points' => 'integer',
             'is_system' => 'boolean',

--- a/app/Models/ChallengeCompletion.php
+++ b/app/Models/ChallengeCompletion.php
@@ -41,6 +41,7 @@ class ChallengeCompletion extends Model
         'verifier_profile_id',
         'status',
         'points_earned',
+        'proof_photo_url',
         'completed_at',
     ];
 

--- a/app/Services/ChallengeCompletionService.php
+++ b/app/Services/ChallengeCompletionService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\ChallengeCompletionStatus;
+use App\Enums\FileUploadType;
 use App\Enums\MissionTrigger;
 use App\Models\Challenge;
 use App\Models\ChallengeCompletion;
@@ -12,6 +13,7 @@ use App\Models\Event;
 use App\Models\EventCheckin;
 use App\Models\Profile;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -22,7 +24,106 @@ class ChallengeCompletionService
         private readonly NotificationService $notificationService,
         private readonly CommunityPointsService $communityPointsService,
         private readonly MissionService $missionService,
+        private readonly FileUploadService $fileUploadService,
     ) {}
+
+    /**
+     * Attach (or replace) the photo the pair took (kolabing-v2#216).
+     *
+     * Either participant may do it. Two people are in that picture, and which of
+     * them happened to press the button first is not a permission model.
+     *
+     * Allowed while `pending` and after `verified`, refused once `rejected`:
+     * before, because the camera opens as soon as the pair agrees and the photo
+     * exists before the confirmation does; after, because people remember to
+     * keep it later. Rejected means the thing did not happen, so there is
+     * nothing to illustrate.
+     *
+     * Replacing deletes the old file rather than orphaning it — one completion,
+     * one photo, and the disk should say the same.
+     *
+     * @throws \InvalidArgumentException not a participant
+     * @throws \LogicException the completion was rejected
+     */
+    public function attachProofPhoto(
+        Profile $actor,
+        ChallengeCompletion $completion,
+        UploadedFile $photo
+    ): ChallengeCompletion {
+        $this->assertParticipant($actor, $completion);
+
+        if ($completion->status === ChallengeCompletionStatus::Rejected) {
+            throw new \LogicException('This challenge was not confirmed, so there is nothing to add a photo to.');
+        }
+
+        $previous = $completion->proof_photo_url;
+
+        // Returns an absolute URL; delete() takes either that or a raw path.
+        $url = $this->fileUploadService->uploadFromFile(
+            $photo,
+            FileUploadType::ChallengeProof,
+            $completion->id
+        );
+
+        $completion->update(['proof_photo_url' => $url]);
+
+        if ($previous !== null && $previous !== $url) {
+            // A failed delete must not fail the upload the user just waited for.
+            try {
+                $this->fileUploadService->delete($previous);
+            } catch (\Throwable $e) {
+                Log::warning('Challenge proof photo replace: old file not deleted', [
+                    'completion_id' => $completion->id,
+                    'path' => $previous,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $completion->fresh(['challenge', 'challenger', 'verifier']);
+    }
+
+    /**
+     * Remove the photo. Either participant, for the same reason as attaching:
+     * both of them are in it, so both can take it down.
+     *
+     * @throws \InvalidArgumentException not a participant
+     */
+    public function removeProofPhoto(Profile $actor, ChallengeCompletion $completion): ChallengeCompletion
+    {
+        $this->assertParticipant($actor, $completion);
+
+        $url = $completion->proof_photo_url;
+        $completion->update(['proof_photo_url' => null]);
+
+        if ($url !== null) {
+            try {
+                $this->fileUploadService->delete($url);
+            } catch (\Throwable $e) {
+                // The row is already clear, which is what the caller asked for.
+                Log::warning('Challenge proof photo delete: file not removed', [
+                    'completion_id' => $completion->id,
+                    'url' => $url,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $completion->fresh(['challenge', 'challenger', 'verifier']);
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function assertParticipant(Profile $actor, ChallengeCompletion $completion): void
+    {
+        $isParticipant = $actor->id === $completion->challenger_profile_id
+            || $actor->id === $completion->verifier_profile_id;
+
+        if (! $isParticipant) {
+            throw new \InvalidArgumentException('Only the two people in this challenge can change its photo.');
+        }
+    }
 
     /**
      * Initiate a peer-to-peer challenge between two checked-in attendees.

--- a/app/Services/ChallengeService.php
+++ b/app/Services/ChallengeService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Models\Challenge;
 use App\Models\Event;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
@@ -44,6 +45,9 @@ class ChallengeService
             'points' => $data['points'] ?? $difficulty->points(),
             'is_system' => false,
             'event_id' => $event->id,
+            // How it is played (#216). Absent means text, which is what every
+            // challenge was before the column existed.
+            'proof_type' => ChallengeProofType::from($data['proof_type'] ?? ChallengeProofType::Text->value),
         ]);
     }
 
@@ -62,6 +66,10 @@ class ChallengeService
 
         if (isset($data['description'])) {
             $updateData['description'] = $data['description'];
+        }
+
+        if (isset($data['proof_type'])) {
+            $updateData['proof_type'] = ChallengeProofType::from($data['proof_type']);
         }
 
         if (isset($data['difficulty'])) {

--- a/database/migrations/2026_08_23_120000_add_proof_type_to_challenges_table.php
+++ b/database/migrations/2026_08_23_120000_add_proof_type_to_challenges_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ChallengeProofType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * How a challenge is played (kolabing-v2#216).
+ *
+ * `challenges` said what a challenge was worth and how hard it was, and nothing
+ * about how you do it — so the app had one surface for all of them and "Take a
+ * selfie together" opened a screen of text.
+ *
+ * Additive with a default, so every challenge that already exists keeps working
+ * and reports itself as text-played, which is what it has always been.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('challenges', function (Blueprint $table): void {
+            $table->string('proof_type', 10)
+                ->default(ChallengeProofType::Text->value)
+                ->after('difficulty');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('challenges', function (Blueprint $table): void {
+            $table->dropColumn('proof_type');
+        });
+    }
+};

--- a/database/migrations/2026_08_23_120001_add_proof_photo_to_challenge_completions_table.php
+++ b/database/migrations/2026_08_23_120001_add_proof_photo_to_challenge_completions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Somewhere to keep the photo two people took (kolabing-v2#216).
+ *
+ * `challenge_completions` recorded that a challenge happened and what it paid,
+ * and nothing of the thing itself. The pair took a selfie and the app had
+ * nowhere to put it, so the only trace of the evening was a number.
+ *
+ * A path on the completion rather than a photos table: there is exactly one
+ * photo per completion by design. Two people, one moment, one picture — a
+ * gallery would invite a different feature.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('challenge_completions', function (Blueprint $table): void {
+            // A URL, not a path: FileUploadService::uploadFromFile() returns an
+            // absolute URL and every other photo in this codebase stores that,
+            // so this one does too rather than inventing a second convention.
+            $table->string('proof_photo_url')->nullable()->after('points_earned');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('challenge_completions', function (Blueprint $table): void {
+            $table->dropColumn('proof_photo_url');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -440,6 +440,14 @@ Route::prefix('v1')->group(function (): void {
             ->name('api.v1.challenge-completions.reject');
 
         // My challenge completions
+        // The photo the pair took (#216). Either participant may attach, replace
+        // or remove it — both of them are in it.
+        Route::post('challenge-completions/{challengeCompletion}/photo', [ChallengeCompletionController::class, 'attachPhoto'])
+            ->name('api.v1.challenge-completions.photo.store');
+
+        Route::delete('challenge-completions/{challengeCompletion}/photo', [ChallengeCompletionController::class, 'removePhoto'])
+            ->name('api.v1.challenge-completions.photo.destroy');
+
         Route::get('me/challenge-completions', [ChallengeCompletionController::class, 'myCompletions'])
             ->name('api.v1.me.challenge-completions');
 

--- a/tests/Feature/Api/V1/ChallengeProofPhotoTest.php
+++ b/tests/Feature/Api/V1/ChallengeProofPhotoTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Enums\ChallengeCompletionStatus;
+use App\Enums\ChallengeProofType;
+use App\Models\AttendeeProfile;
+use App\Models\Challenge;
+use App\Models\ChallengeCompletion;
+use App\Models\Event;
+use App\Models\Profile;
+use App\Services\FileUploadService;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The photo two people took while completing a challenge (kolabing-v2#216).
+ *
+ * Before this there was nowhere to put one: `challenge_completions` recorded
+ * that a challenge happened and what it paid, and nothing of the thing itself.
+ *
+ * The rule being tested is that the photo belongs to the **pair**, not to
+ * whoever pressed the button — so either of them can attach, replace and remove
+ * it, and nobody else can touch it.
+ */
+class ChallengeProofPhotoTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function attendee(): Profile
+    {
+        $profile = Profile::factory()->attendee()->create();
+        AttendeeProfile::factory()->create(['profile_id' => $profile->id]);
+
+        return $profile;
+    }
+
+    /**
+     * @return array{completion: ChallengeCompletion, challenger: Profile, verifier: Profile}
+     */
+    private function completion(ChallengeCompletionStatus $status = ChallengeCompletionStatus::Pending): array
+    {
+        $host = Profile::factory()->business()->create();
+        $event = Event::factory()->forProfile($host)->create(['is_active' => true]);
+        $challenge = Challenge::factory()->system()->easy()->create();
+
+        $challenger = $this->attendee();
+        $verifier = $this->attendee();
+
+        $completion = ChallengeCompletion::query()->create([
+            'challenge_id' => $challenge->id,
+            'event_id' => $event->id,
+            'challenger_profile_id' => $challenger->id,
+            'verifier_profile_id' => $verifier->id,
+            'status' => $status->value,
+            'points_earned' => 0,
+        ]);
+
+        return compact('completion', 'challenger', 'verifier');
+    }
+
+    private function photo(string $name = 'selfie.jpg'): UploadedFile
+    {
+        return UploadedFile::fake()->image($name, 600, 600);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake(app(FileUploadService::class)->getStorageDisk());
+    }
+
+    public function test_the_challenger_can_attach_a_photo(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] = $this->completion();
+
+        $response = $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", [
+                'photo' => $this->photo(),
+            ]);
+
+        $response->assertStatus(200)->assertJsonPath('success', true);
+        $this->assertNotNull($response->json('data.proof_photo_url'));
+        $this->assertNotNull($completion->fresh()->proof_photo_url);
+    }
+
+    /**
+     * The point of the rule: two people are in that picture, and which of them
+     * pressed the button is not a permission model.
+     */
+    public function test_the_verifier_can_attach_it_too(): void
+    {
+        ['completion' => $completion, 'verifier' => $verifier] = $this->completion();
+
+        $this->actingAs($verifier)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo()])
+            ->assertStatus(200);
+
+        $this->assertNotNull($completion->fresh()->proof_photo_url);
+    }
+
+    public function test_a_stranger_cannot(): void
+    {
+        ['completion' => $completion] = $this->completion();
+        $stranger = $this->attendee();
+
+        $this->actingAs($stranger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo()])
+            ->assertStatus(403)
+            ->assertJsonPath('error', 'not_a_participant');
+
+        $this->assertNull($completion->fresh()->proof_photo_url);
+    }
+
+    public function test_replacing_a_photo_deletes_the_old_file(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] = $this->completion();
+        $disk = Storage::disk(app(FileUploadService::class)->getStorageDisk());
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo('first.jpg')])
+            ->assertStatus(200);
+        $first = $completion->fresh()->proof_photo_url;
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo('second.jpg')])
+            ->assertStatus(200);
+        $second = $completion->fresh()->proof_photo_url;
+
+        $this->assertNotSame($first, $second);
+        // One completion, one photo — and the disk should say the same, rather
+        // than quietly keeping every version anyone ever tried.
+        $this->assertCount(1, $disk->allFiles("challenge-proofs/{$completion->id}"));
+    }
+
+    public function test_either_participant_can_remove_it(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger, 'verifier' => $verifier] = $this->completion();
+        $disk = Storage::disk(app(FileUploadService::class)->getStorageDisk());
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo()])
+            ->assertStatus(200);
+        $this->assertCount(1, $disk->allFiles("challenge-proofs/{$completion->id}"));
+
+        // The one who did NOT upload it takes it down.
+        $this->actingAs($verifier)
+            ->deleteJson("/api/v1/challenge-completions/{$completion->id}/photo")
+            ->assertStatus(200)
+            ->assertJsonPath('data.proof_photo_url', null);
+
+        $this->assertNull($completion->fresh()->proof_photo_url);
+        $this->assertCount(0, $disk->allFiles("challenge-proofs/{$completion->id}"));
+    }
+
+    /**
+     * A photo may be attached before the confirmation (the camera opens when the
+     * pair agrees) and after it (people remember to keep it later).
+     */
+    public function test_a_verified_completion_still_accepts_a_photo(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] =
+            $this->completion(ChallengeCompletionStatus::Verified);
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo()])
+            ->assertStatus(200);
+    }
+
+    /**
+     * Rejected means it did not happen, so there is nothing to illustrate.
+     */
+    public function test_a_rejected_completion_does_not(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] =
+            $this->completion(ChallengeCompletionStatus::Rejected);
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", ['photo' => $this->photo()])
+            ->assertStatus(409)
+            ->assertJsonPath('error', 'photo_not_allowed');
+    }
+
+    public function test_a_non_image_is_refused(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] = $this->completion();
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", [
+                'photo' => UploadedFile::fake()->create('notes.pdf', 100, 'application/pdf'),
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['photo']);
+    }
+
+    public function test_an_oversize_photo_is_refused(): void
+    {
+        ['completion' => $completion, 'challenger' => $challenger] = $this->completion();
+
+        $this->actingAs($challenger)
+            ->post("/api/v1/challenge-completions/{$completion->id}/photo", [
+                // 6 MB, over the 5 MB the upload type allows.
+                'photo' => UploadedFile::fake()->image('huge.jpg')->size(6 * 1024),
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['photo']);
+    }
+
+    public function test_it_requires_authentication(): void
+    {
+        ['completion' => $completion] = $this->completion();
+
+        $this->postJson("/api/v1/challenge-completions/{$completion->id}/photo")->assertStatus(401);
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | proof_type — the engine selector
+    |--------------------------------------------------------------------------
+    */
+
+    /**
+     * Every challenge that predates the column has always been text-played, and
+     * must keep reporting itself that way.
+     */
+    public function test_proof_type_defaults_to_text(): void
+    {
+        $challenge = Challenge::factory()->system()->easy()->create();
+
+        $this->assertSame(ChallengeProofType::Text, $challenge->fresh()->proof_type);
+    }
+
+    public function test_an_organizer_can_mark_a_challenge_photo_played(): void
+    {
+        $host = Profile::factory()->community()->create();
+        $event = Event::factory()->forProfile($host)->create(['is_active' => true]);
+
+        $response = $this->actingAs($host)
+            ->postJson("/api/v1/events/{$event->id}/challenges", [
+                'name' => 'Take a selfie together',
+                'description' => 'Get both of you in frame.',
+                'difficulty' => 'easy',
+                'points' => 5,
+                'proof_type' => 'photo',
+            ]);
+
+        $response->assertSuccessful()->assertJsonPath('data.proof_type', 'photo');
+    }
+
+    public function test_an_unknown_proof_type_is_refused(): void
+    {
+        $host = Profile::factory()->community()->create();
+        $event = Event::factory()->forProfile($host)->create(['is_active' => true]);
+
+        $this->actingAs($host)
+            ->postJson("/api/v1/events/{$event->id}/challenges", [
+                'name' => 'Something',
+                'difficulty' => 'easy',
+                'points' => 5,
+                'proof_type' => 'video',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['proof_type']);
+    }
+}


### PR DESCRIPTION
## Summary

Two challenge engines — `photo` (open the camera when the pair agrees) and `text` (the instruction is the game, a photo optional at the end) — plus somewhere for that photo to live. Before this there was nowhere: `challenge_completions` recorded that a challenge happened and what it paid, and nothing of the thing itself.

## Linked tracking item
Closes #216

## Type of change
- [x] ✨ Feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change

## Changes

- `App\Enums\ChallengeProofType` — `text` | `photo`, with the reasoning in its docblock.
- `FileUploadType::ChallengeProof` — own directory, 5 MB, **images only**. No video: this sits behind a button people press at events on venue wifi.
- Migration `challenges.proof_type`, default `text`.
- Migration `challenge_completions.proof_photo_url`.
- `POST /challenge-completions/{id}/photo` (multipart `photo`) and `DELETE` the same path.
- `ChallengeCompletionService::attachProofPhoto()` / `removeProofPhoto()`, both gated on `assertParticipant()`.
- `proof_type` on `ChallengeResource`, `proof_photo_url` on `ChallengeCompletionResource`.
- `proof_type` accepted by `StoreChallengeRequest` / `UpdateChallengeRequest` and carried through `ChallengeService::create()` / `update()`.

### `proof_type` is an engine selector, not a gate

`photo` tells the app to open the camera as soon as the pair agrees. It does **not** make the server refuse a verification that arrives without a photo.

A hard requirement means a pair who cannot get a photo up — no signal in a basement gym, a denied camera permission, a failed upload — cannot earn what they just did together. The person confirming is already the check on honesty, and that is the check this loop is built on. The photo is a memento and a nudge; the moment it is mandatory it becomes a way to lose points to a bad connection.

If it ever has to be enforced, that is its own explicit decision with its own copy in the app — not a silent side effect of this column.

### The photo belongs to the pair

Either participant may attach, replace or remove it. Two people are in that picture and which of them was faster is not a permission model.

Allowed while `pending` — the camera opens before the confirmation exists — and after `verified`, because people remember to keep it later. Refused once `rejected`: then it did not happen, and there is nothing to illustrate.

### A URL, not a path

`FileUploadService::uploadFromFile()` returns an absolute URL and every other photo in this codebase stores that. The column follows it rather than inventing a second convention; `delete()` already accepts either form. **Found by a failing test** — the first version of this stored what it called a path, and the disk assertion caught that it was a URL.

## Mobile impact (kolabing-app)
- [ ] No mobile changes required
- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** kolabing/kolabing-app#144 is the app-side ticket. Two additive response fields — `challenge.proof_type` (always present, `"text"` for everything that exists today) and `challenge_completion.proof_photo_url` (nullable) — plus two new routes. Nothing existing changed shape, so shipped builds are unaffected. The app work is: open the camera when `proof_type == photo`, and offer "add a photo" at the end otherwise.

## Database / migrations
- [ ] No schema changes
- [x] Includes migrations — additive & reversible
- [ ] Includes data backfill / destructive change

**Migration notes:** two `ALTER TABLE`s, both additive and both with a `down()`. `challenges.proof_type` has a default so existing rows need no backfill and read as `text`, which is what they have always been. `challenge_completions.proof_photo_url` is nullable. No locks worth worrying about at this table size.

## Testing
- [x] `php artisan test` passes — **2380 passed** (12400 assertions), 0 failures
- [x] `vendor/bin/pint` clean
- [x] Manually verified the happy path — through the tests below

`tests/Feature/Api/V1/ChallengeProofPhotoTest.php` (13 new):

| Test | Why it is there |
| --- | --- |
| the challenger can attach a photo | the contract |
| the verifier can attach it too | the rule — the photo is the pair's |
| a stranger cannot | the other half of that rule |
| replacing deletes the old file | one completion, one photo, and the disk agrees |
| either participant can remove it | the uploader is not the owner |
| a verified completion still accepts one | people keep it afterwards |
| a rejected one does not | nothing happened, nothing to illustrate |
| a non-image is refused | it is a photo field |
| an oversize photo is refused | the 5 MB limit lives in the enum, and the rule derives from it |
| requires authentication | scoped to the caller |
| `proof_type` defaults to text | **every existing challenge keeps working** |
| an organizer can mark one photo-played | the write path, end to end |
| an unknown `proof_type` is refused | `video` is not an engine |

## Docs & rules updated
- [ ] `BACKLOG.md` updated
- [ ] `docs/ROLES-AND-PERMISSIONS.md` + `docs/ROLES-BACKEND-DB-MAP.md`
- [ ] `docs/BACKEND-SCHEMA.md`
- [x] No docs impact

**Flagging rather than pretending: two of these are not really N/A.** `docs/BACKEND-SCHEMA.md` documents the production schema and this PR adds two columns to it, so it *should* get them — I left it alone because that doc is generated from the live database and updating it from a branch would record a schema that is not deployed yet. It needs a pass once this is merged and migrated. `BACKLOG.md` likewise deserves an entry. No role, paywall or feed rules changed, so the ROLES docs genuinely are N/A.

## Screenshots / notes

```
POST /api/v1/challenge-completions/{id}/photo     (multipart: photo=@selfie.jpg)
200 { "success": true, "data": { …, "proof_photo_url": "https://…/challenge-proofs/…" } }
403 { "error": "not_a_participant" }    409 { "error": "photo_not_allowed" }

GET /api/v1/events/{event}/challenges
200 { …, "proof_type": "photo" }        // "text" for everything that exists today
```
