### PR TITLE
fix(dashboard): stop sending communities `opportunities` — it breaks every shipped app

### DIFF
--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -217,8 +217,22 @@ class DashboardService
         $applicationsReceived = $this->getReceivedApplicationStats($profile);
         $collaborations = $this->getCollaborationStats($profile);
 
+        // `opportunities` is deliberately NOT returned for a community, even
+        // though it is computed above and still feeds `next_action`.
+        //
+        // The shipped mobile client picks which dashboard to parse by SNIFFING
+        // this key: `if (data.containsKey('opportunities')) -> BusinessDashboard`.
+        // Adding the block here for parity therefore made every community parse
+        // as a business, leaving `communityDashboard` null and the app showing
+        // "Unable to load dashboard data" — on a clean 200 with valid JSON, so
+        // no exception surfaced in Sentry or the logs and the break was silent.
+        //
+        // The client is fixed to read the role from auth instead, but that fix
+        // needs an App Store release; every already-installed app keeps
+        // sniffing. So the key stays off this payload until those builds are
+        // gone. The web panel is unaffected: its `d.opportunities` tile lives
+        // inside `x-if="isBusiness"`.
         return [
-            'opportunities' => $opportunities,
             'applications_sent' => $applicationsSent,
             'applications_received' => $applicationsReceived,
             'collaborations' => $collaborations,

--- a/tests/Feature/Api/V1/CommunityDashboardParityTest.php
+++ b/tests/Feature/Api/V1/CommunityDashboardParityTest.php
@@ -74,7 +74,17 @@ class CommunityDashboardParityTest extends TestCase
         $this->dashboard($mine)->assertJsonPath('data.applications_received.total', 0);
     }
 
-    public function test_a_community_sees_the_count_of_its_own_kolabs(): void
+    /**
+     * The community payload must NOT carry `opportunities`.
+     *
+     * The shipped mobile client chooses its parser by sniffing this key
+     * (`if (data.containsKey('opportunities')) -> BusinessDashboard`), so
+     * sending it to a community made every community dashboard parse as a
+     * business and render "Unable to load dashboard data" — on a 200, with no
+     * exception anywhere. This test is the guard: the key may only come back
+     * once the sniffing builds are out of circulation.
+     */
+    public function test_the_community_payload_does_not_carry_opportunities(): void
     {
         $community = $this->community();
         Kolab::factory()->published()->create(['creator_profile_id' => $community->id]);
@@ -85,10 +95,13 @@ class CommunityDashboardParityTest extends TestCase
             'status' => KolabStatus::Draft,
         ]);
 
-        $this->dashboard($community)
-            ->assertJsonPath('data.opportunities.published', 1)
-            ->assertJsonPath('data.opportunities.draft', 1)
-            ->assertJsonPath('data.opportunities.total', 2);
+        $response = $this->dashboard($community)->assertJsonPath('success', true);
+
+        $this->assertArrayNotHasKey(
+            'opportunities',
+            $response->json('data'),
+            'A community dashboard must not carry `opportunities`: the shipped mobile client parses it as a business dashboard.'
+        );
     }
 
     /** The keys the existing clients already read must not move. */
@@ -199,7 +212,7 @@ class CommunityDashboardParityTest extends TestCase
 
         $this->dashboard($community)
             ->assertJsonPath('success', true)
-            ->assertJsonStructure(['data' => ['opportunities', 'applications_received', 'next_action']]);
+            ->assertJsonStructure(['data' => ['applications_received', 'next_action']]);
     }
 
     /** The business dashboard keeps its own chain — this change must not leak into it. */


### PR DESCRIPTION
## Summary

**Production hotfix.** A community reported a dead Home screen — *"Unable to load dashboard data"* — and there was nothing to find: no exception in either Sentry project (`php-laravel` has 3 unresolved issues, none dashboard-related), no backend error, and a clean **200 with valid JSON**.

The break is a **client contract**, not a crash. The shipped mobile client picks its parser by sniffing a key:

```dart
if (data.containsKey('opportunities'))        -> BusinessDashboard
else if (data.containsKey('applications_sent')) -> CommunityDashboard
```

**#227 gave the community payload an `opportunities` block for parity — and it is the first key in the array.** So every community began parsing as a business, the client's `communityDashboard` came back `null`, and the screen fell through to its error state.

Every part of the report matches: community-only (businesses already received `opportunities`), started the day #227 merged, and invisible to error tracking because nothing ever threw.

## The fix

Remove `opportunities` from the **community** payload only.

- `$opportunities` is still computed and still feeds `next_action` — no behaviour lost.
- The **business** payload is untouched.
- The **web panel** is unaffected: its `d.opportunities` tile lives inside `<template x-if="!loading && isBusiness">` (`dashboard.blade.php:191`), so a community never rendered it.
- **`applications_received` — the real defect #227 fixed** (a community never seeing the applications it received) — is untouched and still shipped.

## Why not fix it in the app instead

The client fix is the right long-term shape and is already written (it reads the role from auth instead of from the payload). But it needs an App Store release, and **every already-installed build keeps sniffing.** A backend deploy unbreaks all of them in minutes; a mobile release reaches users over days and never reaches the ones who don't update.

So the key must stay off this payload until the sniffing builds are out of circulation. The parity test now guards that and explains why, instead of asserting the shape that caused the outage.

## Type of change

- [ ] ✨ Feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [x] ⚠️ Breaking change — intentionally reverts one key from #227's response shape

## Tests

`tests/Feature/Api/V1/CommunityDashboardParityTest.php`:

- `test_a_community_sees_the_count_of_its_own_kolabs` → replaced by **`test_the_community_payload_does_not_carry_opportunities`**, which asserts the key is absent and documents the client-sniffing reason in the failure message.
- `test_a_community_needs_no_subscription_for_any_of_this` → structure assertion no longer expects `opportunities`.

Left to CI to run.

## Deploy note

This wants to go out **ahead of** any further dashboard shape changes. Any new key is safe; re-adding `opportunities` to a community response is not, until the old builds are gone.

## Follow-ups, not in this PR

1. **`POSTMARK_API_KEY` is not configured in production** — `PHP-LARAVEL-J`, 27 events over 6 days, last seen 15 hours ago. Transactional email is failing in prod right now. Missing env var, not code.
2. **The mobile app reports no handled API failures.** Outside `main.dart` there is not a single `captureException`, so every non-200 becomes an error state that no one can see — which is why this outage had to arrive by WhatsApp. Worth an app-side reporter (status + endpoint, no PII).
3. **Audit for other shape-sniffing** on either side of this contract; anywhere a role is inferred from payload keys is the same accident waiting.