### PR TITLE
feat(community): a cover photograph of its own, not a blur of the logo

### DIFF
--- a/app/Enums/FileUploadType.php
+++ b/app/Enums/FileUploadType.php
@@ -11,6 +11,7 @@ namespace App\Enums;
 enum FileUploadType: string
 {
     case ProfilePhoto = 'profile_photo';
+    case CoverPhoto = 'cover_photo';
     case KolabMedia = 'kolab_media';
     case OpportunityPhoto = 'opportunity_photo';
     case GalleryPhoto = 'gallery_photo';
@@ -33,6 +34,7 @@ enum FileUploadType: string
     {
         return match ($this) {
             self::ProfilePhoto => 'profiles',
+            self::CoverPhoto => 'covers',
             self::KolabMedia => 'kolabs',
             self::OpportunityPhoto => 'opportunities',
             self::GalleryPhoto => 'gallery',
@@ -50,6 +52,7 @@ enum FileUploadType: string
     {
         return match ($this) {
             self::ProfilePhoto => 5 * 1024 * 1024, // 5MB
+            self::CoverPhoto => 5 * 1024 * 1024, // 5MB
             self::KolabMedia => 50 * 1024 * 1024, // 50MB
             self::OpportunityPhoto => 5 * 1024 * 1024, // 5MB
             self::GalleryPhoto => 5 * 1024 * 1024, // 5MB

--- a/app/Http/Controllers/Api/V1/ProfileController.php
+++ b/app/Http/Controllers/Api/V1/ProfileController.php
@@ -153,6 +153,25 @@ class ProfileController extends Controller
             $extendedProfileData['profile_photo'] = $url;
         }
 
+        // The cover photograph, separate from the logo. A community page has
+        // painted a cover band since IF-31 but had no column behind it, so the
+        // band fell back to a blurred copy of the logo — every community's
+        // background WAS its own profile photo, with no way to change it.
+        // Business profiles have no cover band, so this is community-only.
+        if ($request->hasFile('cover_photo') && $profile->isCommunity()) {
+            $communityProfile = $profile->communityProfile;
+
+            if ($communityProfile?->cover_photo) {
+                $this->fileUploadService->delete($communityProfile->cover_photo);
+            }
+
+            $extendedProfileData['cover_photo'] = $this->fileUploadService->uploadFromFile(
+                $request->file('cover_photo'),
+                FileUploadType::CoverPhoto,
+                $profile->id
+            );
+        }
+
         // Verification: communities can submit/edit their proof channels via the
         // profile edit. Run the shared transition (unverified/rejected → pending;
         // verified stays verified but is flagged for admin re-check) BEFORE the

--- a/app/Http/Requests/Api/V1/UpdateProfileRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateProfileRequest.php
@@ -75,6 +75,7 @@ class UpdateProfileRequest extends FormRequest
             'name' => ['nullable', 'string', 'max:255'],
             'city_id' => ['nullable', 'uuid', Rule::exists('cities', 'id')],
             'profile_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+            'cover_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
         ];
     }
 
@@ -95,6 +96,7 @@ class UpdateProfileRequest extends FormRequest
             'instagram' => ['nullable', 'string', 'max:255'],
             'website' => ['nullable', 'string', 'max:255', 'url'],
             'profile_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+            'cover_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
         ];
     }
 
@@ -115,6 +117,7 @@ class UpdateProfileRequest extends FormRequest
             'tiktok' => ['nullable', 'string', 'max:255'],
             'website' => ['nullable', 'string', 'max:255', 'url'],
             'profile_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
+            'cover_photo' => ['nullable', 'image', 'mimes:jpeg,jpg,png,gif,webp', 'max:5120'],
             ...$this->verificationChannelRules(),
         ];
     }

--- a/app/Http/Resources/Api/V1/CommunityProfileResource.php
+++ b/app/Http/Resources/Api/V1/CommunityProfileResource.php
@@ -42,6 +42,11 @@ class CommunityProfileResource extends JsonResource
             'website' => $this->website,
             'profile_photo' => $logo,
             'logo_url' => $logo,
+            // The cover photograph, separate from the logo. Null until the
+            // community sets one — the client must NOT fall back to the logo
+            // here, because a background that is a blurred copy of the avatar
+            // is exactly the behaviour this field replaces.
+            'cover_photo' => $this->absoluteUrl($this->cover_photo),
             'is_featured' => $this->is_featured,
             ...$this->verificationFields($this->resource, $request, $this->profile_id),
             'created_at' => $this->created_at?->toIso8601String(),

--- a/app/Models/CommunityProfile.php
+++ b/app/Models/CommunityProfile.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $tiktok
  * @property string|null $website
  * @property string|null $profile_photo
+ * @property string|null $cover_photo
  * @property bool $is_featured
  * @property array<int, array{type: string, url: string, is_public: bool}>|null $verification_channels
  * @property string $verification_status
@@ -56,6 +57,7 @@ class CommunityProfile extends Model
         'tiktok',
         'website',
         'profile_photo',
+        'cover_photo',
         'is_featured',
         'verification_channels',
         'verification_status',

--- a/database/migrations/2026_08_26_120000_add_cover_photo_to_community_profiles_table.php
+++ b/database/migrations/2026_08_26_120000_add_cover_photo_to_community_profiles_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A community's cover photograph, stored apart from its logo.
+ *
+ * The app's community page has painted a cover band since IF-31, but there was
+ * no column behind it: the band fell back to a blurred copy of `profile_photo`,
+ * so every community's "background" was its own logo, and there was no way to
+ * set one. This is that missing field — deliberately separate from
+ * `profile_photo`, because they are two different pictures doing two different
+ * jobs.
+ *
+ * `text`, matching `profile_photo`: these hold URLs, which outgrow `varchar(255)`
+ * on some storage drivers.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('community_profiles', function (Blueprint $table): void {
+            $table->text('cover_photo')->nullable()->after('profile_photo');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('community_profiles', function (Blueprint $table): void {
+            $table->dropColumn('cover_photo');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Reported from the app: **the community page's background never arrives, and what you see instead is the profile photo.**

That is exactly right, and it was not a client bug. The page has painted a cover band since IF-31, but **there has never been a column behind it.** With nothing to paint, the app's `_Cover` falls back to a blurred copy of the avatar — so every community's "background" was its own logo, and no amount of app work could change it, because there was nowhere to put a cover.

I checked before assuming: `grep -niE "cover_image|cover_photo|banner"` across `database/migrations` and `app/Models` returns only `blog_posts.cover_image_url`. Nothing on `profiles`, `community_profiles` or `business_profiles`.

## Changes

- **Migration** — `community_profiles.cover_photo`, nullable `text` (matching `profile_photo`: these hold URLs, which outgrow `varchar(255)` on some drivers), placed `after('profile_photo')`.
- **`CommunityProfile`** — `cover_photo` in `$fillable` + docblock property.
- **`FileUploadType::CoverPhoto`** — storage directory `covers/`, 5MB cap, same as `ProfilePhoto`.
- **`UpdateProfileRequest`** — `cover_photo` accepted wherever `profile_photo` is, with the identical rule (`nullable, image, mimes:jpeg,jpg,png,gif,webp, max:5120`). All 3 rule sites.
- **`ProfileController::update`** — handles `cover_photo` by mirroring the `profile_photo` branch exactly: delete the old file, upload, write the URL onto the extended profile data. **Guarded to `$profile->isCommunity()`.**
- **`CommunityProfileResource`** — exposes `cover_photo`.

## Two decisions worth stating

**Separate from `profile_photo`, on purpose.** They are two different pictures doing two different jobs, and one being a washed-out copy of the other is precisely the reported bug.

**The resource does NOT fall back to the logo when `cover_photo` is null.** The client decides what an absent cover looks like. A resource that quietly handed back the avatar would reproduce the reported behaviour from the server side, which is worse — it would look fixed while being the same thing.

**Community-only.** A business profile has no cover band, and the product owner asked for business to be left untouched in this pass.

## Type of change

- [x] ✨ Feature
- [x] 🐛 Bug fix — the cover band has been unfixable from the client since IF-31
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 📝 Docs
- [ ] 🔧 Chore / tooling
- [ ] ⚠️ Breaking change — additive: a new nullable column and a new optional file field

## Deploy note

Needs the migration. Additive and nullable, so it is safe to deploy ahead of the app change: existing clients neither send `cover_photo` nor read it, and `cover_photo` simply comes back `null` until a community sets one.

## Tests

None added here — flagging that honestly rather than claiming coverage. The upload path is a copy of `profile_photo`'s, which is already exercised, and the column is additive. If you want them before merge, the two worth having are: a community `PUT /me/profile` with a `cover_photo` file persists and returns the URL, and the same request from a **business** profile is ignored.

## App side

The client half is ready to follow on `redesign/community-page-on-profile-structure`: the cover is already tappable there, currently wired to the gallery as the only thing that could influence the band. Once this ships, that tap becomes a real `cover_photo` upload and the honest "the server decides which photo leads" caveat in the sheet copy goes away.