### PR TITLE
feat(admin): set whether a challenge opens the camera

### DIFF
--- a/app/Http/Controllers/Admin/ChallengeController.php
+++ b/app/Http/Controllers/Admin/ChallengeController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Admin;
 use App\Enums\ChallengeAudience;
 use App\Enums\ChallengeCategory;
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Enums\MissionRepeat;
 use App\Enums\MissionTrigger;
 use App\Http\Controllers\Controller;
@@ -103,6 +104,7 @@ class ChallengeController extends Controller
             'categories' => ChallengeCategory::cases(),
             'difficulties' => ChallengeDifficulty::cases(),
             'audiences' => ChallengeAudience::cases(),
+            'proofTypes' => ChallengeProofType::cases(),
             'triggers' => MissionTrigger::cases(),
             'repeats' => MissionRepeat::cases(),
         ];

--- a/app/Http/Requests/Admin/StoreChallengeRequest.php
+++ b/app/Http/Requests/Admin/StoreChallengeRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Admin;
 use App\Enums\ChallengeAudience;
 use App\Enums\ChallengeCategory;
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Enums\MissionRepeat;
 use App\Enums\MissionTrigger;
 use Illuminate\Foundation\Http\FormRequest;
@@ -38,11 +39,25 @@ class StoreChallengeRequest extends FormRequest
             'points' => ['required', 'integer', 'between:0,10000'],
             'category' => ['nullable', Rule::in(ChallengeCategory::values())],
             'audience' => ['required', Rule::in(ChallengeAudience::values())],
+            // Whether the app opens the camera when a pair agrees (#248).
+            // Absent means unchanged on update and `text` on create, which is
+            // what every challenge authored before #216 reports.
+            'proof_type' => ['sometimes', Rule::in(ChallengeProofType::values())],
             'trigger_action' => ['nullable', Rule::in(MissionTrigger::values())],
             'target_value' => ['nullable', 'integer', 'min:1', 'max:100000'],
             'repeat_interval' => ['nullable', Rule::in(MissionRepeat::values())],
             'starts_at' => ['nullable', 'date'],
             'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'proof_type.in' => 'How it is played must be text or photo.',
         ];
     }
 }

--- a/app/Http/Requests/Admin/UpdateChallengeRequest.php
+++ b/app/Http/Requests/Admin/UpdateChallengeRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Admin;
 use App\Enums\ChallengeAudience;
 use App\Enums\ChallengeCategory;
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Enums\MissionRepeat;
 use App\Enums\MissionTrigger;
 use Illuminate\Foundation\Http\FormRequest;
@@ -38,11 +39,25 @@ class UpdateChallengeRequest extends FormRequest
             'points' => ['required', 'integer', 'between:0,10000'],
             'category' => ['nullable', Rule::in(ChallengeCategory::values())],
             'audience' => ['required', Rule::in(ChallengeAudience::values())],
+            // Whether the app opens the camera when a pair agrees (#248).
+            // Absent means unchanged on update and `text` on create, which is
+            // what every challenge authored before #216 reports.
+            'proof_type' => ['sometimes', Rule::in(ChallengeProofType::values())],
             'trigger_action' => ['nullable', Rule::in(MissionTrigger::values())],
             'target_value' => ['nullable', 'integer', 'min:1', 'max:100000'],
             'repeat_interval' => ['nullable', Rule::in(MissionRepeat::values())],
             'starts_at' => ['nullable', 'date'],
             'ends_at' => ['nullable', 'date', 'after_or_equal:starts_at'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'proof_type.in' => 'How it is played must be text or photo.',
         ];
     }
 }

--- a/resources/views/admin/gamification/challenges/_form.blade.php
+++ b/resources/views/admin/gamification/challenges/_form.blade.php
@@ -52,6 +52,25 @@
     </div>
 </div>
 
+{{-- How it is played: does the app open the camera when the pair agrees? (#248) --}}
+<div class="form-row">
+    <div class="form-group col-md-6">
+        <label for="proof_type">When the pair agrees</label>
+        <select name="proof_type" id="proof_type" class="form-control">
+            @foreach ($proofTypes as $p)
+                <option value="{{ $p->value }}" {{ old('proof_type', $challenge->proof_type?->value ?? 'text') === $p->value ? 'selected' : '' }}>
+                    {{ $p->value === 'photo' ? 'Open the camera — they take a photo together' : 'No camera — the instruction is the game' }}
+                </option>
+            @endforeach
+        </select>
+        <small class="form-text text-muted">
+            Picks the surface the app opens, and nothing more: a verification that arrives with no photo is still
+            accepted, so a denied camera or a dead connection never costs anybody their points.
+            <strong>&ldquo;Take a selfie together&rdquo; wants the camera; &ldquo;introduce yourselves&rdquo; does not.</strong>
+        </small>
+    </div>
+</div>
+
 <hr>
 <h6 class="text-uppercase text-muted mb-1">Mission settings (optional)</h6>
 <p class="small text-muted">

--- a/resources/views/admin/gamification/challenges/index.blade.php
+++ b/resources/views/admin/gamification/challenges/index.blade.php
@@ -64,6 +64,7 @@
                             <th>Category</th>
                             <th>Difficulty</th>
                             <th>Audience</th>
+                            <th class="text-center">Camera</th>
                             <th class="text-center">Pts</th>
                             <th class="text-right pr-4">Actions</th>
                         </tr>
@@ -82,6 +83,13 @@
                                 <td>
                                     <span class="badge badge-light text-uppercase">{{ $c->audience?->label() ?? 'Both' }}</span>
                                 </td>
+                                <td class="text-center">
+                                    @if ($c->proof_type?->value === 'photo')
+                                        <span class="badge badge-info" title="The app opens the camera when the pair agrees">&#128247; photo</span>
+                                    @else
+                                        <span class="text-muted">&mdash;</span>
+                                    @endif
+                                </td>
                                 <td class="text-center font-weight-bold">{{ $c->points }}</td>
                                 <td class="text-right pr-4">
                                     <a href="{{ route('admin.gamification.challenges.edit', $c) }}" class="btn btn-sm btn-outline-primary">Edit</a>
@@ -94,7 +102,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="6" class="text-center text-muted py-4">No challenges match the current filters.</td>
+                                <td colspan="7" class="text-center text-muted py-4">No challenges match the current filters.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/tests/Feature/Admin/ChallengesAdminTest.php
+++ b/tests/Feature/Admin/ChallengesAdminTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Admin;
 use App\Enums\ChallengeAudience;
 use App\Enums\ChallengeCategory;
 use App\Enums\ChallengeDifficulty;
+use App\Enums\ChallengeProofType;
 use App\Enums\MissionRepeat;
 use App\Enums\MissionTrigger;
 use App\Models\BusinessProfile;
@@ -114,6 +115,106 @@ class ChallengesAdminTest extends TestCase
             ->assertRedirect(route('admin.gamification.challenges.index'));
 
         $this->assertSame('business', $challenge->fresh()->audience->value);
+    }
+
+    // #248: the camera setting existed everywhere except the one screen a human
+    // uses. `proof_type` was on the model, cast, in the API resource and in the
+    // API requests — but not in the admin requests, so `validated()` dropped it
+    // and the panel could never author a camera challenge.
+    public function test_create_persists_the_camera_setting(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.gamification.challenges.store'), [
+                'name' => 'Selfie together',
+                'difficulty' => ChallengeDifficulty::Easy->value,
+                'points' => 15,
+                'audience' => ChallengeAudience::Both->value,
+                'proof_type' => ChallengeProofType::Photo->value,
+            ])
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+
+        $this->assertDatabaseHas('challenges', [
+            'name' => 'Selfie together',
+            'proof_type' => 'photo',
+        ]);
+    }
+
+    public function test_update_can_turn_the_camera_on_and_off_again(): void
+    {
+        $challenge = Challenge::factory()->create([
+            'proof_type' => ChallengeProofType::Text,
+            'audience' => ChallengeAudience::Both,
+            'is_system' => true,
+        ]);
+
+        // Spelled out rather than read back off the model: the factory leaves
+        // `audience` to its own default and the form always posts every field.
+        $payload = fn (string $proofType): array => [
+            'name' => $challenge->name,
+            'difficulty' => ChallengeDifficulty::Easy->value,
+            'points' => 10,
+            'audience' => ChallengeAudience::Both->value,
+            'proof_type' => $proofType,
+        ];
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.challenges.update', $challenge), $payload('photo'))
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+        $this->assertSame('photo', $challenge->fresh()->proof_type->value);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->put(route('admin.gamification.challenges.update', $challenge), $payload('text'))
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+        $this->assertSame('text', $challenge->fresh()->proof_type->value);
+    }
+
+    public function test_create_rejects_an_unknown_camera_setting(): void
+    {
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.gamification.challenges.store'), [
+                'name' => 'Nonsense',
+                'difficulty' => ChallengeDifficulty::Easy->value,
+                'points' => 15,
+                'audience' => ChallengeAudience::Both->value,
+                'proof_type' => 'video',
+            ])
+            ->assertSessionHasErrors('proof_type');
+
+        $this->assertDatabaseMissing('challenges', ['name' => 'Nonsense']);
+    }
+
+    public function test_a_challenge_created_without_the_field_stays_text(): void
+    {
+        // Every challenge authored before #216 reports `text`, and the form
+        // always posts a value — but a script or an older form must not end up
+        // with a null the app has to guess about.
+        $this->actingAs($this->maintainer(), 'admin')
+            ->post(route('admin.gamification.challenges.store'), [
+                'name' => 'Quiet one',
+                'difficulty' => ChallengeDifficulty::Easy->value,
+                'points' => 5,
+                'audience' => ChallengeAudience::Both->value,
+            ])
+            ->assertRedirect(route('admin.gamification.challenges.index'));
+
+        $challenge = Challenge::query()->where('name', 'Quiet one')->sole();
+        $this->assertNotSame('photo', $challenge->proof_type?->value);
+    }
+
+    public function test_the_index_marks_which_challenges_open_the_camera(): void
+    {
+        Challenge::factory()->create([
+            'name' => 'Camera challenge',
+            'proof_type' => ChallengeProofType::Photo,
+            'is_system' => true,
+            'event_id' => null,
+        ]);
+
+        $this->actingAs($this->maintainer(), 'admin')
+            ->get(route('admin.gamification.challenges.index'))
+            ->assertOk()
+            ->assertSee('Camera challenge')
+            ->assertSee('photo');
     }
 
     public function test_index_filters_by_attendee_audience(): void


### PR DESCRIPTION
## Summary

`ChallengeProofType` (`text` | `photo`) has decided since #216 whether the app opens the camera when a pair agrees on a challenge. It was on the model, cast, emitted by `ChallengeResource` and accepted by the API's requests — and **missing from the one screen a human uses**. The admin requests never listed `proof_type`, so `validated()` dropped it and the panel could not author a camera challenge at all: the only routes were the API or SQL. kolabing-app#184's test plan asks a reviewer to *"set a challenge's `proof_type` to `photo`"* — nothing in the panel could.

| | change |
|---|---|
| `Admin\StoreChallengeRequest`, `Admin\UpdateChallengeRequest` | accept `proof_type`, validated against the enum, with a readable message |
| `challenges/_form.blade.php` | one select, worded as what happens: **"Open the camera — they take a photo together"** / **"No camera — the instruction is the game"** |
| `challenges/index.blade.php` | a 📷 badge column, so which challenges open a camera is visible at a glance |
| `Admin\ChallengeController` | passes `proofTypes` to the form |

The form's hint says what the field is **not**, because that is the part people get wrong: it picks the surface the app opens and nothing more. A verification that arrives with no photo is still accepted, so a denied camera or dead venue wifi never costs anybody their points — the enum's own docblock settles that from the other side.

## Linked tracking item

Closes #248. Requested by @olucvolkan: *"admin dashboard dan biz challengelari yonetebilelim … kamera acilsin acilmasin seklinde bunu da yap."*

## Type of change

- [x] ✨ Feature
- [x] 🧪 Tests

## Changes

Five new tests, all run — **18/18 in `tests/Feature/Admin/ChallengesAdminTest.php`, 48 assertions**:

- create with `photo` persists it
- update turns the camera on, then off again
- an unknown value (`video`) is rejected and nothing is written
- a create that omits the field does not end up as `photo`
- the index marks a camera challenge

The update test caught its own bug first: reading `audience` back off the factory model gave `null`, because the factory leaves it to its default. The payload now spells out every field, which is also what the form posts.

## Mobile impact (kolabing-app)

- [x] Mobile changes required (described below + tracked in `kolabing-app`)

**Mobile details / kolabing-app link:** this PR is the *admin* half. The **app** half — a leader setting the same switch from the app dashboard — is separate work in `kolabing-app`, and it depends on kolabing-app#184, which is what introduces `proof_type` to the client at all. Nothing here changes the API contract, so no app change is required for this PR to be useful: it makes the switch settable today, which #184's camera path then reads.

## Database / migrations

- [x] No schema changes

**Migration notes:** none. The column and its `text` default landed with #216 (`2026_08_23_120000_add_proof_type_to_challenges_table`).

## Testing

- [x] `php artisan test` passes — paste counts: `tests/Feature/Admin/ChallengesAdminTest.php` → **OK (18 tests, 48 assertions)**. Full suite not run locally.
- [x] `vendor/bin/pint` clean — `{"result":"pass"}` across `app resources tests`
- [ ] Manually verified the happy path — **not run.** Needs a maintainer session against a seeded admin panel; the five feature tests drive the same routes end to end (POST/PUT → redirect → row in `challenges`), which is what stands behind this.

## Docs & rules updated

- [x] No docs impact

`docs/BACKEND-SCHEMA.md` already documents `proof_type` from #216; no column, payload or role rule moved.

## Screenshots / notes

Reviewer guidance — the select, in full:

```
When the pair agrees
  ( ) No camera — the instruction is the game        (text, default)
  ( ) Open the camera — they take a photo together   (photo)
```

No screenshot of the rendered panel: it needs a maintainer login against a seeded database, which this environment does not have. Flagged rather than faked.

🤖 Written with [Claude Code](https://claude.com/claude-code)