### PR TITLE
fix(profile): cover uploads 500 — CoverPhoto missing from two enum matches

### DIFF
--- a/app/Enums/FileUploadType.php
+++ b/app/Enums/FileUploadType.php
@@ -69,7 +69,7 @@ enum FileUploadType: string
     public function getAllowedMimeTypes(): array
     {
         return match ($this) {
-            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
+            self::ProfilePhoto, self::CoverPhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
                 'image/jpeg',
                 'image/jpg',
                 'image/png',
@@ -97,7 +97,7 @@ enum FileUploadType: string
     public function getAllowedExtensions(): array
     {
         return match ($this) {
-            self::ProfilePhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
+            self::ProfilePhoto, self::CoverPhoto, self::OpportunityPhoto, self::GalleryPhoto, self::EventPhoto, self::ChallengeProof => [
                 'jpeg',
                 'jpg',
                 'png',

--- a/tests/Unit/Enums/FileUploadTypeTest.php
+++ b/tests/Unit/Enums/FileUploadTypeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\FileUploadType;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Every case must be answered by every method.
+ *
+ * `CoverPhoto` was added in #239 and reached two of the four `match`
+ * statements: it had a storage directory and a size limit, but no MIME types
+ * and no extensions. So `FileUploadService::validateMimeType()` hit an
+ * `UnhandledMatchError` and every cover upload answered **500** — the app said
+ * "Could not add that photo" and nobody could tell why from the client side.
+ *
+ * A match on an enum is exhaustive only until someone adds a case. This test is
+ * the thing that notices.
+ */
+class FileUploadTypeTest extends TestCase
+{
+    /**
+     * @return array<string, array{FileUploadType}>
+     */
+    public static function cases(): array
+    {
+        $out = [];
+
+        foreach (FileUploadType::cases() as $case) {
+            $out[$case->value] = [$case];
+        }
+
+        return $out;
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('cases')]
+    public function test_every_case_has_a_storage_directory(FileUploadType $type): void
+    {
+        $this->assertNotSame('', $type->getStorageDirectory());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('cases')]
+    public function test_every_case_has_a_size_limit(FileUploadType $type): void
+    {
+        $this->assertGreaterThan(0, $type->getMaxFileSize());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('cases')]
+    public function test_every_case_has_allowed_mime_types(FileUploadType $type): void
+    {
+        // The call itself is the assertion: an unhandled case throws here.
+        $this->assertNotEmpty($type->getAllowedMimeTypes());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('cases')]
+    public function test_every_case_has_allowed_extensions(FileUploadType $type): void
+    {
+        $this->assertNotEmpty($type->getAllowedExtensions());
+    }
+
+    public function test_the_cover_photo_accepts_the_image_types_a_phone_produces(): void
+    {
+        $mimes = FileUploadType::CoverPhoto->getAllowedMimeTypes();
+
+        $this->assertContains('image/jpeg', $mimes);
+        $this->assertContains('image/png', $mimes);
+        $this->assertContains('jpg', FileUploadType::CoverPhoto->getAllowedExtensions());
+        $this->assertSame('covers', FileUploadType::CoverPhoto->getStorageDirectory());
+    }
+}


### PR DESCRIPTION
## Summary

Every community cover upload answered **500**. `#239` added `FileUploadType::CoverPhoto` and taught two of the four `match` statements in that enum about it — not the two that validate the file — so `FileUploadService::validateMimeType()` threw before anything was written.

## Linked tracking item

Closes #240. App-side counterpart: kolabing-app#176 / kolabing-app#177.

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Changes

| method | CoverPhoto before | after |
|---|---|---|
| `getStorageDirectory()` | ✅ `'covers'` | unchanged |
| `getMaxFileSize()` | ✅ 5 MB | unchanged |
| `getAllowedMimeTypes()` | ❌ **throws** | ✅ the shared image set |
| `getAllowedExtensions()` | ❌ **throws** | ✅ the shared image set |

Plus `tests/Unit/Enums/FileUploadTypeTest.php`: every case must be answered by all four methods. A `match` on an enum is exhaustive only until someone adds a case, and nothing noticed this one.

**How it was found:** the mobile side logged the raw response (500, `{"success":false,"message":"Server error"}`), then Sentry `php-laravel` [PHP-LARAVEL-P](https://kolabng.sentry.io/issues/PHP-LARAVEL-P) gave the real exception: `UnhandledMatchError: Unhandled match case of type App\Enums\FileUploadType`, culprit `/api/v1/me/profile`, 4 events.

This also settles a wrong theory from earlier today: `GET /me/profile` returning `cover_photo: null` looked like the resource not being deployed, then like an unrun migration. Neither. The resource is live and correct; the write could never happen.

## Mobile impact (kolabing-app)

- [x] No mobile changes required

The app already sends `[multipart cover_photo]` and reads `community_profile.cover_photo`. kolabing-app#177 (merged) additionally makes the app honest when the server accepts an upload and stores nothing.

## Database / migrations

- [x] No schema changes

**Migration notes:** none here. Worth confirming on deploy that #239's `add_cover_photo_to_community_profiles_table` actually ran — with the enum throwing first, a missing column could not yet have surfaced. If a cover upload still fails after this, that is the next suspect and it will appear in Sentry as a `QueryException`.

## Testing

- [x] `php artisan test` passes — paste counts: `tests/Unit/Enums/FileUploadTypeTest.php` → **OK (29 tests, 32 assertions)**. Verified it reproduces the production failure with the fix reverted: **3 errors, `UnhandledMatchError: Unhandled match case App\Enums\FileUploadType::CoverPhoto`**. Full suite not run locally.
- [x] `vendor/bin/pint` clean — `{"result":"pass"}` on both files
- [ ] Manually verified the happy path — **not yet.** It needs a deploy: the fix cannot be exercised against the development API until it is live. The app-side reproduction is ready (community leader → tap the cover band → pick a photo) and I can confirm the moment it deploys.

## Docs & rules updated

- [x] No docs impact

The schema is unchanged and no role or payload contract moved; `cover_photo` was already documented by #239.

## Screenshots / notes

Reviewer guidance — the whole diff in one line:

```php
- self::ProfilePhoto, self::OpportunityPhoto, ... => [ ...image types... ],
+ self::ProfilePhoto, self::CoverPhoto, self::OpportunityPhoto, ... => [ ...image types... ],
```

twice, once per match.

🤖 Diagnosed and written with [Claude Code](https://claude.com/claude-code)